### PR TITLE
feat: sequential download cmdline options in remote and daemon

### DIFF
--- a/daemon/daemon.cc
+++ b/daemon/daemon.cc
@@ -144,6 +144,7 @@ auto constexpr Options = std::array<tr_option, 45>{
       { 'x', "pid-file", "Enable PID file", "x", true, "<pid-file>" },
       { 0, nullptr, nullptr, nullptr, false, nullptr } }
 };
+static_assert(Options[std::size(Options) - 2].val != 0);
 
 [[nodiscard]] std::string getConfigDir(int argc, char const* const* argv)
 {

--- a/daemon/daemon.cc
+++ b/daemon/daemon.cc
@@ -77,7 +77,7 @@ char constexpr Usage[] = "Transmission " LONG_VERSION_STRING
 
 // --- Config File
 
-auto constexpr Options = std::array<tr_option, 45>{
+auto constexpr Options = std::array<tr_option, 47>{
     { { 'a', "allowed", "Allowed IP addresses. (Default: " TR_DEFAULT_RPC_WHITELIST ")", "a", true, "<list>" },
       { 'b', "blocklist", "Enable peer blocklists", "b", false, nullptr },
       { 'B', "no-blocklist", "Disable peer blocklists", "B", false, nullptr },
@@ -141,6 +141,8 @@ auto constexpr Options = std::array<tr_option, 45>{
         "GSR",
         false,
         nullptr },
+      { 994, "sequential-download", "Enable sequential download by default", "seq", false, nullptr },
+      { 995, "no-sequential-download", "Disable sequential download by default", "SEQ", false, nullptr },
       { 'x', "pid-file", "Enable PID file", "x", true, "<pid-file>" },
       { 0, nullptr, nullptr, nullptr, false, nullptr } }
 };
@@ -486,6 +488,14 @@ bool tr_daemon::parse_args(int argc, char const* const* argv, bool* dump_setting
 
         case 943:
             tr_variantDictAddStr(&settings_, TR_KEY_default_trackers, optstr);
+            break;
+
+        case 994:
+            tr_variantDictAddBool(&settings_, TR_KEY_sequentialDownload, true);
+            break;
+
+        case 995:
+            tr_variantDictAddBool(&settings_, TR_KEY_sequentialDownload, false);
             break;
 
         case 'd':

--- a/utils/remote.cc
+++ b/utils/remote.cc
@@ -1837,6 +1837,11 @@ void print_session(tr_variant::Map const& map)
         fmt::print("  Maximum memory cache size: {:s}\n", Memory{ *i, Memory::Units::MBytes }.to_string());
     }
 
+    if (auto b = args->value_if<bool>(TR_KEY_sequentialDownload); b)
+    {
+        fmt::print("  Sequential download: {:s}\n", *b ? "Yes" : "No");
+    }
+
     auto const alt_enabled = args->value_if<bool>(TR_KEY_alt_speed_enabled);
     auto const alt_time_enabled = args->value_if<bool>(TR_KEY_alt_speed_time_enabled);
     auto const up_enabled = args->value_if<bool>(TR_KEY_speed_limit_up_enabled);


### PR DESCRIPTION
Closes #6658.

Add command line options for sequential download in `transmission-remote` and `transmission-daemon`.

Notes: Added optional sequential downloading.