### PR TITLE
feat: advanced searching algorithm for web client

### DIFF
--- a/web/src/prefs.js
+++ b/web/src/prefs.js
@@ -103,8 +103,8 @@ Prefs.FilterDownloading = 'downloading';
 Prefs.FilterFinished = 'finished';
 Prefs.FilterMode = 'filter-mode';
 Prefs.FilterOps = {
-  'name': ['name:'],
   'label': ['labels:', 'label:', 'kw:'],
+  'name': ['name:'],
   'status': ['status:', 'is:'],
   'tracker': ['tracker:', 'tr:'],
 };

--- a/web/src/prefs.js
+++ b/web/src/prefs.js
@@ -102,6 +102,12 @@ Prefs.FilterAll = 'all';
 Prefs.FilterDownloading = 'downloading';
 Prefs.FilterFinished = 'finished';
 Prefs.FilterMode = 'filter-mode';
+Prefs.FilterOps = {
+  'name': ['name:'],
+  'label': ['labels:', 'label:', 'kw:'],
+  'status': ['status:', 'is:'],
+  'tracker': ['tracker:', 'tr:'],
+};
 Prefs.FilterPaused = 'paused';
 Prefs.FilterSeeding = 'seeding';
 Prefs.NotificationsEnabled = 'notifications-enabled';

--- a/web/src/prefs.js
+++ b/web/src/prefs.js
@@ -103,10 +103,10 @@ Prefs.FilterDownloading = 'downloading';
 Prefs.FilterFinished = 'finished';
 Prefs.FilterMode = 'filter-mode';
 Prefs.FilterOps = {
-  'label': ['labels:', 'label:', 'kw:'],
-  'name': ['name:'],
-  'status': ['status:', 'is:'],
-  'tracker': ['tracker:', 'tr:'],
+  label: ['labels:', 'label:', 'kw:'],
+  name: ['name:'],
+  status: ['status:', 'is:'],
+  tracker: ['tracker:', 'tr:'],
 };
 Prefs.FilterPaused = 'paused';
 Prefs.FilterSeeding = 'seeding';

--- a/web/src/prefs.js
+++ b/web/src/prefs.js
@@ -102,12 +102,6 @@ Prefs.FilterAll = 'all';
 Prefs.FilterDownloading = 'downloading';
 Prefs.FilterFinished = 'finished';
 Prefs.FilterMode = 'filter-mode';
-Prefs.FilterOps = {
-  label: ['labels:', 'label:', 'kw:'],
-  name: ['name:'],
-  status: ['status:', 'is:'],
-  tracker: ['tracker:', 'tr:'],
-};
 Prefs.FilterPaused = 'paused';
 Prefs.FilterSeeding = 'seeding';
 Prefs.NotificationsEnabled = 'notifications-enabled';

--- a/web/src/torrent.js
+++ b/web/src/torrent.js
@@ -344,18 +344,6 @@ export class Torrent extends EventTarget {
     }
     return f.collatedTrackers || '';
   }
