### PR TITLE
Clarify that torrent ids are not stable

### DIFF
--- a/docs/rpc-spec.md
+++ b/docs/rpc-spec.md
@@ -129,6 +129,9 @@ All torrents are used if the `ids` argument is omitted.
 2. a list of torrent id numbers, SHA1 hash strings, or both
 3. a string, `recently-active`, for recently-active torrents
 
+Note that integer torrent ids are not stable across Transmission daemon
+restarts. Use torrent hashes if you need stable ids.
+
 Response arguments: none
 
 ### 3.2 Torrent mutator: `torrent-set`


### PR DESCRIPTION
Transmission renumbers torrents on restart. This may catch RPC clients off-guard if the daemon happens to restart between two related RPCs.