### PR TITLE
fix: clang-tidy-20 warnings in transmission-qt

### DIFF
--- a/qt/FileTreeModel.cc
+++ b/qt/FileTreeModel.cc
@@ -516,7 +516,7 @@ void FileTreeModel::twiddlePriority(QModelIndexList const& indices)
 
     for (int i = TR_PRI_LOW; i <= TR_PRI_HIGH; ++i)
     {
-        if (priority_indices.count(i) != 0U)
+        if (priority_indices.contains(i))
         {
             setPriority(priority_indices[i], i);
         }

--- a/qt/FileTreeView.cc
+++ b/qt/FileTreeView.cc
@@ -125,7 +125,7 @@ void FileTreeView::resizeEvent(QResizeEvent* event)
         QString const header_text = model_->headerData(column, Qt::Horizontal).toString();
         int const header_width = Utils::measureHeaderItem(this->header(), header_text);
 
-        int const width = std::max(min_width, std::max(item_width, header_width));
+        int const width = std::max({ min_width, item_width, header_width });
         setColumnWidth(column, width);
 
         left -= width;

--- a/qt/PathButton.cc
+++ b/qt/PathButton.cc
@@ -85,8 +85,19 @@ void PathButton::paintEvent(QPaintEvent* /*event*/)
         text_width -= style()->pixelMetric(QStyle::PM_MenuButtonIndicator, &option, this);
     }
 
-    QFileInfo const path_info(path_);
-    option.text = path_.isEmpty() ? tr("(None)") : (path_info.fileName().isEmpty() ? path_ : path_info.fileName());
+    if (path_.isEmpty())
+    {
+        option.text = tr("(None)");
+    }
+    else if (auto const info = QFileInfo{ path_ }; !info.fileName().isEmpty())
+    {
+        option.text = info.fileName();
+    }
+    else
+    {
+        option.text = path_;
+    }
+
     option.text = fontMetrics().elidedText(option.text, Qt::ElideMiddle, text_width);
 
     painter.drawComplexControl(QStyle::CC_ToolButton, option);

--- a/qt/SqueezeLabel.cc
+++ b/qt/SqueezeLabel.cc
@@ -69,7 +69,8 @@ void SqueezeLabel::paintEvent(QPaintEvent* paint_event)
 
     if (hasFocus() && (textInteractionFlags() & (Qt::TextSelectableByKeyboard | Qt::TextSelectableByMouse)) != 0)
     {
-        return QLabel::paintEvent(paint_event);
+        QLabel::paintEvent(paint_event);
+        return;
     }
 
     auto painter = QPainter{ this };

--- a/qt/Torrent.h
+++ b/qt/Torrent.h
@@ -114,28 +114,13 @@ public:
     explicit TorrentHash(tr_sha1_digest_t const& data)
         : data_{ data }
     {
+        auto const hashstr = tr_sha1_to_string(data_);
+        data_str_ = QString::fromUtf8(std::data(hashstr), std::size(hashstr));
     }
 
-    explicit TorrentHash(char const* str)
+    explicit TorrentHash(std::string_view const str)
+        : TorrentHash{ tr_sha1_from_string(str).value_or(tr_sha1_digest_t{}) }
     {
-        if (auto const hash = tr_sha1_from_string(str != nullptr ? str : ""); hash)
-        {
-            data_ = *hash;
-
-            auto const tmpstr = tr_sha1_to_string(data_);
-            data_str_ = QString::fromUtf8(std::data(tmpstr), std::size(tmpstr));
-        }
-    }
-
-    explicit TorrentHash(QString const& str)
-    {
-        if (auto const hash = tr_sha1_from_string(str.toStdString()); hash)
-        {
-            data_ = *hash;
-
-            auto const tmpstr = tr_sha1_to_string(data_);
-            data_str_ = QString::fromUtf8(std::data(tmpstr), std::size(tmpstr));
-        }
     }
 
     [[nodiscard]] TR_CONSTEXPR20 auto operator==(TorrentHash const& that) const

