### PR TITLE
docs: fix a link to send-email-when-torrent-done.sh script in Transmi…

### DIFF
--- a/docs/Scripts.md
+++ b/docs/Scripts.md
@@ -30,7 +30,7 @@ Transmission can be set to invoke a script when downloads complete. The environm
  * `TR_TORRENT_PRIORITY` - The priority of the torrent (Low is "-1", Normal is "0", High is "1")
  * `TR_TORRENT_TRACKERS` - A comma-delimited list of the torrent's trackers' announce URLs
 
-[Here is an example script](https://trac.transmissionbt.com/browser/trunk/extras/send-email-when-torrent-done.sh) that sends an email when a torrent finishes.
+[Here is an example script](https://github.com/transmission/transmission/blob/main/extras/send-email-when-torrent-done.sh) that sends an email when a torrent finishes.
 
 ### Obsolete
 Functionality of these scripts has been implemented in libtransmission and is thus available in all clients.


### PR DESCRIPTION
Fix a link to the  `send-email-when-torrent-done.sh` script as docs point to the previous repository.