### PR TITLE
feat: log timestamps in local ISO8601 format

### DIFF
--- a/libtransmission/log.cc
+++ b/libtransmission/log.cc
@@ -202,7 +202,7 @@ char* tr_logGetTimeStr(char* buf, size_t buflen)
     auto const [out, len] = fmt::format_to_n(
         buf,
         buflen - 1,
-        "{0:%FT%T.}{1:%Q}{0:%z}",
+        "{0:%FT%T.}{1:0>3%Q}{0:%z}",
         a_tm,
         std::chrono::duration_cast<std::chrono::milliseconds>(subseconds));
     *out = '\0';

--- a/libtransmission/log.cc
+++ b/libtransmission/log.cc
@@ -197,12 +197,14 @@ void tr_logFreeQueue(tr_log_message* freeme)
 char* tr_logGetTimeStr(char* buf, size_t buflen)
 {
     auto const a = std::chrono::system_clock::now();
+    auto const a_tm = fmt::localtime(std::chrono::system_clock::to_time_t(a));
     auto const [out, len] = fmt::format_to_n(
         buf,
         buflen - 1,
-        "{0:%F %H:%M:}{1:%S}",
-        a,
-        std::chrono::duration_cast<std::chrono::milliseconds>(a.time_since_epoch()));
+        "{0:%FT%R:}{1:%S}{2:%z}",
+        a_tm,
+        std::chrono::time_point_cast<std::chrono::milliseconds>(a),
+        a_tm);
     *out = '\0';
     return buf;
 }

--- a/libtransmission/log.cc
+++ b/libtransmission/log.cc
@@ -201,10 +201,9 @@ char* tr_logGetTimeStr(char* buf, size_t buflen)
     auto const [out, len] = fmt::format_to_n(
         buf,
         buflen - 1,
-        "{0:%FT%R:}{1:%S}{2:%z}",
+        "{0:%FT%R:}{1:%S}{0:%z}",
         a_tm,
-        std::chrono::time_point_cast<std::chrono::milliseconds>(a),
-        a_tm);
+        std::chrono::time_point_cast<std::chrono::milliseconds>(a));
     *out = '\0';
     return buf;
 }

--- a/libtransmission/log.cc
+++ b/libtransmission/log.cc
@@ -198,12 +198,13 @@ char* tr_logGetTimeStr(char* buf, size_t buflen)
 {
     auto const a = std::chrono::system_clock::now();
     auto const a_tm = fmt::localtime(std::chrono::system_clock::to_time_t(a));
+    auto const subseconds = a - std::chrono::time_point_cast<std::chrono::seconds>(a);
     auto const [out, len] = fmt::format_to_n(
         buf,
         buflen - 1,
-        "{0:%FT%R:}{1:%S}{0:%z}",
+        "{0:%FT%T.}{1:%Q}{0:%z}",
         a_tm,
-        std::chrono::time_point_cast<std::chrono::milliseconds>(a));
+        std::chrono::duration_cast<std::chrono::milliseconds>(subseconds));
     *out = '\0';
     return buf;
 }


### PR DESCRIPTION
Closes #7046.

Sample:

```
[2024-08-12T14:20:59.731+0800] inf session.cc:418 Listening to incoming peer connections on 0.0.0.0:51413 (session.cc:418)
[2024-08-12T14:20:59.731+0800] inf session.cc:418 Listening to incoming peer connections on [::]:51413 (session.cc:418)
```

Notes: Daemon log timestamps are now in local ISO8601 format.