### PR TITLE
RFC: utils: fold utils into a monobinary

### DIFF
--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -1,29 +1,21 @@
-foreach(P create edit remote show)
-    add_executable(${TR_NAME}-${P})
+add_executable(${TR_NAME}-new)
 
-    target_sources(${TR_NAME}-${P}
+    target_sources(${TR_NAME}-new
         PRIVATE
-            ${P}.cc)
+	    main.c
+            create.cc
+            edit.cc
+            remote.cc
+            show.cc)
 
-    target_link_libraries(${TR_NAME}-${P}
+    target_link_libraries(${TR_NAME}-new
         PRIVATE
             ${TR_NAME}
             CURL::libcurl
             fmt::fmt-header-only
             libevent::event)
 
-    tr_win32_app_info(${TR_NAME}-${P}
-        "Transmission Utility ('${P}')"
-        "${TR_NAME}-${P}"
-        "${TR_NAME}-${P}.exe")
-
     install(
-        TARGETS ${TR_NAME}-${P}
+        TARGETS ${TR_NAME}-new
         DESTINATION ${CMAKE_INSTALL_BINDIR})
 
-    if(INSTALL_DOC)
-        install(
-            FILES ${TR_NAME}-${P}.1
-            DESTINATION ${CMAKE_INSTALL_MANDIR}/man1)
-    endif()
-endforeach()

--- a/utils/create.cc
+++ b/utils/create.cc
@@ -30,6 +30,8 @@
 #include <libtransmission/values.h>
 #include <libtransmission/version.h>
 
+#include <utils/tools.h>
+
 using namespace std::literals;
 
 using namespace libtransmission::Values;
@@ -37,8 +39,8 @@ using namespace libtransmission::Values;
 namespace
 {
 
-char constexpr MyName[] = "transmission-create";
-char constexpr Usage[] = "Usage: transmission-create [options] <file|directory>";
+char constexpr MyName[] = "transmission create";
+char constexpr Usage[] = "Usage: transmission create [options] <file|directory>";
 
 uint32_t constexpr KiB = 1024;
 
@@ -135,7 +137,8 @@ int parseCommandLine(app_options& options, int argc, char const* const* argv)
 }
 } // namespace
 
-int tr_main(int argc, char* argv[])
+static
+int do_tr_create(int argc, char* argv[])
 {
     tr_locale_set_global("");
 
@@ -295,3 +298,8 @@ int tr_main(int argc, char* argv[])
     fmt::print("done!\n");
     return EXIT_SUCCESS;
 }
+
+struct tr_cmd tr_create = {
+	.name = "create",
+	.cmd = do_tr_create,
+};

--- a/utils/edit.cc
+++ b/utils/edit.cc
@@ -20,6 +20,8 @@
 #include <libtransmission/variant.h>
 #include <libtransmission/version.h>
 
+#include <utils/tools.h>
+
 namespace
 {
 char constexpr MyName[] = "transmission-edit";
@@ -323,7 +325,8 @@ bool setSource(tr_variant* metainfo, char const* source_value)
 }
 } // namespace
 
-int tr_main(int argc, char* argv[])
+static
+int do_tr_edit(int argc, char* argv[])
 {
     tr_locale_set_global("");
 
@@ -405,3 +408,8 @@ int tr_main(int argc, char* argv[])
 
     return EXIT_SUCCESS;
 }
+
+struct tr_cmd tr_edit = {
+	.name = "edit",
+	.cmd = do_tr_edit,
+};

--- a/utils/main.c
+++ b/utils/main.c
@@ -1,0 +1,27 @@
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <utils/tools.h>
+
+
+#define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
+
+int main(int argc, char* argv[])
+{
+	struct tr_cmd cmds[] = {
+		tr_create,
+		tr_edit,
+		tr_remote,
+		tr_show,
+	};
+	size_t i;
+
+	for (i = 0; i < ARRAY_SIZE(cmds); i++) {
+		if (strcmp(argv[1], cmds[i].name) == 0)
+			return cmds[i].cmd(argc - 1, ++argv);
+	}
+
+	return -1;
+}

--- a/utils/remote.cc
+++ b/utils/remote.cc
@@ -40,6 +40,8 @@
 #include <libtransmission/variant.h>
 #include <libtransmission/version.h>
 
+#include <utils/tools.h>
+
 using namespace std::literals;
 
 using namespace libtransmission::Values;
@@ -3416,7 +3418,8 @@ void get_host_and_port_and_rpc_url(
 }
 } // namespace
 
-int tr_main(int argc, char* argv[])
+static
+int do_tr_remote(int argc, char* argv[])
 {
     auto const init_mgr = tr_lib_init();
 
@@ -3447,3 +3450,8 @@ int tr_main(int argc, char* argv[])
 
     return process_args(rpcurl.c_str(), argc, (char const* const*)argv, config);
 }
+
+struct tr_cmd tr_remote = {
+	.name = "remote",
+	.cmd = do_tr_remote,
+};

--- a/utils/show.cc
+++ b/utils/show.cc
@@ -36,6 +36,8 @@
 #include <libtransmission/web.h>
 #include <libtransmission/web-utils.h>
 
+#include <utils/tools.h>
+
 using namespace std::literals;
 using namespace libtransmission::Values;
 
@@ -401,7 +403,8 @@ void doScrape(tr_torrent_metainfo const& metainfo)
 
 } // namespace
 
-int tr_main(int argc, char* argv[])
+static
+int do_tr_show(int argc, char* argv[])
 {
     auto const init_mgr = tr_lib_init();
 
@@ -472,3 +475,8 @@ int tr_main(int argc, char* argv[])
     putc('\n', stdout);
     return EXIT_SUCCESS;
 }
+
+struct tr_cmd tr_show = {
+	.name = "show",
+	.cmd = do_tr_show,
+};

--- a/utils/tools.h
+++ b/utils/tools.h
@@ -1,0 +1,9 @@
+struct tr_cmd {
+	const char *name;
+	int (*cmd)(int argc, char *argv[]);
+};
+
+extern struct tr_cmd tr_create;
+extern struct tr_cmd tr_edit;
+extern struct tr_cmd tr_remote;
+extern struct tr_cmd tr_show;


### PR DESCRIPTION
Currently the four utils are nearly identical. Fold them into a mono-binary so that distributions and end users can save some space.

This is became more prominent since the C++ rewrite, which nearly tripled the overall size. For example in Arch we saw ~0.5M to ~1.4M change.

The change will be more beneficial to size constrained devices running OpenWrt. From a quick check:
 - transmission-cli carries 1.2M of binaries
 - transmission-remote - 260K

With this change, these two could become a single transmission-foo worth approximately 0.9M.

---

NOTES: 
 - the `cli` and `daemon` are explicitly left as-is, since each of those is larger than all the utils combined, they are often split off as sub packages, in part due to the extra dependencies
 - the PR is opened as request for comments, enough to demonstrate the changes required and for people can check the numbers on their systems.

If the community is onboard with the idea, I will respin the lot fixing the glaring issues and adding `transmission-create` compat wrappers. I'm thinking one-liner shell scripts for *nix ... not sure about Win32 though - any suggestions?
