### PR TITLE
refactor: avoid `front()` prior to loop

### DIFF
--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -1647,7 +1647,8 @@ uint64_t tr_peerMgrGetDesiredAvailable(tr_torrent const* tor)
         return 0;
     }
 
-    auto available = swarm->peers.front()->has();
+    auto available = tr_bitfield(0);
+    available.set_has_none();
     for (auto const* const peer : swarm->peers)
     {
         available |= peer->has();

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -1647,8 +1647,7 @@ uint64_t tr_peerMgrGetDesiredAvailable(tr_torrent const* tor)
         return 0;
     }
 
-    auto available = tr_bitfield(0);
-    available.set_has_none();
+    auto available = tr_bitfield{ tor->piece_count() };
     for (auto const* const peer : swarm->peers)
     {
         available |= peer->has();


### PR DESCRIPTION
It was bothering me that we duplicated the call to `->has()` and that the first element of the loop would bitwise compare with itself, so I refactored it to a more classic logic with an initialisation to zero.