-  searchName() {
-    return (x) => this.getCollatedName().includes(x);
-  }
-  searchTrackers() {
-    return (x) => this.getCollatedTrackers().includes(x);
-  }
-  searchLabels() {
-    return (x) => this.fields.labels.some((z) => z.includes(x));
-  }
-  searchState() {
-    return (x) => this.testState(this.fields.status, x);
-  }
 
   /****
    *****
@@ -386,19 +374,36 @@ export class Torrent extends EventTarget {
   }
 
   test(_filter) {
-    const pass = (a, callback) => {
+    let v = null;
+    const pass = (a, vf, callback) => {
       if (a.length === 0) {
         return true;
       }
-      const c = callback();
-      return a.some((t) => t.every((x) => c(x)));
+      v = vf();
+      return a.some((t) => t.every((x) => callback(x)));
     };
 
     return (
-      pass(_filter.search, () => this.searchName()) &&
-      pass(_filter.trackers, () => this.searchTrackers()) &&
-      pass(_filter.labels, () => this.searchLabels()) &&
-      pass(_filter.states, () => this.searchState())
+      pass(
+        _filter.search,
+        () => this.getCollatedName(),
+        (x) => v.includes(x),
+      ) &&
+      pass(
+        _filter.trackers,
+        () => this.getCollatedTrackers(),
+        (x) => v.includes(x),
+      ) &&
+      pass(
+        _filter.states,
+        () => this.getStatus(),
+        (x) => this.testState(v, x),
+      ) &&
+      pass(
+        _filter.labels,
+        () => this.getLabels(),
+        (x) => v.some((z) => z.includes(x)),
+      )
     );
   }
 

--- a/web/src/torrent.js
+++ b/web/src/torrent.js
@@ -164,7 +164,7 @@ export class Torrent extends EventTarget {
     return this.fields.id;
   }
   getLabels(search) {
-    const labels = this.fields.labels;
+    const { labels } = this.fields;
     return search ? (x) => labels.some((z) => z.includes(x)) : labels.sort();
   }
   getLastActivity() {
@@ -225,7 +225,7 @@ export class Torrent extends EventTarget {
     return this.fields.startDate;
   }
   getStatus(search) {
-    const status = this.fields.status;
+    const { status } = this.fields;
     return search ? (x) => this.testState(status, x) : status;
   }
   getTotalSize() {
@@ -390,7 +390,7 @@ export class Torrent extends EventTarget {
       pass(_filter.search, () => this.getCollatedName(true)) &&
       pass(_filter.trackers, () => this.getCollatedTrackers(true)) &&
       pass(_filter.labels, () => this.getLabels(true)) &&
-      pass(_filter.states,() => this.getStatus(true))
+      pass(_filter.states, () => this.getStatus(true))
     );
   }
 

--- a/web/src/torrent.js
+++ b/web/src/torrent.js
@@ -387,22 +387,22 @@ export class Torrent extends EventTarget {
       pass(
         _filter.search,
         () => this.getCollatedName(),
-        (x) => v.includes(x),
-      ) &&
-      pass(
-        _filter.trackers,
-        () => this.getCollatedTrackers(),
-        (x) => v.includes(x),
-      ) &&
-      pass(
-        _filter.states,
-        () => this.getStatus(),
-        (x) => this.testState(v, x),
+        (x) => v.includes(x)
       ) &&
       pass(
         _filter.labels,
         () => this.getLabels(),
-        (x) => v.some((z) => z.includes(x)),
+        (x) => v.some((z) => z.includes(x))
+      ) &&
+      pass(
+        _filter.states,
+        () => this.getStatus(),
+        (x) => this.testState(v, x)
+      ) &&
+      pass(
+        _filter.trackers,
+        () => this.getCollatedTrackers(),
+        (x) => v.includes(x)
       )
     );
   }

--- a/web/src/torrent.js
+++ b/web/src/torrent.js
@@ -353,7 +353,7 @@ export class Torrent extends EventTarget {
   searchLabels() {
     return (x) => this.fields.labels.some((z) => z.includes(x));
   }
-  searchStatus() {
+  searchState() {
     return (x) => this.testState(this.fields.status, x);
   }
 
@@ -398,7 +398,7 @@ export class Torrent extends EventTarget {
       pass(_filter.search, () => this.searchName()) &&
       pass(_filter.trackers, () => this.searchTrackers()) &&
       pass(_filter.labels, () => this.searchLabels()) &&
-      pass(_filter.states, () => this.searchStatus())
+      pass(_filter.states, () => this.searchState())
     );
   }
 

--- a/web/src/torrent.js
+++ b/web/src/torrent.js
@@ -375,25 +375,24 @@ export class Torrent extends EventTarget {
     }
   }
 
-  subTest(a, callback, f) {
-    return a.length === 0 || a.some((t) => t.every((x) => callback(x, f)));
-  }
-
   test(_filter) {
+    const subTest = (a, callback, f) => {
+      return a.length === 0 || a.some((t) => t.every((x) => callback(x, f)));
+    }
     const callback = (x, f) => f.includes(x);
     const callback2 = (x, f) => f.some((z) => z.includes(x));
 
     // filter by status
-    return this.subTest(_filter.states, (x) => this.testState(x)) &&
+    return subTest(_filter.states, (x) => this.testState(x)) &&
 
     // filter by text
-    this.subTest(_filter.search, callback, this.getCollatedName()) &&
+    subTest(_filter.search, callback, this.getCollatedName()) &&
 
     // filter by label
-    this.subTest(_filter.labels, callback2, this.getLabels()) &&
+    subTest(_filter.labels, callback2, this.getLabels()) &&
 
     // filter by tracker
-    this.subTest(_filter.trackers, callback, this.getCollatedTrackers());
+    subTest(_filter.trackers, callback, this.getCollatedTrackers());
   }
 
   static compareById(ta, tb) {

--- a/web/src/torrent.js
+++ b/web/src/torrent.js
@@ -374,35 +374,37 @@ export class Torrent extends EventTarget {
   }
 
   test(_filter) {
-    let v = null;
     const pass = (a, vf, callback) => {
       if (a.length === 0) {
         return true;
       }
-      v = vf();
-      return a.some((t) => t.every((x) => callback(x)));
+      const v = vf();
+      if (_filter.swap) {
+        return a.every((t) => t.some((x) => callback(x, v)));
+      }
+      return a.some((t) => t.every((x) => callback(x, v)));
     };
 
     return (
       pass(
         _filter.search,
         () => this.getCollatedName(),
-        (x) => v.includes(x),
+        (x, v) => v.includes(x),
       ) &&
       pass(
         _filter.labels,
         () => this.getLabels(),
-        (x) => v.some((z) => z.includes(x)),
+        (x, v) => v.some((z) => z.includes(x)),
       ) &&
       pass(
         _filter.states,
         () => this.getStatus(),
-        (x) => this.testState(v, x),
+        (x, v) => this.testState(v, x),
       ) &&
       pass(
         _filter.trackers,
         () => this.getCollatedTrackers(),
-        (x) => v.includes(x),
+        (x, v) => v.includes(x),
       )
     );
   }

--- a/web/src/torrent.js
+++ b/web/src/torrent.js
@@ -373,21 +373,37 @@ export class Torrent extends EventTarget {
     }
   }
 
-  test(f) {
+  test(_filter) {
     let v = null;
-    const i = (a, vf, callback) => {
+    const pass = (a, vf, callback) => {
       if (a.length === 0) {
         return true;
       }
       v = vf();
       return a.some((t) => t.every((x) => callback(x)));
-    }
+    };
 
     return (
-      i(f.search, () => this.getCollatedName(), (x) => v.includes(x)) &&
-      i(f.trackers, () => this.getCollatedTrackers(), (x) => v.includes(x)) &&
-      i(f.states, () => this.getStatus(), (x) => this.testState(v, x)) &&
-      i(f.labels, () => this.getLabels(), (x) => v.some((z) => z.includes(x)))
+      pass(
+        _filter.search,
+        () => this.getCollatedName(),
+        (x) => v.includes(x),
+      ) &&
+      pass(
+        _filter.trackers,
+        () => this.getCollatedTrackers(),
+        (x) => v.includes(x)
+      ) &&
+      pass(
+        _filter.states,
+        () => this.getStatus(),
+        (x) => this.testState(v, x),
+      ) &&
+      pass(
+        _filter.labels,
+        () => this.getLabels(),
+        (x) => v.some((z) => z.includes(x)),
+      )
     )
   }
 

--- a/web/src/torrent.js
+++ b/web/src/torrent.js
@@ -390,6 +390,11 @@ export class Torrent extends EventTarget {
         (x) => v.includes(x),
       ) &&
       pass(
+        _filter.trackers,
+        () => this.getCollatedTrackers(),
+        (x) => v.includes(x),
+      ) &&
+      pass(
         _filter.states,
         () => this.getStatus(),
         (x) => this.testState(v, x),
@@ -398,11 +403,6 @@ export class Torrent extends EventTarget {
         _filter.labels,
         () => this.getLabels(),
         (x) => v.some((z) => z.includes(x)),
-      ) &&
-      pass(
-        _filter.trackers,
-        () => this.getCollatedTrackers(),
-        (x) => v.includes(x),
       )
     );
   }

--- a/web/src/torrent.js
+++ b/web/src/torrent.js
@@ -387,10 +387,10 @@ export class Torrent extends EventTarget {
     };
 
     return (
-      this.pass(_filter.search, () => this.getCollatedName(true)) &&
-      this.pass(_filter.trackers, () => this.getCollatedTrackers(true)) &&
-      this.pass(_filter.labels, () => this.getLabels(true)) &&
-      this.pass(_filter.states,() => this.getStatus(true))
+      pass(_filter.search, () => this.getCollatedName(true)) &&
+      pass(_filter.trackers, () => this.getCollatedTrackers(true)) &&
+      pass(_filter.labels, () => this.getLabels(true)) &&
+      pass(_filter.states,() => this.getStatus(true))
     );
   }
 

--- a/web/src/torrent.js
+++ b/web/src/torrent.js
@@ -163,9 +163,8 @@ export class Torrent extends EventTarget {
   getId() {
     return this.fields.id;
   }
-  getLabels(search) {
-    const { labels } = this.fields;
-    return search ? (x) => labels.some((z) => z.includes(x)) : labels.sort();
+  getLabels() {
+    return this.fields.labels.sort();
   }
   getLastActivity() {
     return this.fields.activityDate;
@@ -225,8 +224,7 @@ export class Torrent extends EventTarget {
     return this.fields.startDate;
   }
   getStatus(search) {
-    const { status } = this.fields;
-    return search ? (x) => this.testState(status, x) : status;
+    return this.fields.status;
   }
   getTotalSize() {
     return this.fields.totalSize;
@@ -332,21 +330,31 @@ export class Torrent extends EventTarget {
         return null;
     }
   }
-  getCollatedName(search) {
+  getCollatedName() {
     const f = this.fields;
     if (!f.collatedName && f.name) {
       f.collatedName = f.name.toLowerCase();
     }
-    const name = f.collatedName || '';
-    return search ? (x) => name.includes(x) : name;
+    return f.collatedName || '';
   }
-  getCollatedTrackers(search) {
+  getCollatedTrackers() {
     const f = this.fields;
     if (!f.collatedTrackers && f.trackers) {
       f.collatedTrackers = Torrent.collateTrackers(f.trackers);
     }
-    const trackers = f.collatedTrackers || '';
-    return search ? (x) => trackers.includes(x) : trackers;
+    return f.collatedTrackers || '';
+  }
+  searchName() {
+    return (x) => this.getCollatedName().includes(x);
+  }
+  searchTrackers() {
+    return (x) => this.getCollatedTrackers().includes(x);
+  }
+  searchLabels() {
+    return (x) => this.fields.labels.some((z) => z.includes(x));
+  }
+  searchStatus() {
+    return (x) => this.testState(this.fields.status, x);
   }
 
   /****
@@ -387,10 +395,10 @@ export class Torrent extends EventTarget {
     };
 
     return (
-      pass(_filter.search, () => this.getCollatedName(true)) &&
-      pass(_filter.trackers, () => this.getCollatedTrackers(true)) &&
-      pass(_filter.labels, () => this.getLabels(true)) &&
-      pass(_filter.states, () => this.getStatus(true))
+      pass(_filter.search, () => this.searchName()) &&
+      pass(_filter.trackers, () => this.searchTrackers()) &&
+      pass(_filter.labels, () => this.searchLabels()) &&
+      pass(_filter.states, () => this.searchStatus())
     );
   }
 

--- a/web/src/torrent.js
+++ b/web/src/torrent.js
@@ -378,21 +378,20 @@ export class Torrent extends EventTarget {
   test(_filter) {
     const subTest = (a, callback, f) => {
       return a.length === 0 || a.some((t) => t.every((x) => callback(x, f)));
-    }
+    };
     const callback = (x, f) => f.includes(x);
     const callback2 = (x, f) => f.some((z) => z.includes(x));
 
-    // filter by status
-    return subTest(_filter.states, (x) => this.testState(x)) &&
-
-    // filter by text
-    subTest(_filter.search, callback, this.getCollatedName()) &&
-
-    // filter by label
-    subTest(_filter.labels, callback2, this.getLabels()) &&
-
-    // filter by tracker
-    subTest(_filter.trackers, callback, this.getCollatedTrackers());
+    return (
+      // filter by status
+      subTest(_filter.states, (x) => this.testState(x)) &&
+      // filter by text
+      subTest(_filter.search, callback, this.getCollatedName()) &&
+      // filter by label
+      subTest(_filter.labels, callback2, this.getLabels()) &&
+      // filter by tracker
+      subTest(_filter.trackers, callback, this.getCollatedTrackers())
+    );
   }
 
   static compareById(ta, tb) {

--- a/web/src/torrent.js
+++ b/web/src/torrent.js
@@ -387,22 +387,22 @@ export class Torrent extends EventTarget {
       pass(
         _filter.search,
         () => this.getCollatedName(),
-        (x) => v.includes(x)
+        (x) => v.includes(x),
       ) &&
       pass(
         _filter.labels,
         () => this.getLabels(),
-        (x) => v.some((z) => z.includes(x))
+        (x) => v.some((z) => z.includes(x)),
       ) &&
       pass(
         _filter.states,
         () => this.getStatus(),
-        (x) => this.testState(v, x)
+        (x) => this.testState(v, x),
       ) &&
       pass(
         _filter.trackers,
         () => this.getCollatedTrackers(),
-        (x) => v.includes(x)
+        (x) => v.includes(x),
       )
     );
   }

--- a/web/src/torrent.js
+++ b/web/src/torrent.js
@@ -392,7 +392,7 @@ export class Torrent extends EventTarget {
       pass(
         _filter.trackers,
         () => this.getCollatedTrackers(),
-        (x) => v.includes(x)
+        (x) => v.includes(x),
       ) &&
       pass(
         _filter.states,
@@ -404,7 +404,7 @@ export class Torrent extends EventTarget {
         () => this.getLabels(),
         (x) => v.some((z) => z.includes(x)),
       )
-    )
+    );
   }
 
   static compareById(ta, tb) {

--- a/web/src/torrent.js
+++ b/web/src/torrent.js
@@ -396,8 +396,8 @@ export class Torrent extends EventTarget {
           label_array.every((label) =>
             torrent_labels.some((torrent_label) =>
               torrent_label.includes(label),
-            )
-          )
+            ),
+          ),
         )
       ) {
         return false;
@@ -405,14 +405,13 @@ export class Torrent extends EventTarget {
     }
 
     // filter by status
-    if (_filter.states.length > 0) {
-      if (
-        !_filter.states.some((state_array) =>
-          state_array.every((state) => this.testState(state)),
-        )
-      ) {
-        return false;
-      }
+    if (
+      _filter.states.length > 0 &&
+      !_filter.states.some((state_array) =>
+        state_array.every((state) => this.testState(state)),
+      )
+    ) {
+      return false;
     }
 
     // filter by tracker
@@ -420,9 +419,7 @@ export class Torrent extends EventTarget {
       const torrent_trackers = this.getCollatedTrackers();
       if (
         !_filter.trackers.some((tracker_array) =>
-          tracker_array.every((tracker) =>
-            torrent_trackers.includes(tracker),
-          )
+          tracker_array.every((tracker) => torrent_trackers.includes(tracker)),
         )
       ) {
         return false;

--- a/web/src/torrent.js
+++ b/web/src/torrent.js
@@ -376,14 +376,12 @@ export class Torrent extends EventTarget {
   }
 
   test(_filter) {
+    const pass = (a, c) => a.some((t) => t.every((x) => c(x)));
+
     // filter by text
     if (_filter.search.length > 0) {
       const name = this.getCollatedName();
-      if (
-        !_filter.search.some((search_array) =>
-          search_array.every((text) => name.includes(text)),
-        )
-      ) {
+      if (!pass(_filter.search, (x) => name.includes(x))) {
         return false;
       }
     }
@@ -391,25 +389,16 @@ export class Torrent extends EventTarget {
     // filter by label
     if (_filter.labels.length > 0) {
       const torrent_labels = this.getLabels();
-      if (
-        !_filter.labels.some((label_array) =>
-          label_array.every((label) =>
-            torrent_labels.some((torrent_label) =>
-              torrent_label.includes(label),
-            ),
-          ),
-        )
+      if (!pass(_filter.labels, (x) =>
+        torrent_labels.some((z) => z.includes(x)))
       ) {
         return false;
       }
     }
 
     // filter by status
-    if (
-      _filter.states.length > 0 &&
-      !_filter.states.some((state_array) =>
-        state_array.every((state) => this.testState(state)),
-      )
+    if (_filter.states.length > 0 &&
+      !pass(_filter.states, (x) => this.testState(x))
     ) {
       return false;
     }
@@ -417,11 +406,7 @@ export class Torrent extends EventTarget {
     // filter by tracker
     if (_filter.trackers.length > 0) {
       const torrent_trackers = this.getCollatedTrackers();
-      if (
-        !_filter.trackers.some((tracker_array) =>
-          tracker_array.every((tracker) => torrent_trackers.includes(tracker)),
-        )
-      ) {
+      if (!pass(_filter.trackers, (x) => torrent_trackers.includes(x))) {
         return false;
       }
     }

--- a/web/src/torrent.js
+++ b/web/src/torrent.js
@@ -223,7 +223,7 @@ export class Torrent extends EventTarget {
   getStartDate() {
     return this.fields.startDate;
   }
-  getStatus(search) {
+  getStatus() {
     return this.fields.status;
   }
   getTotalSize() {

--- a/web/src/torrent.js
+++ b/web/src/torrent.js
@@ -379,9 +379,6 @@ export class Torrent extends EventTarget {
         return true;
       }
       const v = vf();
-      if (_filter.swap) {
-        return a.every((t) => t.some((x) => callback(x, v)));
-      }
       return a.some((t) => t.every((x) => callback(x, v)));
     };
 

--- a/web/src/torrent.js
+++ b/web/src/torrent.js
@@ -390,11 +390,6 @@ export class Torrent extends EventTarget {
         (x) => v.includes(x),
       ) &&
       pass(
-        _filter.trackers,
-        () => this.getCollatedTrackers(),
-        (x) => v.includes(x),
-      ) &&
-      pass(
         _filter.states,
         () => this.getStatus(),
         (x) => this.testState(v, x),
@@ -403,6 +398,11 @@ export class Torrent extends EventTarget {
         _filter.labels,
         () => this.getLabels(),
         (x) => v.some((z) => z.includes(x)),
+      ) &&
+      pass(
+        _filter.trackers,
+        () => this.getCollatedTrackers(),
+        (x) => v.includes(x),
       )
     );
   }

--- a/web/src/torrent.js
+++ b/web/src/torrent.js
@@ -379,7 +379,11 @@ export class Torrent extends EventTarget {
     // filter by text
     if (_filter.search.length > 0) {
       const name = this.getCollatedName();
-      if (!_filter.search.some((search_array) => search_array.every((text) => name.includes(text)))) {
+      if (
+        !_filter.search.some((search_array) =>
+          search_array.every((text) => name.includes(text)),
+        )
+      ) {
         return false;
       }
     }
@@ -387,14 +391,26 @@ export class Torrent extends EventTarget {
     // filter by label
     if (_filter.labels.length > 0) {
       const torrent_labels = this.getLabels();
-      if (!_filter.labels.some((label_array) => label_array.every((label) => torrent_labels.some((torrent_label) => torrent_label.includes(label))))) {
+      if (
+        !_filter.labels.some((label_array) =>
+          label_array.every((label) =>
+            torrent_labels.some((torrent_label) =>
+              torrent_label.includes(label),
+            )
+          )
+        )
+      ) {
         return false;
       }
     }
 
     // filter by status
     if (_filter.states.length > 0) {
-      if (!_filter.states.some((state_array) => state_array.every((state) => this.testState(state)))) {
+      if (
+        !_filter.states.some((state_array) =>
+          state_array.every((state) => this.testState(state)),
+        )
+      ) {
         return false;
       }
     }
@@ -402,7 +418,13 @@ export class Torrent extends EventTarget {
     // filter by tracker
     if (_filter.trackers.length > 0) {
       const torrent_trackers = this.getCollatedTrackers();
-      if (!_filter.trackers.some((tracker_array) => tracker_array.every((tracker) => torrent_trackers.includes(tracker)))) {
+      if (
+        !_filter.trackers.some((tracker_array) =>
+          tracker_array.every((tracker) =>
+            torrent_trackers.includes(tracker),
+          )
+        )
+      ) {
         return false;
       }
     }

--- a/web/src/torrent.js
+++ b/web/src/torrent.js
@@ -349,9 +349,7 @@ export class Torrent extends EventTarget {
    *****
    ****/
 
