### PR TITLE
fix: clang-tidy-20 warnings

### DIFF
--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -258,19 +258,19 @@ struct tr_tracker
             return 20U;
 
         case 2:
-            return tr_rand_int(60U) + 60U * 5U;
+            return tr_rand_int(60U) + (60U * 5U);
 
         case 3:
-            return tr_rand_int(60U) + 60U * 15U;
+            return tr_rand_int(60U) + (60U * 15U);
 
         case 4:
-            return tr_rand_int(60U) + 60U * 30U;
+            return tr_rand_int(60U) + (60U * 30U);
 
         case 5:
-            return tr_rand_int(60U) + 60U * 60U;
+            return tr_rand_int(60U) + (60U * 60U);
 
         default:
-            return tr_rand_int(60U) + 60U * 120U;
+            return tr_rand_int(60U) + (60U * 120U);
         }
     }
 

--- a/libtransmission/bandwidth.cc
+++ b/libtransmission/bandwidth.cc
@@ -182,7 +182,7 @@ void tr_bandwidth::phase_one(std::vector<tr_peerIo*>& peers, tr_direction dir)
     tr_logAddTrace(fmt::format("{} peers to go round-robin for {}", peers.size(), dir == TR_UP ? "upload" : "download"));
 
     // Shuffle the peers so they all have equal chance to be first in line.
-    thread_local auto urbg = tr_urbg<size_t>{};
+    static thread_local auto urbg = tr_urbg<size_t>{};
     std::shuffle(std::begin(peers), std::end(peers), urbg);
 
     // Give each peer `Increment` bandwidth bytes to use. Repeat this

