### PR TITLE
Show location for each peer

### DIFF
--- a/gtk/DetailsDialog.cc
+++ b/gtk/DetailsDialog.cc
@@ -1223,10 +1223,13 @@ void initPeerRow(
     MMDB_s mmdb;
     MMDB_open("/path/to/dbip-country-lite-2024-10.mmdb", MMDB_MODE_MMAP, &mmdb);
     int gai_error, mmdb_error;
-    MMDB_lookup_result_s result = MMDB_lookup_string(&mmdb, "1.1.1.1", &gai_error, &mmdb_error);
+    MMDB_lookup_result_s result = MMDB_lookup_string(&mmdb, std::data(peer->addr), &gai_error, &mmdb_error);
     MMDB_entry_data_s entry_data;
-    MMDB_get_value(&result.entry, &entry_data, "names", "en", NULL);
-    (*iter)[peer_cols.country] = entry_data.utf8_string;
+    MMDB_get_value(&result.entry, &entry_data, "country", "names", "en", NULL);
+    char country[64];
+    strncpy(country, entry_data.utf8_string, entry_data.data_size);
+    country[entry_data.data_size] = 0;
+    (*iter)[peer_cols.country] = country;
     (*iter)[peer_cols.client] = client;
     (*iter)[peer_cols.encryption_stock_id] = peer->isEncrypted ? "lock" : "";
     (*iter)[peer_cols.key] = std::string(key);


### PR DESCRIPTION
I wish to make `Transmission` show the location of each peer in the `DetailsDialog`.

I found a free database from [db-ip](https://db-ip.com/db/download/ip-to-city-lite), and created a repo that automatically updates the required `mmdb` database (which changes monthly) and transforms an IP to a location string `"City, Country"`. This repo contains a `C` file that needs to be build by linking with `libmaxminddb`. I made `transmission-gtk` automatically check the folder `$HOME/.ip-to-location` for the executable. I have only tested it on `Linux`.

So, in order to make things work, install `transmission-gtk` from source as usual, install `libmaxminddb` using your system's package manager, and run
```
git clone https://github.com/gmou3/ip-to-location $HOME/.ip-to-location
cd $HOME/.ip-to-location
gcc ip_to_location.c -o ip_to_location -libmaxminddb
```
(Note that even if you skip these extra steps everything works normally with an empty `Location` column.)

Then run `transmission-gtk` and go to the `Properties` dialog of a torrent, under `Peers` to see the changes. The first time will take some time as it downloads the `mmdb` database file (`~50MB`).

I suppose there is a more proper integration method, using `cmake` and building `libmaxminddb` as a `third-party` submodule. I tried a bit but couldn't achieve that. There also exist issues of compatibility outside `Linux`.
Any help will be much appreciated!

Resolves #1512.