### PR TITLE
fix: restore peer ID on resume (#7035)

### DIFF
--- a/libtransmission/quark.cc
+++ b/libtransmission/quark.cc
@@ -222,6 +222,7 @@ auto constexpr MyStatic = std::array<std::string_view, TR_N_KEYS>{
     "paused"sv,
     "pausedTorrentCount"sv,
     "peer-congestion-algorithm"sv,
+    "peer-id"sv,
     "peer-limit"sv,
     "peer-limit-global"sv,
     "peer-limit-per-torrent"sv,

--- a/libtransmission/quark.h
+++ b/libtransmission/quark.h
@@ -224,6 +224,7 @@ enum
     TR_KEY_paused,
     TR_KEY_pausedTorrentCount,
     TR_KEY_peer_congestion_algorithm,
+    TR_KEY_peer_id,
     TR_KEY_peer_limit,
     TR_KEY_peer_limit_global,
     TR_KEY_peer_limit_per_torrent,

--- a/libtransmission/resume.h
+++ b/libtransmission/resume.h
@@ -45,6 +45,7 @@ auto inline constexpr Name = fields_t{ 1 << 21 };
 auto inline constexpr Labels = fields_t{ 1 << 22 };
 auto inline constexpr Group = fields_t{ 1 << 23 };
 auto inline constexpr SequentialDownload = fields_t{ 1 << 24 };
+auto inline constexpr PeerId = fields_t{ 1 << 25 };
 
 auto inline constexpr All = ~fields_t{ 0 };
 

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -916,6 +916,11 @@ struct tr_torrent
         return peer_id_;
     }
 
+    constexpr void set_peer_id(tr_peer_id_t const& id) noexcept
+    {
+        peer_id_ = id;
+    }
+
     void on_block_received(tr_block_index_t block);
 
     [[nodiscard]] constexpr auto& error() noexcept


### PR DESCRIPTION
This change adds support for saving and restoring the `peer_id` for each torrent across sessions, which should help address #7035. Note that the `peer_id` needs to be successfully saved at least once in order for it to be successfully restored. This can be done by manually stopping the torrent or by letting Transmission cleanly shut down.

I tested this by running `TR_CURL_VERBOSE=1 Transmission.app/Contents/MacOS/Transmission 2>&1 | grep peer_id` to check the `peer_id` before killing Transmission with <kbd>Ctrl</kbd> + <kbd>C</kbd>. `peer_id` persists with this change as long as it was previously saved.

I am leaving this as a draft as I'm new to the Transmission codebase. Feel free to make suggestions.