### PR TITLE
fix: clear tracker error if tracker is removed

### DIFF
--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -2079,7 +2079,7 @@ void tr_torrent::on_announce_list_changed()
     if (auto const& error_url = error_.announce_url(); !std::empty(error_url))
     {
         auto const& ann = metainfo().announce_list();
-        if (std::any_of(
+        if (std::none_of(
                 std::begin(ann),
                 std::end(ann),
                 [error_url](auto const& tracker) { return tracker.announce == error_url; }))


### PR DESCRIPTION
Regression from #2308.

The code is supposed to clear the torrent's error state if the error was from a tracker that was just removed. But now the error is cleared if the tracker was not removed.

Notes: Fixed a `4.0.0` bug where the tracker error is not cleared when the tracker is removed from the torrent.