### PR TITLE
remove redundant send_ltep_handshake() and send_ut_pex()

### DIFF
--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -908,12 +908,6 @@ void tr_peerMsgsImpl::parse_ltep(MessageReader& payload)
     {
         logtrace(this, "got ltep handshake");
         parse_ltep_handshake(payload);
-
-        if (io_->supports_ltep())
-        {
-            send_ltep_handshake();
-            send_ut_pex();
-        }
     }
     else if (ltep_msgid == UT_PEX_ID)
     {

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -922,7 +922,7 @@ void tr_peerMsgsImpl::parse_ltep(MessageReader& payload)
     }
     else if (ltep_msgid == UT_PEX_ID)
     {
-        if (!tor_->is_public())
+        if (!tor_.is_public())
         {
             logwarn(this, "rejecting ut pex, torrent is private");
             return;
@@ -934,7 +934,7 @@ void tr_peerMsgsImpl::parse_ltep(MessageReader& payload)
     }
     else if (ltep_msgid == UT_METADATA_ID)
     {
-        if (!tor_->is_public())
+        if (!tor_.is_public())
         {
             logwarn(this, "rejecting ut metadata, torrent is private");
             return;

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -310,6 +310,7 @@ public:
     {
         if (tor_.allows_pex())
         {
+            send_ut_pex();
             pex_timer_ = session->timerMaker().create([this]() { send_ut_pex(); });
             pex_timer_->start_repeating(SendPexInterval);
         }


### PR DESCRIPTION
Seems to be a legacy hangover. Both of these are done in `tr_peerMsgsImpl()` which always happens prior to receiving any BT messages. Also, this respects the timer for ut_pex exchange created at initialization of `tr_peerMsgsImpl` rather than forcing off-timer, which I presume is the intention

