### PR TITLE
fix: Avoid ambiguous overload when calling Gdk::Cursor::create

### DIFF
--- a/gtk/MainWindow.cc
+++ b/gtk/MainWindow.cc
@@ -887,7 +887,7 @@ void MainWindow::set_busy(bool isBusy)
     if (get_realized())
     {
 #if GTKMM_CHECK_VERSION(4, 0, 0)
-        auto const cursor = isBusy ? Gdk::Cursor::create("wait") : Glib::RefPtr<Gdk::Cursor>();
+        auto const cursor = isBusy ? Gdk::Cursor::create(Glib::ustring("wait")) : Glib::RefPtr<Gdk::Cursor>();
         set_cursor(cursor);
 #else
         auto const display = get_display();


### PR DESCRIPTION
Since gtkmm 4.15.0 a new overload for Gdk::Cursor::create exists which creates an ambiguity when passing a string literal.

We can avoid the ambiguity by explicitly constructing a Glib::ustring from the string literal before calling the method.

https://gitlab.gnome.org/GNOME/gtkmm/-/issues/159