### PR TITLE
Include libcurl version in User-Agent

### DIFF
--- a/libtransmission/web.cc
+++ b/libtransmission/web.cc
@@ -194,8 +194,10 @@ public:
 
         if (auto const& ua = mediator.userAgent(); ua)
         {
-            this->user_agent = *ua;
+            this->user_agent = std::string(*ua) + " ";
         }
+        this->user_agent += "libcurl/";
+        this->user_agent += curl_version_info(CURLVERSION_NOW)->version;
 
         auto const lock = std::unique_lock{ tasks_mutex_ };
         curl_thread = std::make_unique<std::thread>(&Impl::curlThreadFunc, this);


### PR DESCRIPTION
Transmission has a history of being badly affected by issues in libcurl, see notably #1563 and #7035.

For this reason it seems prudent for Transmission to advertise its libcurl version to trackers, so that they can react accordingly in case more libcurl issues arise in the future. Transmission does advertise its own version number to trackers, but that is not enough to deduce the libcurl version because a given Transmission version can be linked against a variety of libcurl versions.

For example, if trackers knew what libcurl version a particular client was using, they could have banned libcurl 8.9.1 in response to #7035. Instead, they ended up in a tricky situation that left them no choice but to ban a Transmission version as a poor man's proxy for the libcurl version.

Before:

```
User-Agent: Transmission/4.1.0-dev
```

After:

```
User-Agent: Transmission/4.1.0-dev libcurl/8.9.1
```