--- a/qt/TorrentDelegate.cc
+++ b/qt/TorrentDelegate.cc
@@ -483,8 +483,8 @@ void TorrentDelegate::setProgressBarPercentDone(QStyleOptionViewItem const& opti
         progress_bar_style_.direction = option.direction;
         progress_bar_style_.progress = static_cast<int>(
             progress_bar_style_.minimum +
-            (is_magnet ? tor.metadataPercentDone() : tor.percentDone()) *
-                (progress_bar_style_.maximum - progress_bar_style_.minimum));
+            ((is_magnet ? tor.metadataPercentDone() : tor.percentDone()) *
+             (progress_bar_style_.maximum - progress_bar_style_.minimum)));
     }
 }
 

--- a/qt/TorrentDelegate.cc
+++ b/qt/TorrentDelegate.cc
@@ -419,8 +419,10 @@ QString TorrentDelegate::statusString(Torrent const& tor)
 QSize TorrentDelegate::sizeHint(QStyleOptionViewItem const& option, Torrent const& tor) const
 {
     auto const m = margin(*QApplication::style());
-    auto const layout = ItemLayout{ tor.name(),  progressString(tor), statusString(tor), QIcon{},
-                                    option.font, option.direction,    QPoint{ 0, 0 },    option.rect.width() - m.width() * 2 };
+    auto const layout = ItemLayout{
+        tor.name(),  progressString(tor), statusString(tor), QIcon{},
+        option.font, option.direction,    QPoint{ 0, 0 },    option.rect.width() - (m.width() * 2)
+    };
     return layout.size() + m * 2;
 }
 

--- a/qt/TorrentDelegateMin.cc
+++ b/qt/TorrentDelegateMin.cc
@@ -119,7 +119,7 @@ ItemLayout::ItemLayout(
     bar_style.progress = 100;
     bar_style.textVisible = true;
     QSize const bar_size(
-        bar_style.rect.width() * 2 - style->subElementRect(QStyle::SE_ProgressBarGroove, &bar_style).width(),
+        (bar_style.rect.width() * 2) - style->subElementRect(QStyle::SE_ProgressBarGroove, &bar_style).width(),
         bar_style.rect.height());
 
     QRect base_rect{ top_left,
@@ -153,7 +153,7 @@ QSize TorrentDelegateMin::sizeHint(QStyleOptionViewItem const& option, Torrent c
                                     option.font,
                                     option.direction,
                                     QPoint{},
-                                    option.rect.width() - m.width() * 2 };
+                                    option.rect.width() - (m.width() * 2) };
     return layout.size() + m * 2;
 }
 

--- a/qt/TrackerDelegate.cc
+++ b/qt/TrackerDelegate.cc
@@ -90,7 +90,11 @@ ItemLayout::ItemLayout(
 
 QSize TrackerDelegate::sizeHint(QStyleOptionViewItem const& option, TrackerInfo const& info) const
 {
-    ItemLayout const layout{ getText(info), true, option.direction, QPoint{ 0, 0 }, option.rect.width() - Margin.width() * 2 };
+    ItemLayout const layout{ getText(info),
+                             true,
+                             option.direction,
+                             QPoint{ 0, 0 },
+                             option.rect.width() - (Margin.width() * 2) };
     return layout.size() + Margin * 2;
 }
 

--- a/qt/VariantHelpers.cc
+++ b/qt/VariantHelpers.cc
@@ -40,7 +40,7 @@ bool change(Speed& setme, tr_variant const* value)
 bool change(TorrentHash& setme, tr_variant const* value)
 {
     auto const hash_string = getValue<std::string_view>(value);
-    return hash_string && change(setme, TorrentHash(hash_string->data()));
+    return hash_string && change(setme, TorrentHash{ *hash_string });
 }
 
 bool change(Peer& setme, tr_variant const* value)


### PR DESCRIPTION
Mostly small changes like adding parenthesis to make order-of-precedence explicit, but clang-tidy did find an unused `TorrentHash` construtor :+1: 