### PR TITLE
Refactor async torrent removal logic

### DIFF
--- a/gtk/Session.cc
+++ b/gtk/Session.cc
@@ -168,6 +168,8 @@ private:
     void on_torrent_completeness_changed(tr_torrent* tor, tr_completeness completeness, bool was_running);
     void on_torrent_metadata_changed(tr_torrent* raw_torrent);
 
+    void on_torrent_removal_done(tr_torrent_id_t id, bool succeeded);
+
 private:
     Session& core_;
 
@@ -912,45 +914,41 @@ void Session::remove_torrent(tr_torrent_id_t id, bool delete_files)
 
 void Session::Impl::remove_torrent(tr_torrent_id_t id, bool delete_files)
 {
+    static auto const callback = [](tr_torrent_id_t processed_id, bool succeeded, void* user_data)
+    {
+        // "Own" the core since refcount has already been incremented before operation start — only decrement required.
+        auto const core = Glib::make_refptr_for_instance(static_cast<Session*>(user_data));
+
+        Glib::signal_idle().connect_once([processed_id, succeeded, core]()
+                                         { core->impl_->on_torrent_removal_done(processed_id, succeeded); });
+    };
+
     if (auto const& [torrent, position] = find_torrent_by_id(id); torrent)
     {
-        // Callback to remove the torrent entry from the GUI if it was
-        // successfuly removed. This is called from the libtransmission thread.
-        auto handle_result = [](tr_torrent_id_t processed_id, bool succeeded, void* user_data)
-        {
-            // "Own" the core since refcount has already been incremented before operation start — only decrement required.
-            auto const core = Glib::make_refptr_for_instance(static_cast<Session*>(user_data));
-
-            // Schedule the actual handler in the main thread:
-            Glib::signal_idle().connect_once(
-                [processed_id, succeeded, core]()
-                {
-                    if (!succeeded)
-                    {
-                        return;
-                    }
-
-                    auto const& impl = *core->impl_;
-                    if (auto const& [torrent_, position_] = impl.find_torrent_by_id(processed_id); torrent_)
-                    {
-                        /* remove from the gui */
-                        impl.get_raw_model()->remove(position_);
-                    }
-                });
-        };
-
         // Extend core lifetime, refcount will be decremented in the callback.
         core_.reference();
 
-        /* remove the torrent */
         tr_torrentRemove(
             &torrent->get_underlying(),
             delete_files,
             [](char const* filename, void* /*user_data*/, tr_error* error)
             { return gtr_file_trash_or_remove(filename, error); },
             nullptr,
-            handle_result,
+            callback,
             &core_);
+    }
+}
+
+void Session::Impl::on_torrent_removal_done(tr_torrent_id_t id, bool succeeded)
+{
+    if (!succeeded)
+    {
+        return;
+    }
+
+    if (auto const& [torrent, position] = find_torrent_by_id(id); torrent)
+    {
+        get_raw_model()->remove(position);
     }
 }
 

--- a/libtransmission/torrent-files.cc
+++ b/libtransmission/torrent-files.cc
@@ -198,7 +198,7 @@ bool tr_torrent_files::move(
         }
 
         tr_logAddTrace(fmt::format("Moving file #{:d} to '{:s}'", i, old_path, path), parent_name);
-        if (!tr_file_move(old_path, path, error))
+        if (!tr_file_move(old_path, path, true, error))
         {
             err = true;
             break;
@@ -268,7 +268,7 @@ void tr_torrent_files::remove(std::string_view parent_in, std::string_view tmpdi
                 auto const f = moved_file{ found->filename(), tr_pathbuf{ tmpdir, '/', found->subpath() } };
 
                 // if moving a file fails, give up and let the error propagate
-                if (!tr_file_move_strict(f.from, f.to, error))
+                if (!tr_file_move(f.from, f.to, false, error))
                 {
                     return;
                 }

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -763,8 +763,8 @@ void tr_torrentRemoveInSessionThread(
     bool delete_flag,
     tr_fileFunc delete_func,
     void* delete_user_data,
-    tr_result_notify_func notify_func,
-    void* notify_user_data)
+    tr_torrent_remove_done_func callback,
+    void* callback_user_data)
 {
     auto const lock = tor->unique_lock();
 
@@ -800,9 +800,9 @@ void tr_torrentRemoveInSessionThread(
         }
     }
 
-    if (notify_func != nullptr)
+    if (callback != nullptr)
     {
-        notify_func(ok, notify_user_data);
+        callback(ok, callback_user_data);
     }
 
     if (ok)
@@ -830,8 +830,8 @@ void tr_torrentRemove(
     bool delete_flag,
     tr_fileFunc delete_func,
     void* delete_user_data,
-    tr_result_notify_func notify_func,
-    void* notify_user_data)
+    tr_torrent_remove_done_func callback,
+    void* callback_user_data)
 {
     using namespace start_stop_helpers;
 
@@ -845,8 +845,8 @@ void tr_torrentRemove(
         delete_flag,
         delete_func,
         delete_user_data,
-        notify_func,
-        notify_user_data);
+        callback,
+        callback_user_data);
 }
 
 void tr_torrentFreeInSessionThread(tr_torrent* tor)

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -802,7 +802,7 @@ void tr_torrentRemoveInSessionThread(
 
     if (callback != nullptr)
     {
-        callback(ok, callback_user_data);
+        callback(tor->id(), ok, callback_user_data);
     }
 
     if (ok)

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -989,15 +989,15 @@ private:
         bool delete_flag,
         tr_fileFunc delete_func,
         void* delete_user_data,
-        tr_result_notify_func notify_func,
-        void* notify_user_data);
+        tr_torrent_remove_done_func callback,
+        void* callback_user_data);
     friend void tr_torrentRemove(
         tr_torrent* tor,
         bool delete_flag,
         tr_fileFunc delete_func,
         void* delete_user_data,
-        tr_result_notify_func notify_func,
-        void* notify_user_data);
+        tr_torrent_remove_done_func callback,
+        void* callback_user_data);
     friend void tr_torrentSetDownloadDir(tr_torrent* tor, char const* path);
     friend void tr_torrentSetPriority(tr_torrent* tor, tr_priority_t priority);
     friend void tr_torrentStart(tr_torrent* tor);

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -829,7 +829,7 @@ tr_torrent* tr_torrentNew(tr_ctor* ctor, tr_torrent** setme_duplicate_of);
 
 using tr_fileFunc = bool (*)(char const* filename, void* user_data, tr_error* error);
 
