### PR TITLE
refactor: remove last byte special case in `tr_block_info::byte_loc()`

### DIFF
--- a/libtransmission/block-info.h
+++ b/libtransmission/block-info.h
@@ -83,16 +83,8 @@ public:
         {
             loc.byte = byte_idx;
 
-            if (byte_idx == total_size()) // handle 0-byte files at the end of a torrent
-            {
-                loc.block = block_count() - 1U;
-                loc.piece = piece_count() - 1U;
-            }
-            else
-            {
-                loc.block = static_cast<tr_block_index_t>(byte_idx / BlockSize);
-                loc.piece = static_cast<tr_piece_index_t>(byte_idx / piece_size());
-            }
+            loc.block = static_cast<tr_block_index_t>(byte_idx / BlockSize);
+            loc.piece = static_cast<tr_piece_index_t>(byte_idx / piece_size());
 
             loc.block_offset = static_cast<uint32_t>(loc.byte - (uint64_t{ loc.block } * BlockSize));
             loc.piece_offset = static_cast<uint32_t>(loc.byte - (uint64_t{ loc.piece } * piece_size()));

--- a/libtransmission/file-piece-map.cc
+++ b/libtransmission/file-piece-map.cc
@@ -44,9 +44,13 @@ void tr_file_piece_map::reset(tr_block_info const& block_info, uint64_t const* c
     for (tr_file_index_t i = 0U; i < n_files; ++i)
     {
         auto const file_size = file_sizes[i];
+
         auto const begin_byte = offset;
-        auto const begin_piece = block_info.byte_loc(begin_byte).piece;
         auto end_byte = tr_byte_index_t{};
+
+        // N.B. If the last file in the torrent is 0 bytes, and the torrent size is a multiple of piece size,
+        // then the computed piece index will be past-the-end. We handle this with std::min.
+        auto const begin_piece = std::min(block_info.byte_loc(begin_byte).piece, block_info.piece_count() - 1U);
         auto end_piece = tr_piece_index_t{};
 
         edge_pieces.insert(begin_piece);
@@ -63,7 +67,6 @@ void tr_file_piece_map::reset(tr_block_info const& block_info, uint64_t const* c
         else
         {
             end_byte = begin_byte;
-            // TODO(ckerr): should end_piece == begin_piece, same as _bytes are?
             end_piece = begin_piece + 1U;
         }
         file_bytes_[i] = byte_span_t{ begin_byte, end_byte };

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1987,7 +1987,10 @@ tr_block_span_t tr_torrent::block_span_for_file(tr_file_index_t const file) cons
 {
     auto const [begin_byte, end_byte] = byte_span_for_file(file);
 
-    auto const begin_block = byte_loc(begin_byte).block;
+    // N.B. If the last file in the torrent is 0 bytes, and the torrent size is a multiple of block size,
+    // then the computed block index will be past-the-end. We handle this with std::min.
+    auto const begin_block = std::min(byte_loc(begin_byte).block, block_count() - 1U);
+
     if (begin_byte >= end_byte) // 0-byte file
     {
         return { begin_block, begin_block + 1 };


### PR DESCRIPTION
This was added in #2220, ~I'm not sure what it's supposed to fix.~

Edit: I've realise what it is catering to, and written code to work around it.

It prevents `byte_loc()` from returning a past-the-end piece/block index, but I think `byte_loc()` will be more useful if it does return past-the-end.

P.S. It actually costed me a few hours of debugging. 🤡 