### PR TITLE
fix: accurate timestamp in daemon logs

### DIFF
--- a/daemon/daemon.cc
+++ b/daemon/daemon.cc
@@ -270,7 +270,7 @@ auto onFileAdded(tr_session* session, std::string_view dirname, std::string_view
 
 void printMessage(
     FILE* ostream,
-    std::chrono::time_point<std::chrono::system_clock> now,
+    std::chrono::system_clock::time_point now,
     tr_log_level level,
     std::string_view name,
     std::string_view message,

--- a/daemon/daemon.cc
+++ b/daemon/daemon.cc
@@ -291,7 +291,7 @@ void printMessage(
     if (ostream != nullptr)
     {
         auto buf = std::array<char, 64>{};
-        auto timestr = tr_logGetTimeStr(now, std::data(buf), std::size(buf));
+        auto const timestr = tr_logGetTimeStr(now, std::data(buf), std::size(buf));
         fmt::print(ostream, "[{:s}] {:s} {:s}\n", timestr, levelName(level), out.c_str());
     }
 

--- a/daemon/daemon.cc
+++ b/daemon/daemon.cc
@@ -5,6 +5,7 @@
 
 #include <array>
 #include <cerrno>
+#include <chrono>
 #include <cstdio> /* printf */
 #include <iostream>
 #include <iterator> /* std::back_inserter */
@@ -269,6 +270,7 @@ auto onFileAdded(tr_session* session, std::string_view dirname, std::string_view
 
 void printMessage(
     FILE* ostream,
+    std::chrono::time_point<std::chrono::system_clock> now,
     tr_log_level level,
     std::string_view name,
     std::string_view message,
@@ -288,9 +290,9 @@ void printMessage(
 
     if (ostream != nullptr)
     {
-        auto timestr = std::array<char, 64>{};
-        tr_logGetTimeStr(std::data(timestr), std::size(timestr));
-        fmt::print(ostream, "[{:s}] {:s} {:s}\n", std::data(timestr), levelName(level), out.c_str());
+        auto buf = std::array<char, 64>{};
+        auto timestr = tr_logGetTimeStr(now, std::data(buf), std::size(buf));
+        fmt::print(ostream, "[{:s}] {:s} {:s}\n", timestr, levelName(level), out.c_str());
     }
 
 #ifdef HAVE_SYSLOG
@@ -329,13 +331,24 @@ void printMessage(
 #endif
 }
 
+void printMessage(
+    FILE* ostream,
+    tr_log_level level,
+    std::string_view name,
+    std::string_view message,
+    std::string_view filename,
+    long line)
+{
+    printMessage(ostream, std::chrono::system_clock::now(), level, name, message, filename, line);
+}
+
 void pumpLogMessages(FILE* log_stream)
 {
     tr_log_message* list = tr_logGetQueue();
 
     for (tr_log_message const* l = list; l != nullptr; l = l->next)
     {
-        printMessage(log_stream, l->level, l->name, l->message, l->file, l->line);
+        printMessage(log_stream, l->when, l->level, l->name, l->message, l->file, l->line);
     }
 
     // two reasons to not flush stderr:

--- a/gtk/MessageLogWindow.cc
+++ b/gtk/MessageLogWindow.cc
@@ -202,7 +202,7 @@ void MessageLogWindow::Impl::level_combo_changed_cb(Gtk::ComboBox* combo_box)
 
 namespace
 {
-using namespace std::chrono;
+using std::chrono::system_clock;
 
 /* similar to asctime, but is utf8-clean */
 Glib::ustring gtr_asctime(system_clock::time_point t)

--- a/gtk/MessageLogWindow.cc
+++ b/gtk/MessageLogWindow.cc
@@ -37,6 +37,7 @@
 #include <fmt/ostream.h>
 
 #include <array>
+#include <chrono>
 #include <fstream>
 #include <memory>
 #include <utility>
@@ -203,9 +204,9 @@ namespace
 {
 
 /* similar to asctime, but is utf8-clean */
-Glib::ustring gtr_asctime(time_t t)
+Glib::ustring gtr_asctime(std::chrono::time_point<system_clock> t)
 {
-    return Glib::DateTime::create_now_local(t).format("%a %b %e %T %Y"); /* ctime equiv */
+    return Glib::DateTime::create_now_local(std::chrono::system_clock::to_time_t(t)).format("%a %b %e %T %Y"); /* ctime equiv */
 }
 
 } // namespace
@@ -324,7 +325,7 @@ void renderText(
 void renderTime(Gtk::CellRendererText* renderer, Gtk::TreeModel::const_iterator const& iter)
 {
     auto const* const node = iter->get_value(message_log_cols.tr_msg);
-    renderer->property_text() = Glib::DateTime::create_now_local(node->when).format("%T");
+    renderer->property_text() = Glib::DateTime::create_now_local(std::chrono::system_clock::to_time_t(node->when)).format("%T");
     setForegroundColor(renderer, node->level);
 }
 

--- a/gtk/MessageLogWindow.cc
+++ b/gtk/MessageLogWindow.cc
@@ -202,11 +202,12 @@ void MessageLogWindow::Impl::level_combo_changed_cb(Gtk::ComboBox* combo_box)
 
 namespace
 {
+using namespace std::chrono;
 
 /* similar to asctime, but is utf8-clean */
-Glib::ustring gtr_asctime(std::chrono::time_point<system_clock> t)
+Glib::ustring gtr_asctime(time_point<system_clock> t)
 {
-    return Glib::DateTime::create_now_local(std::chrono::system_clock::to_time_t(t)).format("%a %b %e %T %Y"); /* ctime equiv */
+    return Glib::DateTime::create_now_local(system_clock::to_time_t(t)).format("%a %b %e %T %Y"); /* ctime equiv */
 }
 
 } // namespace

--- a/gtk/MessageLogWindow.cc
+++ b/gtk/MessageLogWindow.cc
@@ -205,7 +205,7 @@ namespace
 using namespace std::chrono;
 
 /* similar to asctime, but is utf8-clean */
-Glib::ustring gtr_asctime(time_point<system_clock> t)
+Glib::ustring gtr_asctime(system_clock::time_point t)
 {
     return Glib::DateTime::create_now_local(system_clock::to_time_t(t)).format("%a %b %e %T %Y"); /* ctime equiv */
 }

--- a/libtransmission/log.cc
+++ b/libtransmission/log.cc
@@ -198,11 +198,10 @@ std::string_view tr_logGetTimeStr(std::chrono::system_clock::time_point now, cha
 {
     auto const [out, len] = fmt::format_to_n(
         buf,
-        buflen - 1,
+        buflen,
         "{0:%F %H:%M:}{1:%S}",
         now,
         std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()));
-    *out = '\0';
     return { buf, len };
 }
 

--- a/libtransmission/log.cc
+++ b/libtransmission/log.cc
@@ -194,7 +194,7 @@ void tr_logFreeQueue(tr_log_message* freeme)
 
 // ---
 
-std::string_view tr_logGetTimeStr(std::chrono::time_point<std::chrono::system_clock> now, char* buf, size_t buflen)
+std::string_view tr_logGetTimeStr(std::chrono::system_clock::time_point now, char* buf, size_t buflen)
 {
     auto const [out, len] = fmt::format_to_n(
         buf,

--- a/libtransmission/log.h
+++ b/libtransmission/log.h
@@ -54,7 +54,7 @@ struct tr_log_message
     long line;
 
     // when the message was generated
-    std::chrono::time_point<std::chrono::system_clock> when;
+    std::chrono::system_clock::time_point when;
 
     // torrent name or code module name associated with the message
     std::string name;
@@ -111,5 +111,5 @@ void tr_logAddMessage(
 
 // ---
 
-std::string_view tr_logGetTimeStr(std::chrono::time_point<std::chrono::system_clock> now, char* buf, size_t buflen);
+std::string_view tr_logGetTimeStr(std::chrono::system_clock::time_point now, char* buf, size_t buflen);
 std::string_view tr_logGetTimeStr(char* buf, size_t buflen);

--- a/libtransmission/log.h
+++ b/libtransmission/log.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include <chrono>
 #include <cstddef> // size_t
 #include <ctime>
 #include <optional>
@@ -53,7 +54,7 @@ struct tr_log_message
     long line;
 
     // when the message was generated
-    time_t when;
+    std::chrono::time_point<std::chrono::system_clock> when;
 
     // torrent name or code module name associated with the message
     std::string name;
@@ -110,4 +111,5 @@ void tr_logAddMessage(
 
 // ---
 
-char* tr_logGetTimeStr(char* buf, size_t buflen);
+std::string_view tr_logGetTimeStr(std::chrono::time_point<std::chrono::system_clock> now, char* buf, size_t buflen);
+std::string_view tr_logGetTimeStr(char* buf, size_t buflen);

--- a/macosx/MessageWindowController.mm
+++ b/macosx/MessageWindowController.mm
@@ -250,9 +250,10 @@ static NSTimeInterval const kUpdateSeconds = 0.75;
         auto const file_string = std::string{ currentMessage->file };
         NSString* file = [(@(file_string.c_str())).lastPathComponent stringByAppendingFormat:@":%ld", currentMessage->line];
 
+        auto const secs_since_1970 = std::chrono::system_clock::to_time_t(currentMessage->when);
         NSDictionary* message = @{
             @"Message" : @(currentMessage->message.c_str()),
-            @"Date" : [NSDate dateWithTimeIntervalSince1970:currentMessage->when],
+            @"Date" : [NSDate dateWithTimeIntervalSince1970:secs_since_1970],
             @"Index" : @(currentIndex++), //more accurate when sorting by date
             @"Level" : @(currentMessage->level),
             @"Name" : name,


### PR DESCRIPTION
Currently, daemon logs take the timestamp when they are printed, instead of when they are queued. This PR changes the behaviour to the latter, so that they more accurately reflect when the event happened.

Notes: More accurate timestamps for daemon logs.