### PR TITLE
fix(web): pressing the enter key now submits dialogs

### DIFF
--- a/web/src/open-dialog.js
+++ b/web/src/open-dialog.js
@@ -153,11 +153,6 @@ export class OpenDialog extends EventTarget {
     input.value = url;
     workarea.append(input);
     elements.url_input = input;
-    input.addEventListener('keyup', ({ key }) => {
-      if (key === 'Enter') {
-        confirm.click();
-      }
-    });
 
     input_id = makeUUID();
     label = document.createElement('label');

--- a/web/src/utils.js
+++ b/web/src/utils.js
@@ -125,6 +125,12 @@ export function createDialogContainer(id) {
   confirm.textContent = 'OK';
   buttons.append(confirm);
 
+  win.addEventListener('keyup', ({ key }) => {
+    if (key === 'Enter') {
+      confirm.click();
+    }
+  });
+
   const bend = document.createElement('span');
   bend.classList.add('dialog-buttons-end');
   buttons.append(bend);


### PR DESCRIPTION
Dialogs by themselves aren't submitted when pressing the Enter key,
for that we need to add an event handler to the dialog itself.

One approach I tried was to add a form to the dialog. This worked, but
needed a CSS workaround to keep the buttons in the same order.

Tested with some other dialogs as well:

* edit labels; and
* set location.

References:

* https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog#handling_the_return_value_from_the_dialog
* https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#formmethod
* https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form#method

Fixes #6553

