### PR TITLE
Opt-in to secure coding explicitly

### DIFF
--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -843,6 +843,8 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
     }
 }
 
+#pragma mark - NSApplicationDelegate
+
 - (void)applicationWillFinishLaunching:(NSNotification*)notification
 {
     // user notifications
@@ -1091,6 +1093,13 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
     //complete cleanup
     tr_sessionClose(self.fLib);
 }
+
+- (BOOL)applicationSupportsSecureRestorableState:(NSApplication*)app
+{
+    return YES;
+}
+
+#pragma mark -
 
 - (tr_session*)sessionHandle
 {


### PR DESCRIPTION
fix this warning:

>WARNING: Secure coding is automatically enabled for restorable state! However, not on all supported macOS versions of this application. Opt-in to secure coding explicitly by implementing NSApplicationDelegate.applicationSupportsSecureRestorableState:.
