### PR TITLE
fix: make name and hash readable

### DIFF
--- a/web/assets/css/transmission-app.scss
+++ b/web/assets/css/transmission-app.scss
@@ -1057,9 +1057,7 @@ a {
     cursor: pointer;
     font-size: 14px;
     grid-area: name;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+    overflow-wrap: anywhere;
   }
 
   .inspector-torrent-file-list-entry.skip
@@ -1556,6 +1554,7 @@ dialog {
   display: flex;
   font-size: 1.2em;
   font-weight: bold;
+  overflow-wrap: anywhere;
 }
 
 .dialog-logo {
@@ -1684,6 +1683,10 @@ dialog {
   legend {
     font-weight: bolder;
     margin-bottom: 4px;
+  }
+
+  span {
+    overflow-wrap: anywhere;
   }
 }
 

--- a/web/src/inspector.js
+++ b/web/src/inspector.js
@@ -103,6 +103,7 @@ export class Inspector extends EventTarget {
 
     append_section_title('Details');
     rows = [
+      ['name', 'Name:'],
       ['size', 'Size:'],
       ['location', 'Location:'],
       ['hash', 'Hash:'],
@@ -323,7 +324,7 @@ export class Inspector extends EventTarget {
     }
     setTextContent(e.info.availability, fmt.stringSanitizer(string));
 
-    //  downloaded
+    // downloaded
     if (torrents.length === 0) {
       string = none;
     } else {
@@ -366,7 +367,7 @@ export class Inspector extends EventTarget {
     if (torrents.length === 0) {
       string = none;
     } else if (torrents.every((t) => t.isStopped())) {
-      string = stateString; // paused || finished}
+      string = stateString;
     } else {
       const get = (t) => t.getStartDate();
       const first = get(torrents[0]);
@@ -420,6 +421,14 @@ export class Inspector extends EventTarget {
       string = torrents.every((t) => get(t) === first) ? first : mixed;
     }
     setTextContent(e.info.error, string || none);
+
+    // torrent name
+    if (torrents.length === 1) {
+      string = torrents[0].getName();
+    } else {
+      string = torrents.length > 0 ? mixed : none;
+    }
+    setTextContent(e.info.name, string);
 
     // size
     if (torrents.length === 0) {

--- a/web/src/inspector.js
+++ b/web/src/inspector.js
@@ -423,15 +423,10 @@ export class Inspector extends EventTarget {
     setTextContent(e.info.error, string || none);
 
     // torrent name
-    switch (torrents.length) {
-      case 0:
-        string = none;
-        break;
-      case 1:
-        string = torrents[0].getName();
-        break;
-      default:
-        string = mixed;
+    if (torrents.length === 1) {
+      string = torrents[0].getName();
+    } else {
+      string = torrents.length > 0 ? mixed : none;
     }
     setTextContent(e.info.name, string);
 

--- a/web/src/inspector.js
+++ b/web/src/inspector.js
@@ -423,10 +423,15 @@ export class Inspector extends EventTarget {
     setTextContent(e.info.error, string || none);
 
     // torrent name
-    if (torrents.length === 1) {
-      string = torrents[0].getName();
-    } else {
-      string = torrents.length > 0 ? mixed : none;
+    switch (torrents.length) {
+      case 0:
+        string = none;
+        break;
+      case 1:
+        string = torrents[0].getName();
+        break;
+      default:
+        string = mixed;
     }
     setTextContent(e.info.name, string);
 
@@ -870,7 +875,6 @@ export class Inspector extends EventTarget {
         break;
       default:
         command = 'priority-normal';
-        break;
     }
 
     this._changeFileCommand(indices, command);


### PR DESCRIPTION
Supersedes: #6288 along with more fixes

Left: This PR, Right: Original
![Transmission no-escaping](https://github.com/user-attachments/assets/37e89bd8-9ccb-4d70-b6da-494d4e922bf4)

The top part of the screenshot is observation of a problem that calls for an addition of name to the info page.

Notes: Fixed truncated hash in inspector page, added name section to inspector page