### PR TITLE
fix: use message id to check for pex and metadata xfer support

### DIFF
--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -585,7 +585,7 @@ private:
 
     // ---
 
-    [[nodiscard]] bool can_xfer_metadata() const noexcept
+    [[nodiscard]] constexpr bool can_xfer_metadata() const noexcept
     {
         return tor_.is_public() && ut_metadata_id_ != 0U;
     }
@@ -617,7 +617,7 @@ private:
     void parse_ut_pex(MessageReader& payload);
     void parse_ltep(MessageReader& payload);
 
-    [[nodiscard]] bool can_send_ut_pex() const noexcept
+    [[nodiscard]] constexpr bool can_send_ut_pex() const noexcept
     {
         // only send pex if both the torrent and peer support it
         return tor_.allows_pex() && ut_pex_id_ != 0U;

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -1238,13 +1238,15 @@ void tr_peerMsgsImpl::parse_ltep_handshake(MessageReader& payload)
 
     if (tr_variant* sub = nullptr; tr_variantDictFindDict(&*var, TR_KEY_m, &sub))
     {
-        if (auto ut_pex = int64_t{}; tr_variantDictFindInt(sub, TR_KEY_ut_pex, &ut_pex))
+        auto const tor_is_public = tor_.is_public();
+
+        if (auto ut_pex = int64_t{}; tor_is_public && tr_variantDictFindInt(sub, TR_KEY_ut_pex, &ut_pex))
         {
             ut_pex_id_ = static_cast<uint8_t>(ut_pex);
             logtrace(this, fmt::format("msgs->ut_pex is {:d}", ut_pex_id_));
         }
 
-        if (auto ut_metadata = int64_t{}; tr_variantDictFindInt(sub, TR_KEY_ut_metadata, &ut_metadata))
+        if (auto ut_metadata = int64_t{}; tor_is_public && tr_variantDictFindInt(sub, TR_KEY_ut_metadata, &ut_metadata))
         {
             ut_metadata_id_ = static_cast<uint8_t>(ut_metadata);
             logtrace(this, fmt::format("msgs->ut_metadata_id_ is {:d}", ut_metadata_id_));


### PR DESCRIPTION
Remove the Boolean class variables that indicate whether the peer supports PEX and metadata transfer, and rely only on whether the message ID is set to check for support.

This fixes a bug where Transmission would assume a peer supports PEX or metadata transfer after receiving these messages from the peer, then start to send messages to it despite not knowing the "extended message ID" of the peer for these message types.