### PR TITLE
refactor: respond immediately to block requests from peer

### DIFF
--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -559,6 +559,12 @@ private:
         if (can_add_request_from_peer(req))
         {
             peer_requested_.emplace_back(req);
+
+            auto const now_sec = tr_time();
+            auto const now_msec = tr_time_msec();
+            while (fill_output_buffer(now_sec, now_msec) != 0U)
+            {
+            }
         }
         else if (io_->supports_fext())
         {

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -560,11 +560,7 @@ private:
         {
             peer_requested_.emplace_back(req);
 
-            auto const now_sec = tr_time();
-            auto const now_msec = tr_time_msec();
-            while (fill_output_buffer(now_sec, now_msec) != 0U)
-            {
-            }
+            fill_output_buffer(tr_time(), tr_time_msec());
         }
         else if (io_->supports_fext())
         {
@@ -613,7 +609,14 @@ private:
     void maybe_send_metadata_requests(time_t now) const;
     [[nodiscard]] size_t add_next_metadata_piece();
     [[nodiscard]] size_t add_next_block(time_t now_sec, uint64_t now_msec);
-    [[nodiscard]] size_t fill_output_buffer(time_t now_sec, uint64_t now_msec);
+
+    [[nodiscard]] size_t fill_output_buffer_impl(time_t now_sec, uint64_t now_msec);
+    void fill_output_buffer(time_t now_sec, uint64_t now_msec)
+    {
+        while (fill_output_buffer_impl(now_sec, now_msec) != 0U)
+        {
+        }
+    }
 
     // ---
 
@@ -1840,14 +1843,7 @@ void tr_peerMsgsImpl::pulse()
     update_desired_request_count();
     maybe_send_block_requests();
     maybe_send_metadata_requests(now_sec);
-
-    for (;;)
-    {
-        if (fill_output_buffer(now_sec, now_msec) == 0U)
-        {
-            break;
-        }
-    }
+    fill_output_buffer(now_sec, now_msec);
 }
 
 void tr_peerMsgsImpl::maybe_send_metadata_requests(time_t now) const
@@ -1907,7 +1903,7 @@ void tr_peerMsgsImpl::check_request_timeout(time_t now)
     }
 }
 
-[[nodiscard]] size_t tr_peerMsgsImpl::fill_output_buffer(time_t now_sec, uint64_t now_msec)
+[[nodiscard]] size_t tr_peerMsgsImpl::fill_output_buffer_impl(time_t now_sec, uint64_t now_msec)
 {
     auto n_bytes_written = size_t{};
 


### PR DESCRIPTION
Part of #6986.

To saturate the upload bandwidth, send back a piece message as soon as Transmission receives a request message, instead of sending out one batch every 0.5 seconds.

~This PR won't have much effect until #7027 is merged, but it is harmless and does not conflict with other code regardless.~
Edit: It's merged.

Notes: Better utilize high Internet bandwidth.