### PR TITLE
fix: Use non-lib64 systemd system unit dir path

### DIFF
--- a/daemon/CMakeLists.txt
+++ b/daemon/CMakeLists.txt
@@ -56,6 +56,6 @@ foreach(P daemon)
     if (WITH_SYSTEMD)
         install(
             FILES ${TR_NAME}-${P}.service
-            DESTINATION ${CMAKE_INSTALL_LIBDIR}/systemd/system)
+            DESTINATION lib/systemd/system)
     endif()
 endforeach()


### PR DESCRIPTION
This is a common path across Linux distros.

Checked distros:
* Arch Linux
* Fedora
* Gentoo
* openSUSE
* Ubuntu