-using tr_torrent_remove_done_func = void (*)(bool succeeded, void* user_data);
+using tr_torrent_remove_done_func = void (*)(tr_torrent_id_t id, bool succeeded, void* user_data);
 
 /** @brief Removes our torrent and .resume files for this torrent */
 void tr_torrentRemove(

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -829,7 +829,7 @@ tr_torrent* tr_torrentNew(tr_ctor* ctor, tr_torrent** setme_duplicate_of);
 
 using tr_fileFunc = bool (*)(char const* filename, void* user_data, tr_error* error);
 
-using tr_result_notify_func = void (*)(bool succeeded, void* user_data);
+using tr_torrent_remove_done_func = void (*)(bool succeeded, void* user_data);
 
 /** @brief Removes our torrent and .resume files for this torrent */
 void tr_torrentRemove(
@@ -837,8 +837,8 @@ void tr_torrentRemove(
     bool delete_flag,
     tr_fileFunc delete_func,
     void* delete_user_data,
-    tr_result_notify_func notify_func,
-    void* notify_user_data);
+    tr_torrent_remove_done_func callback,
+    void* callback_user_data);
 
 /** @brief Start a torrent */
 void tr_torrentStart(tr_torrent* torrent);

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -569,13 +569,11 @@ std::string tr_strratio(double ratio, char const* infinity)
 
 // ---
 
-namespace
+bool tr_file_move(std::string_view oldpath_in, std::string_view newpath_in, bool allow_copy, tr_error* error)
 {
-namespace tr_file_move_impl
-{
+    auto const oldpath = tr_pathbuf{ oldpath_in };
+    auto const newpath = tr_pathbuf{ newpath_in };
 
-bool check_paths(std::string_view const oldpath, std::string_view const newpath, tr_error* error)
-{
     auto local_error = tr_error{};
     if (error == nullptr)
     {
@@ -604,46 +602,16 @@ bool check_paths(std::string_view const oldpath, std::string_view const newpath,
         return false;
     }
 
-    return true;
-}
-
-} // namespace tr_file_move_impl
-} // namespace
-
-bool tr_file_move_strict(std::string_view oldpath_in, std::string_view newpath_in, tr_error* error)
-{
-    if (!tr_file_move_impl::check_paths(oldpath_in, newpath_in, error))
+    /* they might be on the same filesystem... */
+    if (tr_sys_path_rename(oldpath, newpath, error))
     {
-        return false;
+        return true;
     }
 
-    auto const oldpath = tr_pathbuf{ oldpath_in };
-    auto const newpath = tr_pathbuf{ newpath_in };
-
-    /* do the actual moving */
-    if (!tr_sys_path_rename(oldpath, newpath, error))
+    if (!allow_copy)
     {
         error->prefix_message("Unable to move file: ");
         return false;
-    }
-
-    return true;
-}
-
-bool tr_file_move(std::string_view oldpath_in, std::string_view newpath_in, tr_error* error)
-{
-    if (!tr_file_move_impl::check_paths(oldpath_in, newpath_in, error))
-    {
-        return false;
-    }
-
-    auto const oldpath = tr_pathbuf{ oldpath_in };
-    auto const newpath = tr_pathbuf{ newpath_in };
-
-    /* they might be on the same filesystem... */
-    if (tr_sys_path_rename(oldpath, newpath))
-    {
-        return true;
     }
 
     /* Otherwise, copy the file. */

--- a/libtransmission/utils.h
+++ b/libtransmission/utils.h
@@ -64,18 +64,11 @@ std::optional<std::locale> tr_locale_set_global(std::locale const& locale) noexc
 bool tr_file_read(std::string_view filename, std::vector<char>& contents, tr_error* error = nullptr);
 
 /**
- * Tries to move a file by renaming, but never by copying.
+ * Tries to move a file by renaming, and [optionally] if that fails, by copying.
  *
  * Creates the destination directory if it doesn't exist.
  */
-bool tr_file_move_strict(std::string_view oldpath_in, std::string_view newpath_in, tr_error* error = nullptr);
-
-/**
- * Tries to move a file by renaming, and if that fails, by copying.
- *
- * Creates the destination directory if it doesn't exist.
- */
-bool tr_file_move(std::string_view oldpath, std::string_view newpath, tr_error* error = nullptr);
+bool tr_file_move(std::string_view oldpath, std::string_view newpath, bool allow_copy, tr_error* error = nullptr);
 
 bool tr_file_save(std::string_view filename, std::string_view contents, tr_error* error = nullptr);
 


### PR DESCRIPTION
Apply changes previously suggested in #6055. Remove unused code and simplify. Fixup crash if `tr_file_move()` passed null error.