### PR TITLE
fix: code should be clang-formatted

### DIFF
--- a/gtk/FilterBase.h
+++ b/gtk/FilterBase.h
@@ -20,13 +20,16 @@
 template<typename T>
 class FilterBase : public IF_GTKMM4(Gtk::Filter, Glib::Object)
 {
-public:
 #if !GTKMM_CHECK_VERSION(4, 0, 0)
-    enum class Change : uint8_t{
+public:
+    // clang-format off
+    enum class Change : uint8_t
+    {
         DIFFERENT,
         LESS_STRICT,
         MORE_STRICT,
     };
+    // clang-format on
 #endif
 
 public:

--- a/gtk/SorterBase.h
+++ b/gtk/SorterBase.h
@@ -18,14 +18,17 @@
 template<typename T>
 class SorterBase : public IF_GTKMM4(Gtk::Sorter, Glib::Object)
 {
-public:
 #if !GTKMM_CHECK_VERSION(4, 0, 0)
-    enum class Change : uint8_t{
+public:
+    // clang-format off
+    enum class Change : uint8_t
+    {
         DIFFERENT,
         INVERTED,
         LESS_STRICT,
         MORE_STRICT,
     };
+    // clang-format on
 #endif
 
 public:

--- a/qt/DetailsDialog.cc
+++ b/qt/DetailsDialog.cc
@@ -1549,8 +1549,10 @@ void DetailsDialog::initOptionsTab()
     cr->addLayout(ui_.peerConnectionsSectionLayout);
     cr->update();
 
-    void (QComboBox::*const combo_index_changed)(int) = &QComboBox::currentIndexChanged;
-    void (QSpinBox::*const spin_value_changed)(int) = &QSpinBox::valueChanged;
+    // clang-format off
+    void (QComboBox::* const combo_index_changed)(int) = &QComboBox::currentIndexChanged;
+    void (QSpinBox::* const spin_value_changed)(int) = &QSpinBox::valueChanged;
+    // clang-format on
     connect(ui_.bandwidthPriorityCombo, combo_index_changed, this, &DetailsDialog::onBandwidthPriorityChanged);
     connect(ui_.idleCombo, combo_index_changed, this, &DetailsDialog::onIdleModeChanged);
     connect(ui_.idleSpin, &QSpinBox::editingFinished, this, &DetailsDialog::onSpinBoxEditingFinished);


### PR DESCRIPTION
```
➜  ~ clang-format --version
clang-format version 19.1.2
```

I had to use clang-format macros to make it compatible both new (19) and old (17) clang-format.

Note that on macOS, brew will only let you install clang-format 19 or clang-format 11: the version 17 is not directly supported anymore.
```
➜  ~ brew search clang-format
==> Formulae
clang-format ✔      clang-format@11     clang-format@8
```