### PR TITLE
fix: update torrent progress when verifying partially completed pieces

### DIFF
--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1699,9 +1699,7 @@ void tr_torrent::VerifyMediator::on_verify_started()
 
 void tr_torrent::VerifyMediator::on_piece_checked(tr_piece_index_t const piece, bool const has_piece)
 {
-    auto const had_piece = tor_->has_piece(piece);
-
-    if (!has_piece || !had_piece)
+    if (auto const had_piece = tor_->has_piece(piece); !has_piece || !had_piece)
     {
         tor_->set_has_piece(piece, has_piece);
         tor_->set_dirty();

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1701,7 +1701,7 @@ void tr_torrent::VerifyMediator::on_piece_checked(tr_piece_index_t const piece, 
 {
     auto const had_piece = tor_->has_piece(piece);
 
-    if (has_piece != had_piece)
+    if (!has_piece || !had_piece)
     {
         tor_->set_has_piece(piece, has_piece);
         tor_->set_dirty();


### PR DESCRIPTION
Fixes #6994.

If a piece is found to be incomplete after verifying, Transmission need to assume that it needs to be downloaded from scratch. This is because the smallest unit of data when verifying a torrent is a piece, and so Transmission cannot tell apart a piece that is not downloaded at all and a piece that is partially downloaded.

The current code fails to do that. It does not reset the piece's progress if the piece was incomplete before verifying and stays incomplete after verifying. So if a piece that was thought to be partially completed is in fact not downloaded at all, the current code will fail to recognise that and wrongly assume it has a part of the piece even after verifying the torrent.

Notes: Fixed a bug where torrent progress is not properly updated after verifying.