-  testState(state) {
-    const s = this.getStatus();
-
+  testState(s, state) {
     switch (state) {
       case Prefs.FilterActive:
         return (
@@ -375,44 +373,22 @@ export class Torrent extends EventTarget {
     }
   }
 
-  test(_filter) {
-    const pass = (a, c) => a.some((t) => t.every((x) => c(x)));
-
-    // filter by text
-    if (_filter.search.length > 0) {
-      const name = this.getCollatedName();
-      if (!pass(_filter.search, (x) => name.includes(x))) {
-        return false;
+  test(f) {
+    let v = null;
+    const i = (a, vf, callback) => {
+      if (a.length === 0) {
+        return true;
       }
+      v = vf();
+      return a.some((t) => t.every((x) => callback(x)));
     }
 
-    // filter by label
-    if (_filter.labels.length > 0) {
-      const torrent_labels = this.getLabels();
-      if (
-        !pass(_filter.labels, (x) => torrent_labels.some((z) => z.includes(x)))
-      ) {
-        return false;
-      }
-    }
-
-    // filter by status
-    if (
-      _filter.states.length > 0 &&
-      !pass(_filter.states, (x) => this.testState(x))
-    ) {
-      return false;
-    }
-
-    // filter by tracker
-    if (_filter.trackers.length > 0) {
-      const torrent_trackers = this.getCollatedTrackers();
-      if (!pass(_filter.trackers, (x) => torrent_trackers.includes(x))) {
-        return false;
-      }
-    }
-
-    return true;
+    return (
+      i(f.search, () => this.getCollatedName(), (x) => v.includes(x)) &&
+      i(f.trackers, () => this.getCollatedTrackers(), (x) => v.includes(x)) &&
+      i(f.states, () => this.getStatus(), (x) => this.testState(v, x)) &&
+      i(f.labels, () => this.getLabels(), (x) => v.some((z) => z.includes(x)))
+    )
   }
 
   static compareById(ta, tb) {

--- a/web/src/torrent.js
+++ b/web/src/torrent.js
@@ -375,58 +375,25 @@ export class Torrent extends EventTarget {
     }
   }
 
-  test(_filter) {
-    // filter by text
-    if (_filter.search.length > 0) {
-      const name = this.getCollatedName();
-      if (
-        !_filter.search.some((search_array) =>
-          search_array.every((text) => name.includes(text)),
-        )
-      ) {
-        return false;
-      }
-    }
+  subTest(a, callback, f) {
+    return a.length === 0 || a.some((t) => t.every((x) => callback(x, f)));
+  }
 
-    // filter by label
-    if (_filter.labels.length > 0) {
-      const torrent_labels = this.getLabels();
-      if (
-        !_filter.labels.some((label_array) =>
-          label_array.every((label) =>
-            torrent_labels.some((torrent_label) =>
-              torrent_label.includes(label),
-            ),
-          ),
-        )
-      ) {
-        return false;
-      }
-    }
+  test(_filter) {
+    const callback = (x, f) => f.includes(x);
+    const callback2 = (x, f) => f.some((z) => z.includes(x));
 
     // filter by status
-    if (
-      _filter.states.length > 0 &&
-      !_filter.states.some((state_array) =>
-        state_array.every((state) => this.testState(state)),
-      )
-    ) {
-      return false;
-    }
+    return this.subTest(_filter.states, (x) => this.testState(x)) &&
+
+    // filter by text
+    this.subTest(_filter.search, callback, this.getCollatedName()) &&
+
+    // filter by label
+    this.subTest(_filter.labels, callback2, this.getLabels()) &&
 
     // filter by tracker
-    if (_filter.trackers.length > 0) {
-      const torrent_trackers = this.getCollatedTrackers();
-      if (
-        !_filter.trackers.some((tracker_array) =>
-          tracker_array.every((tracker) => torrent_trackers.includes(tracker)),
-        )
-      ) {
-        return false;
-      }
-    }
-
-    return true;
+    this.subTest(_filter.trackers, callback, this.getCollatedTrackers());
   }
 
   static compareById(ta, tb) {

--- a/web/src/torrent.js
+++ b/web/src/torrent.js
@@ -380,7 +380,7 @@ export class Torrent extends EventTarget {
     if (_filter.search.length > 0) {
       const name = this.getCollatedName();
       if (!_filter.search.some((search_array) => search_array.every((text) => name.includes(text)))) {
-        return;
+        return false;
       }
     }
 
@@ -388,14 +388,14 @@ export class Torrent extends EventTarget {
     if (_filter.labels.length > 0) {
       const torrent_labels = this.getLabels();
       if (!_filter.labels.some((label_array) => label_array.every((label) => torrent_labels.some((torrent_label) => torrent_label.includes(label))))) {
-        return;
+        return false;
       }
     }
 
     // filter by status
     if (_filter.states.length > 0) {
       if (!_filter.states.some((state_array) => state_array.every((state) => this.testState(state)))) {
-        return;
+        return false;
       }
     }
 
@@ -403,7 +403,7 @@ export class Torrent extends EventTarget {
     if (_filter.trackers.length > 0) {
       const torrent_trackers = this.getCollatedTrackers();
       if (!_filter.trackers.some((tracker_array) => tracker_array.every((tracker) => torrent_trackers.includes(tracker)))) {
-        return;
+        return false;
       }
     }
 

--- a/web/src/torrent.js
+++ b/web/src/torrent.js
@@ -389,15 +389,16 @@ export class Torrent extends EventTarget {
     // filter by label
     if (_filter.labels.length > 0) {
       const torrent_labels = this.getLabels();
-      if (!pass(_filter.labels, (x) =>
-        torrent_labels.some((z) => z.includes(x)))
+      if (
+        !pass(_filter.labels, (x) => torrent_labels.some((z) => z.includes(x)))
       ) {
         return false;
       }
     }
 
     // filter by status
-    if (_filter.states.length > 0 &&
+    if (
+      _filter.states.length > 0 &&
       !pass(_filter.states, (x) => this.testState(x))
     ) {
       return false;

--- a/web/src/torrent.js
+++ b/web/src/torrent.js
@@ -376,22 +376,57 @@ export class Torrent extends EventTarget {
   }
 
   test(_filter) {
-    const subTest = (a, callback, f) => {
-      return a.length === 0 || a.some((t) => t.every((x) => callback(x, f)));
-    };
-    const callback = (x, f) => f.includes(x);
-    const callback2 = (x, f) => f.some((z) => z.includes(x));
+    // filter by text
+    if (_filter.search.length > 0) {
+      const name = this.getCollatedName();
+      if (
+        !_filter.search.some((search_array) =>
+          search_array.every((text) => name.includes(text)),
+        )
+      ) {
+        return false;
+      }
+    }
 
-    return (
-      // filter by status
-      subTest(_filter.states, (x) => this.testState(x)) &&
-      // filter by text
-      subTest(_filter.search, callback, this.getCollatedName()) &&
-      // filter by label
-      subTest(_filter.labels, callback2, this.getLabels()) &&
-      // filter by tracker
-      subTest(_filter.trackers, callback, this.getCollatedTrackers())
-    );
+    // filter by label
+    if (_filter.labels.length > 0) {
+      const torrent_labels = this.getLabels();
+      if (
+        !_filter.labels.some((label_array) =>
+          label_array.every((label) =>
+            torrent_labels.some((torrent_label) =>
+              torrent_label.includes(label),
+            ),
+          ),
+        )
+      ) {
+        return false;
+      }
+    }
+
+    // filter by status
+    if (
+      _filter.states.length > 0 &&
+      !_filter.states.some((state_array) =>
+        state_array.every((state) => this.testState(state)),
+      )
+    ) {
+      return false;
+    }
+
+    // filter by tracker
+    if (_filter.trackers.length > 0) {
+      const torrent_trackers = this.getCollatedTrackers();
+      if (
+        !_filter.trackers.some((tracker_array) =>
+          tracker_array.every((tracker) => torrent_trackers.includes(tracker)),
+        )
+      ) {
+        return false;
+      }
+    }
+
+    return true;
   }
 
   static compareById(ta, tb) {

--- a/web/src/transmission.js
+++ b/web/src/transmission.js
@@ -1073,7 +1073,8 @@ TODO: fix this when notifications get fixed
       this._filter.opless = [];
       const farray = this.filterText.match(/(?:\\.|[^"])+|^/g);
       // array of non-quoted then quoted in odd-even model
-      for (const [n, t] of farray.entries()) {
+      for (let [n, t] of farray.entries()) {
+        t = t.replace(/\\(.)/g, '$1');
         if (n % 2) {
           // quoted
           const c = this._filter.controller;

--- a/web/src/transmission.js
+++ b/web/src/transmission.js
@@ -1024,16 +1024,13 @@ TODO: fix this when notifications get fixed
         if (!op) {
           continue;
         }
+        text = op_text.slice(op.length);
         this._filter.autocomplete = a;
         this._filter.controller = this._filter[c];
       }
 
       c = this._filter.controller;
       if (op || c) {
-        if (op) {
-          text = op_text.slice(op.length);
-        }
-
         let text_array = text.split(/,+/);
         a = this._filter.autocomplete;
         if (a) {

--- a/web/src/transmission.js
+++ b/web/src/transmission.js
@@ -1086,7 +1086,7 @@ TODO: fix this when notifications get fixed
           }
         } else {
           // not quoted
-          for (const op_text of text.toLowerCase().split(/ +/)) {
+          for (const op_text of text.trimEnd().toLowerCase().split(/ +/)) {
             if (op_text) {
               this._registerFilter(op_text);
             } else {

--- a/web/src/transmission.js
+++ b/web/src/transmission.js
@@ -1016,10 +1016,11 @@ TODO: fix this when notifications get fixed
     }
   }
 
-  _registerFilter(text) {
+  _registerFilter(op_text) {
+    let text = op_text;
     for (let [op, c, a] of this.searchOperators) {
       if (op) {
-        op = op.find((x) => text.startsWith(x));
+        op = op.find((x) => op_text.startsWith(x));
         if (!op) {
           continue;
         }
@@ -1030,7 +1031,7 @@ TODO: fix this when notifications get fixed
       c = this._filter.controller;
       if (op || c) {
         if (op) {
-          text = text.slice(op.length);
+          text = op_text.slice(op.length);
         }
 
         let text_array = text.split(/,+/);
@@ -1089,9 +1090,9 @@ TODO: fix this when notifications get fixed
           }
         } else {
           // not quoted
-          for (const text of t.toLowerCase().split(/ +/)) {
-            if (text) {
-              this._registerFilter(text);
+          for (const op_text of t.toLowerCase().split(/ +/)) {
+            if (op_text) {
+              this._registerFilter(op_text);
             } else {
               this._filter.autocomplete = null;
               this._filter.controller = null;
@@ -1110,7 +1111,6 @@ TODO: fix this when notifications get fixed
     const { sort_mode, sort_direction } = this.prefs;
     const renderer = this.torrentRenderer;
     const list = this.elements.torrent_list;
-
     const countRows = () => [...list.children].length;
     const countSelectedRows = () =>
       [...list.children].reduce(

--- a/web/src/transmission.js
+++ b/web/src/transmission.js
@@ -1076,7 +1076,7 @@ TODO: fix this when notifications get fixed
 
     if (this.filterText.length > 0) {
       const farray = this.filterText.match(/(?:\\.|[^"])+|^/g);
-      for (let [n, t] of farray.entries()) {
+      for (const [n, t] of farray.entries()) {
         // array of non-quoted then quoted in odd-even model
         if (n % 2) {
           // quoted

--- a/web/src/transmission.js
+++ b/web/src/transmission.js
@@ -1073,8 +1073,8 @@ TODO: fix this when notifications get fixed
 
     if (this.filterText.length > 0) {
       const farray = this.filterText.match(/(?:\\.|[^"])+|^/g);
+      // array of non-quoted then quoted in odd-even model
       for (const [n, t] of farray.entries()) {
-        // array of non-quoted then quoted in odd-even model
         if (n % 2) {
           // quoted
           const c = this._filter.controller;

--- a/web/src/transmission.js
+++ b/web/src/transmission.js
@@ -41,23 +41,6 @@ export class Transmission extends EventTarget {
 
     // Initialize the implementation fields
     this.filterText = '';
-    this.searchOperators = [
-      [Prefs.FilterOps.name, 'search'],
-      [Prefs.FilterOps.label, 'labels'],
-      [
-        Prefs.FilterOps.status,
-        'states',
-        [
-          Prefs.FilterActive,
-          Prefs.FilterDownloading,
-          Prefs.FilterSeeding,
-          Prefs.FilterPaused,
-          Prefs.FilterFinished,
-        ],
-      ],
-      [Prefs.FilterOps.tracker, 'trackers'],
-      [],
-    ];
     this._filter = {};
     this._torrents = {};
     this._rows = [];
@@ -1017,8 +1000,31 @@ TODO: fix this when notifications get fixed
   }
 
   _registerFilter(op_text) {
+    const op_keywords = {
+      label: ['labels:', 'label:', 'kw:'],
+      name: ['name:'],
+      status: ['status:', 'is:'],
+      tracker: ['tracker:', 'tr:'],
+    };
+    const search_ops = [
+      [op_keywords.name, 'search'],
+      [op_keywords.label, 'labels'],
+      [
+        op_keywords.status,
+        'states',
+        [
+          Prefs.FilterActive,
+          Prefs.FilterDownloading,
+          Prefs.FilterSeeding,
+          Prefs.FilterPaused,
+          Prefs.FilterFinished,
+        ],
+      ],
+      [op_keywords.tracker, 'trackers'],
+      [],
+    ];
     let text = op_text;
-    for (let [op, c, a] of this.searchOperators) {
+    for (let [op, c, a] of search_ops) {
       if (op) {
         op = op.find((x) => op_text.startsWith(x));
         if (!op) {

--- a/web/src/transmission.js
+++ b/web/src/transmission.js
@@ -1040,7 +1040,7 @@ TODO: fix this when notifications get fixed
           const new_ta = [];
           for (const t of text_array) {
             if (t) {
-              new_ta.push(a.find(e => e.startsWith(t)));
+              new_ta.push(a.find((e) => e.startsWith(t)));
             }
           }
           text_array = new_ta;
@@ -1049,7 +1049,7 @@ TODO: fix this when notifications get fixed
         if (op) {
           c.push(text_array);
         } else {
-          c[c.length - 1].push(...text_array);
+          c.at(-1).push(...text_array);
         }
 
         if (text && !text.endsWith(',')) {
@@ -1071,20 +1071,19 @@ TODO: fix this when notifications get fixed
     this._filter.search = [];
     this._filter.labels = [];
     this._filter.states =
-      filter_mode !== Prefs.FilterAll
-        ? [[filter_mode]]
-        : [];
+      filter_mode === Prefs.FilterAll ? [] : [[filter_mode]];
     this._filter.trackers = this.filterTracker ? [[this.filterTracker]] : [];
 
     if (this.filterText.length > 0) {
-      for (let [n, t] of this.filterText.match(/(?:\\.|[^"])+|^/g).entries()) {
+      const farray = this.filterText.match(/(?:\\.|[^"])+|^/g);
+      for (let [n, t] of farray.entries()) {
         // array of non-quoted then quoted in odd-even model
         if (n % 2) {
           // quoted
           const c = this._filter.controller;
           if (c) {
             const a = this._filter.autocomplete;
-            c[c.length - 1].push(a ? a.find(e => e.startsWith(t)) : t);
+            c.at(-1).push(a ? a.find((e) => e.startsWith(t)) : t);
           } else {
             this._filter.opless.push(t);
           }

--- a/web/src/transmission.js
+++ b/web/src/transmission.js
@@ -1074,7 +1074,7 @@ TODO: fix this when notifications get fixed
       const farray = this.filterText.match(/(?:\\.|[^"])+|^/g);
       // array of non-quoted then quoted in odd-even model
       for (const [n, t] of farray.entries()) {
-        const text = t.replace(/\\(.)/g, '$1');
+        const text = t.replaceAll(/\\(.)/g, '$1');
         if (n % 2) {
           // quoted
           const c = this._filter.controller;

--- a/web/src/transmission.js
+++ b/web/src/transmission.js
@@ -1071,7 +1071,7 @@ TODO: fix this when notifications get fixed
       filter_mode === Prefs.FilterAll ? [] : [[filter_mode]];
     this._filter.trackers = this.filterTracker ? [[this.filterTracker]] : [];
 
-    if (this.filterText.length > 0) {
+    if (this.filterText) {
       const farray = this.filterText.match(/(?:\\.|[^"])+|^/g);
       // array of non-quoted then quoted in odd-even model
       for (const [n, t] of farray.entries()) {
@@ -1124,7 +1124,7 @@ TODO: fix this when notifications get fixed
     if (rebuildEverything) {
       this._rebuildFilter();
       while (list.firstChild) {
-        list.firstChild.remove();
+        list.lastChild.remove();
       }
       this._rows = [];
       this.dirtyTorrents = new Set(Object.keys(this._torrents));

--- a/web/src/transmission.js
+++ b/web/src/transmission.js
@@ -1030,7 +1030,7 @@ TODO: fix this when notifications get fixed
       }
 
       c = this._filter.controller;
-      if (op || c) {
+      if (c) {
         let text_array = text.split(/,+/);
         a = this._filter.autocomplete;
         if (a) {

--- a/web/src/transmission.js
+++ b/web/src/transmission.js
@@ -1073,20 +1073,20 @@ TODO: fix this when notifications get fixed
       this._filter.opless = [];
       const farray = this.filterText.match(/(?:\\.|[^"])+|^/g);
       // array of non-quoted then quoted in odd-even model
-      for (let [n, t] of farray.entries()) {
-        t = t.replace(/\\(.)/g, '$1');
+      for (const [n, t] of farray.entries()) {
+        const text = t.replace(/\\(.)/g, '$1');
         if (n % 2) {
           // quoted
           const c = this._filter.controller;
           if (c) {
             const a = this._filter.autocomplete;
-            c.at(-1).push(a ? a.find((e) => e.startsWith(t)) : t);
+            c.at(-1).push(a ? a.find((e) => e.startsWith(text)) : text);
           } else {
-            this._filter.opless.push(t);
+            this._filter.opless.push(text);
           }
         } else {
           // not quoted
-          for (const op_text of t.toLowerCase().split(/ +/)) {
+          for (const op_text of text.toLowerCase().split(/ +/)) {
             if (op_text) {
               this._registerFilter(op_text);
             } else {

--- a/web/src/transmission.js
+++ b/web/src/transmission.js
@@ -41,6 +41,24 @@ export class Transmission extends EventTarget {
 
     // Initialize the implementation fields
     this.filterText = '';
+    this.searchOperators = [
+      [Prefs.FilterOps.name, 'search'],
+      [Prefs.FilterOps.label, 'labels'],
+      [
+        Prefs.FilterOps.status,
+        'states',
+        [
+          Prefs.FilterActive,
+          Prefs.FilterDownloading,
+          Prefs.FilterSeeding,
+          Prefs.FilterPaused,
+          Prefs.FilterFinished,
+        ],
+      ],
+      [Prefs.FilterOps.tracker, 'trackers'],
+      [],
+    ];
+    this._filter = {};
     this._torrents = {};
     this._rows = [];
     this.dirtyTorrents = new Set();
@@ -998,22 +1016,100 @@ TODO: fix this when notifications get fixed
     }
   }
 
+  _registerFilter(text) {
+    for (let [op, c, a] of this.searchOperators) {
+      if (op) {
+        op = op.find((x) => text.startsWith(x));
+        if (!op) {
+          continue;
+        }
+        this._filter.autocomplete = a;
+        this._filter.controller = this._filter[c];
+      }
+
+      c = this._filter.controller;
+      if (op || c) {
+        if (op) {
+          text = text.slice(op.length);
+        }
+
+        let text_array = text.split(/,+/);
+        a = this._filter.autocomplete;
+        if (a) {
+          const new_ta = [];
+          for (const t of text_array) {
+            if (t) {
+              new_ta.push(a.find(e => e.startsWith(t)));
+            }
+          }
+          text_array = new_ta;
+        }
+
+        if (op) {
+          c.push(text_array);
+        } else {
+          c[c.length - 1].push(...text_array);
+        }
+
+        if (text && !text.endsWith(',')) {
+          this._filter.autocomplete = null;
+          this._filter.controller = null;
+        }
+        return;
+      }
+    }
+    this._filter.opless.push(text);
+  }
+
+  _rebuildFilter() {
+    const { filter_mode } = this.prefs;
+
+    this._filter.autocomplete = null;
+    this._filter.controller = null;
+    this._filter.opless = [];
+    this._filter.search = [];
+    this._filter.labels = [];
+    this._filter.states =
+      filter_mode !== Prefs.FilterAll
+        ? [[filter_mode]]
+        : [];
+    this._filter.trackers = this.filterTracker ? [[this.filterTracker]] : [];
+
+    if (this.filterText.length > 0) {
+      for (let [n, t] of this.filterText.match(/(?:\\.|[^"])+|^/g).entries()) {
+        // array of non-quoted then quoted in odd-even model
+        if (n % 2) {
+          // quoted
+          const c = this._filter.controller;
+          if (c) {
+            const a = this._filter.autocomplete;
+            c[c.length - 1].push(a ? a.find(e => e.startsWith(t)) : t);
+          } else {
+            this._filter.opless.push(t);
+          }
+        } else {
+          // not quoted
+          for (const text of t.toLowerCase().split(/ +/)) {
+            if (text) {
+              this._registerFilter(text);
+            } else {
+              this._filter.autocomplete = null;
+              this._filter.controller = null;
+            }
+          }
+        }
+      }
+    }
+
+    if (this._filter.opless.length > 0) {
+      this._filter.search.push(this._filter.opless);
+    }
+  }
+
   _refilter(rebuildEverything) {
-    const { sort_mode, sort_direction, filter_mode } = this.prefs;
-    const filter_tracker = this.filterTracker;
+    const { sort_mode, sort_direction } = this.prefs;
     const renderer = this.torrentRenderer;
     const list = this.elements.torrent_list;
-
-    let filter_text = null;
-    let labels = null;
-    const m = /^labels:([\w,-\s]*)(.*)$/.exec(this.filterText);
-    if (m) {
-      filter_text = m[2].trim();
-      labels = m[1].split(',');
-    } else {
-      filter_text = this.filterText;
-      labels = [];
-    }
 
     const countRows = () => [...list.children].length;
     const countSelectedRows = () =>
@@ -1030,6 +1126,7 @@ TODO: fix this when notifications get fixed
     delete this.refilterTimer;
 
     if (rebuildEverything) {
+      this._rebuildFilter();
       while (list.firstChild) {
         list.firstChild.remove();
       }
@@ -1059,7 +1156,7 @@ TODO: fix this when notifications get fixed
     for (const row of dirty_rows) {
       const id = row.getTorrentId();
       const t = this._torrents[id];
-      if (t && t.test(filter_mode, filter_tracker, filter_text, labels)) {
+      if (t && t.test(this._filter)) {
         temporary.push(row);
       }
       this.dirtyTorrents.delete(id);
@@ -1070,7 +1167,7 @@ TODO: fix this when notifications get fixed
     // but don't already have a row
     for (const id of this.dirtyTorrents.values()) {
       const t = this._torrents[id];
-      if (t && t.test(filter_mode, filter_tracker, filter_text, labels)) {
+      if (t && t.test(this._filter)) {
         const row = new TorrentRow(renderer, this, t);
         const e = row.getElement();
         e.row = row;

--- a/web/src/transmission.js
+++ b/web/src/transmission.js
@@ -1061,10 +1061,6 @@ TODO: fix this when notifications get fixed
 
   _rebuildFilter() {
     const { filter_mode } = this.prefs;
-
-    this._filter.autocomplete = null;
-    this._filter.controller = null;
-    this._filter.opless = [];
     this._filter.search = [];
     this._filter.labels = [];
     this._filter.states =
@@ -1072,6 +1068,9 @@ TODO: fix this when notifications get fixed
     this._filter.trackers = this.filterTracker ? [[this.filterTracker]] : [];
 
     if (this.filterText) {
+      this._filter.autocomplete = null;
+      this._filter.controller = null;
+      this._filter.opless = [];
       const farray = this.filterText.match(/(?:\\.|[^"])+|^/g);
       // array of non-quoted then quoted in odd-even model
       for (const [n, t] of farray.entries()) {
@@ -1096,10 +1095,10 @@ TODO: fix this when notifications get fixed
           }
         }
       }
-    }
 
-    if (this._filter.opless.length > 0) {
-      this._filter.search.push(this._filter.opless);
+      if (this._filter.opless.length > 0) {
+        this._filter.search.push(this._filter.opless);
+      }
     }
   }
 


### PR DESCRIPTION
This pull-request replaces searching algorithms of the search bar to provide a much needed flex in filtering torrents: phrases now separated by spaces, several new delimiters, and plenty of new torrent-related search operators.

Please enter unlikely phrases and let me know if you run into issues. Feedback appreciated and I'm looking forward to tips on making code smaller or some further improvements to the algorithm. The algorithm is big, I've done quite a bit of clean up and everything is working as expected.

Search operators:
* No operators - standard name searching.
* `name:` logical OR name searching.
* `status:` shorthand `is:` accept & autocomplete for torrent listing by status: `active`, `downloading`, `seeding`, `paused`, `finished`. Left-most autocomplete will be chosen first. I'll add `private`, `public`, and `error` when #6977 ships.
* `labels:` / `label:` / `kw:` label searching.
* `tracker:` / `tr:` list torrents containing this tracker.

Repeat operator for multiple possibilities (logical OR).

Delimiters:
* ` ` (space) list torrents by name with all of the words together separated by spaces (logical AND).
* Search operators: ` ` (space) finish and return to no-operator if not ending with comma.
* Search operators: `,` commas to refine torrent list with another match in this operator (logical AND).
* `"` quotation marks for exact phrase. Quote delimiter is odd-even based: uneven quotes mean everything after the last quotation mark will be quoted. Repeated quotation marks e.g. double-quotes, etc. will be trimmed.
* `\` backslash quotes to include quotes, backlash backlashes to include backlashes.

Notes: Replaced searching algorithms for web client: phrases now separated by spaces, new search delimiters and operators.