### PR TITLE
Fix infinite loop when searching for missing torrents by id

### DIFF
--- a/gtk/Session.cc
+++ b/gtk/Session.cc
@@ -622,7 +622,14 @@ std::pair<Glib::RefPtr<Torrent>, guint> Session::Impl::find_torrent_by_id(tr_tor
             return { torrent, position };
         }
 
-        (current_torrent_id < torrent_id ? begin_position : end_position) = position;
+        if (current_torrent_id < torrent_id)
+        {
+            begin_position = position + 1;
+        }
+        else
+        {
+            end_position = position;
+        }
     }
 
     return {};


### PR DESCRIPTION
Notes: Fix `4.0.0` regression causing GTK client to hang in some cases.
Broken-by: #4430