### PR TITLE
refactor: use evhttp public accessors in rpc server

### DIFF
--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -223,9 +223,10 @@ void send_simple_response(struct evhttp_request* req, int code, char const* text
 [[nodiscard]] evbuffer* make_response(struct evhttp_request* req, tr_rpc_server const* server, std::string_view content)
 {
     auto* const out = evbuffer_new();
+    auto const* const input_headers = evhttp_request_get_input_headers(req);
+    auto* const output_headers = evhttp_request_get_output_headers(req);
 
-    char const* key = "Accept-Encoding";
-    char const* encoding = evhttp_find_header(req->input_headers, key);
+    char const* encoding = evhttp_find_header(input_headers, "Accept-Encoding");
 
     if (bool const do_compress = encoding != nullptr && tr_strv_contains(encoding, "gzip"sv); !do_compress)
     {
@@ -247,7 +248,7 @@ void send_simple_response(struct evhttp_request* req, int code, char const* text
         if (0 < compressed_len && compressed_len < std::size(content))
         {
             iov.iov_len = compressed_len;
-            evhttp_add_header(req->output_headers, "Content-Encoding", "gzip");
+            evhttp_add_header(output_headers, "Content-Encoding", "gzip");
         }
         else
         {

--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -402,7 +402,7 @@ bool isIPAddressWithOptionalPort(char const* host)
     return evutil_parse_sockaddr_port(host, reinterpret_cast<sockaddr*>(&address), &address_len) != -1;
 }
 
-bool isHostnameAllowed(tr_rpc_server const* server, evhttp_request const* req)
+bool isHostnameAllowed(tr_rpc_server const* server, evhttp_request* const req)
 {
     /* If password auth is enabled, any hostname is permitted. */
     if (server->is_password_enabled())
@@ -416,7 +416,7 @@ bool isHostnameAllowed(tr_rpc_server const* server, evhttp_request const* req)
         return true;
     }
 
-    char const* const host = evhttp_find_header(req->input_headers, "Host");
+    auto const* const host = evhttp_request_get_host(req);
 
     /* No host header, invalid request. */
     if (host == nullptr)
@@ -431,10 +431,10 @@ bool isHostnameAllowed(tr_rpc_server const* server, evhttp_request const* req)
     }
 
     /* Host header might include the port. */
-    auto const hostname = std::string(host, strcspn(host, ":"));
+    auto const hostname = std::string_view{ host, strcspn(host, ":") };
 
     /* localhost is always acceptable. */
-    if (hostname == "localhost" || hostname == "localhost.")
+    if (hostname == "localhost"sv || hostname == "localhost."sv)
     {
         return true;
     }

--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -359,8 +359,9 @@ void handle_rpc_from_json(struct evhttp_request* req, tr_rpc_server* server, std
             *otop,
             [req, server](tr_session* /*session*/, tr_variant&& content)
             {
+                auto* const output_headers = evhttp_request_get_output_headers(req);
                 auto* const response = make_response(req, server, tr_variant_serde::json().compact().to_string(content));
-                evhttp_add_header(req->output_headers, "Content-Type", "application/json; charset=UTF-8");
+                evhttp_add_header(output_headers, "Content-Type", "application/json; charset=UTF-8");
                 evhttp_send_reply(req, HTTP_OK, "OK", response);
                 evbuffer_free(response);
             });

--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -555,7 +555,7 @@ void handle_request(struct evhttp_request* req, void* arg)
     }
     else if (!isHostnameAllowed(server, req))
     {
-        char const* const tmp =
+        static auto constexpr Body =
             "<p>Transmission received your request, but the hostname was unrecognized.</p>"
             "<p>To fix this, choose one of the following options:"
             "<ul>"
@@ -568,13 +568,13 @@ void handle_request(struct evhttp_request* req, void* arg)
             "attacks.</p>";
         tr_logAddWarn(
             fmt::format(fmt::runtime(_("Rejected request from {host} (Host not whitelisted)")), fmt::arg("host", remote_host)));
-        send_simple_response(req, 421, tmp);
+        send_simple_response(req, 421, Body);
     }
 #ifdef REQUIRE_SESSION_ID
     else if (!test_session_id(server, req))
     {
         auto const session_id = std::string{ server->session->sessionId() };
-        auto const tmp = fmt::format(
+        auto const body = fmt::format(
             "<p>Your request had an invalid session-id header.</p>"
             "<p>To fix this, follow these steps:"
             "<ol><li> When reading a response, get its X-Transmission-Session-Id header and remember it"
@@ -589,7 +589,7 @@ void handle_request(struct evhttp_request* req, void* arg)
             session_id);
         evhttp_add_header(output_headers, TR_RPC_SESSION_ID_HEADER, session_id.c_str());
         evhttp_add_header(output_headers, "Access-Control-Expose-Headers", TR_RPC_SESSION_ID_HEADER);
-        send_simple_response(req, 409, tmp.c_str());
+        send_simple_response(req, 409, body.c_str());
     }
 #endif
     else if (tr_strv_starts_with(location, "rpc"sv))
@@ -601,7 +601,7 @@ void handle_request(struct evhttp_request* req, void* arg)
         tr_logAddWarn(fmt::format(
             fmt::runtime(_("Unknown URI from {host}: '{uri}'")),
             fmt::arg("host", remote_host),
-            fmt::arg("uri", uri)));
+            fmt::arg("uri", uri_sv)));
         send_simple_response(req, HTTP_NOTFOUND, uri);
     }
 }

--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -443,9 +443,10 @@ bool isHostnameAllowed(tr_rpc_server const* server, evhttp_request* const req)
     return std::any_of(std::begin(src), std::end(src), [&hostname](auto const& str) { return tr_wildmat(hostname, str); });
 }
 
-bool test_session_id(tr_rpc_server const* server, evhttp_request const* req)
+bool test_session_id(tr_rpc_server const* server, evhttp_request* const req)
 {
-    char const* const session_id = evhttp_find_header(req->input_headers, TR_RPC_SESSION_ID_HEADER);
+    auto const* const input_headers = evhttp_request_get_input_headers(req);
+    char const* const session_id = evhttp_find_header(input_headers, TR_RPC_SESSION_ID_HEADER);
     return session_id != nullptr && server->session->sessionId() == session_id;
 }
 

--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -370,10 +370,11 @@ void handle_rpc_from_json(struct evhttp_request* req, tr_rpc_server* server, std
 
 void handle_rpc(struct evhttp_request* req, tr_rpc_server* server)
 {
-    if (req->type == EVHTTP_REQ_POST)
+    if (auto const cmd = evhttp_request_get_command(req); cmd == EVHTTP_REQ_POST)
     {
-        auto json = std::string_view{ reinterpret_cast<char const*>(evbuffer_pullup(req->input_buffer, -1)),
-                                      evbuffer_get_length(req->input_buffer) };
+        auto* const input_buffer = evhttp_request_get_input_buffer(req);
+        auto json = std::string_view{ reinterpret_cast<char const*>(evbuffer_pullup(input_buffer, -1)),
+                                      evbuffer_get_length(input_buffer) };
         handle_rpc_from_json(req, server, json);
         return;
     }


### PR DESCRIPTION
Use evhttp public accessors instead of private implementation details in rpc server code.