--- a/libtransmission/bitfield.cc
+++ b/libtransmission/bitfield.cc
@@ -292,7 +292,7 @@ void tr_bitfield::set_raw(uint8_t const* raw, size_t byte_count)
     // ensure any excess bits at the end of the array are set to '0'.
     if (byte_count == getBytesNeededSafe(bit_count_))
     {
-        auto const excess_bit_count = byte_count * 8 - bit_count_;
+        auto const excess_bit_count = (byte_count * 8) - bit_count_;
 
         TR_ASSERT(excess_bit_count <= 7);
 

--- a/libtransmission/crypto-utils.cc
+++ b/libtransmission/crypto-utils.cc
@@ -242,8 +242,8 @@ std::optional<tr_sha256_digest_t> tr_sha256_from_string(std::string_view hex)
 // fallback implementation in case the system crypto library's RNG fails
 void tr_rand_buffer_std(void* buffer, size_t length)
 {
-    thread_local auto gen = std::mt19937{ std::random_device{}() };
-    thread_local auto dist = std::uniform_int_distribution<unsigned long long>{};
+    static thread_local auto gen = std::mt19937{ std::random_device{}() };
+    static thread_local auto dist = std::uniform_int_distribution<unsigned long long>{};
 
     for (auto *walk = static_cast<uint8_t*>(buffer), *end = walk + length; walk < end;)
     {

--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -77,7 +77,7 @@ ReadState tr_handshake::read_yb(tr_peerIo* peer_io)
 
     /* now send these: HASH('req1', S), HASH('req2', SKEY) xor HASH('req3', S),
      * ENCRYPT(VC, crypto_provide, len(PadC), PadC, len(IA)), ENCRYPT(IA) */
-    static auto constexpr BufSize = std::tuple_size_v<tr_sha1_digest_t> * 2 + std::size(VC) + sizeof(crypto_provide_) +
+    static auto constexpr BufSize = (std::tuple_size_v<tr_sha1_digest_t> * 2U) + std::size(VC) + sizeof(crypto_provide_) +
         sizeof(pad_c_len_) + sizeof(ia_len_) + HandshakeSize;
     auto outbuf = libtransmission::StackBuffer<BufSize, std::byte>{};
 

--- a/libtransmission/peer-mgr-active-requests.cc
+++ b/libtransmission/peer-mgr-active-requests.cc
@@ -114,7 +114,7 @@ std::vector<tr_block_index_t> ActiveRequests::remove(tr_peer const* peer)
 
     for (auto const& [block, peers_at] : impl_->blocks_)
     {
-        if (peers_at.count(peer) != 0U)
+        if (peers_at.contains(peer))
         {
             removed.push_back(block);
         }
@@ -157,7 +157,7 @@ std::vector<tr_peer*> ActiveRequests::remove(tr_block_index_t block)
 bool ActiveRequests::has(tr_block_index_t block, tr_peer const* peer) const
 {
     auto const iter = impl_->blocks_.find(block);
-    return iter != std::end(impl_->blocks_) && (iter->second.count(peer) != 0U);
+    return iter != std::end(impl_->blocks_) && iter->second.contains(peer);
 }
 
 // count how many peers we're asking for `block`

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -2129,7 +2129,7 @@ auto constexpr MaxUploadIdleSecs = time_t{ 60 * 5 };
             peer_count / (float)relax_strictness_if_fewer_than_n;
         auto const lo = MinUploadIdleSecs;
         auto const hi = MaxUploadIdleSecs;
-        time_t const limit = hi - (hi - lo) * strictness;
+        time_t const limit = hi - ((hi - lo) * strictness);
 
         if (auto const idle_secs = info->idle_secs(now); idle_secs && *idle_secs > limit)
         {

--- a/libtransmission/peer-mse.cc
+++ b/libtransmission/peer-mse.cc
@@ -80,16 +80,11 @@ namespace tr_message_stream_encryption
 
 DH::key_bigend_t DH::publicKey() noexcept
 {
-    auto generate_public_key = [](DH::private_key_bigend_t const& private_key) noexcept
-    {
-        auto const private_key_wi = wi::import_bits<wi::private_key_t>(private_key);
-        auto const public_key_wi = math::wide_integer::powm(wi::generator, private_key_wi, wi::prime);
-        return wi::export_bits(public_key_wi);
-    };
-
     if (public_key_ == key_bigend_t{})
     {
-        public_key_ = generate_public_key(private_key_);
+        auto const private_key_wi = wi::import_bits<wi::private_key_t>(private_key_);
+        auto const public_key_wi = math::wide_integer::powm(wi::generator, private_key_wi, wi::prime);
+        public_key_ = wi::export_bits(public_key_wi);
     }
 
     return public_key_;

--- a/libtransmission/peer-mse.cc
+++ b/libtransmission/peer-mse.cc
@@ -78,18 +78,18 @@ namespace tr_message_stream_encryption
     return tr_rand_obj<DH::private_key_bigend_t>();
 }
 
-[[nodiscard]] auto generatePublicKey(DH::private_key_bigend_t const& private_key) noexcept
-{
-    auto const private_key_wi = wi::import_bits<wi::private_key_t>(private_key);
-    auto const public_key_wi = math::wide_integer::powm(wi::generator, private_key_wi, wi::prime);
-    return wi::export_bits(public_key_wi);
-}
-
 DH::key_bigend_t DH::publicKey() noexcept
 {
+    auto generate_public_key = [](DH::private_key_bigend_t const& private_key) noexcept
+    {
+        auto const private_key_wi = wi::import_bits<wi::private_key_t>(private_key);
+        auto const public_key_wi = math::wide_integer::powm(wi::generator, private_key_wi, wi::prime);
+        return wi::export_bits(public_key_wi);
+    };
+
     if (public_key_ == key_bigend_t{})
     {
-        public_key_ = generatePublicKey(private_key_);
+        public_key_ = generate_public_key(private_key_);
     }
 
     return public_key_;

--- a/libtransmission/session-alt-speeds.cc
+++ b/libtransmission/session-alt-speeds.cc
@@ -80,7 +80,7 @@ void tr_session_alt_speeds::set_active(bool active, ChangeReason reason, bool fo
 {
     auto const tm = fmt::localtime(time);
 
-    size_t minute_of_the_week = tm.tm_wday * MinutesPerDay + tm.tm_hour * MinutesPerHour + tm.tm_min;
+    size_t minute_of_the_week = (tm.tm_wday * MinutesPerDay) + (tm.tm_hour * MinutesPerHour) + tm.tm_min;
 
     if (minute_of_the_week >= MinutesPerWeek) /* leap minutes? */
     {

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -200,7 +200,7 @@ tr_peer_id_t tr_peerIdInit()
         total += val;
         *it++ = Pool[val];
     }
-    int const val = total % std::size(Pool) != 0 ? std::size(Pool) - total % std::size(Pool) : 0;
+    int const val = total % std::size(Pool) != 0 ? std::size(Pool) - (total % std::size(Pool)) : 0;
     *it = Pool[val];
 
     return peer_id;

--- a/libtransmission/torrent-ctor.cc
+++ b/libtransmission/torrent-ctor.cc
@@ -205,21 +205,6 @@ bool tr_ctorGetDownloadDir(tr_ctor const* const ctor, tr_ctorMode const mode, ch
     return false;
 }
 
-bool tr_ctorGetIncompleteDir(tr_ctor const* const ctor, char const** setme)
-{
-    if (auto const& val = ctor->incomplete_dir(); !std::empty(val))
-    {
-        if (setme != nullptr)
-        {
-            *setme = val.c_str();
-        }
-
-        return true;
-    }
-
-    return false;
-}
-
 tr_torrent_metainfo const* tr_ctorGetMetainfo(tr_ctor const* const ctor)
 {
     auto const& metainfo = ctor->metainfo();

--- a/libtransmission/torrent-ctor.cc
+++ b/libtransmission/torrent-ctor.cc
@@ -84,11 +84,6 @@ void tr_ctorFree(tr_ctor* ctor)
     delete ctor;
 }
 
-tr_session* tr_ctorGetSession(tr_ctor const* ctor)
-{
-    return ctor->session();
-}
-
 bool tr_ctorSetMetainfoFromFile(tr_ctor* const ctor, char const* const filename, tr_error* const error)
 {
     return ctor->set_metainfo_from_file(std::string_view{ filename != nullptr ? filename : "" }, error);


### PR DESCRIPTION
fix some clang-tidy-20 warnings in libtransmission.