### PR TITLE
feat: disconnect blocklisted peers on blocklist update

### DIFF
--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -1176,7 +1176,7 @@ private:
                 if (peer->peer_info->is_blocklisted(blocklists_))
                 {
                     peer->disconnect_soon();
-                    tr_logAddDebug(fmt::format("Peer {} blocked in blocklists update", peer->display_name()));
+                    tr_logAddDebugTor(tor, fmt::format("Peer {} blocked in blocklists update", peer->display_name()));
                 }
             }
         }

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -1176,6 +1176,7 @@ private:
                 if (peer->peer_info->is_blocklisted(blocklists_))
                 {
                     peer->disconnect_soon();
+                    tr_logAddDebug(fmt::format("Peer {} blocked in blocklists update", peer->display_name()));
                 }
             }
         }

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -1173,6 +1173,10 @@ private:
             for (auto* const peer : tor->swarm->peers)
             {
                 peer->peer_info->set_blocklisted_dirty();
+                if (peer->peer_info->is_blocklisted(blocklists_))
+                {
+                    peer->disconnect_soon();
+                }
             }
         }
     }


### PR DESCRIPTION
Mark peer to be disconnected upon blocklist update. Tested on my torrent, seems to be working.

I am not familiar with transmission code or cpp. Hope the fix does not cause any problems.

Notes: Disconnect blocklisted peers immediately upon blocklist update.

Fix #732 .