### PR TITLE
fix: use process umask for new files.

### DIFF
--- a/libtransmission/file-posix.cc
+++ b/libtransmission/file-posix.cc
@@ -598,8 +598,6 @@ tr_sys_file_t tr_sys_file_open(char const* path, int flags, int permissions, tr_
 
 tr_sys_file_t tr_sys_file_open_temp(char* path_template, tr_error* error)
 {
-    mode_t tmpmask = 0000;
-
     TR_ASSERT(path_template != nullptr);
 
     tr_sys_file_t const ret = mkstemp(path_template);
@@ -609,12 +607,6 @@ tr_sys_file_t tr_sys_file_open_temp(char* path_template, tr_error* error)
         error->set_from_errno(errno);
     }
 
-    else
-    {
-        tmpmask = umask(0);
-        fchmod(ret, 0666 - tmpmask);
-        umask(tmpmask);
-    }
     set_file_for_single_pass(ret);
 
     return ret;

--- a/libtransmission/file-posix.cc
+++ b/libtransmission/file-posix.cc
@@ -598,6 +598,8 @@ tr_sys_file_t tr_sys_file_open(char const* path, int flags, int permissions, tr_
 
 tr_sys_file_t tr_sys_file_open_temp(char* path_template, tr_error* error)
 {
+    mode_t tmpmask = 0000;
+
     TR_ASSERT(path_template != nullptr);
 
     tr_sys_file_t const ret = mkstemp(path_template);
@@ -607,6 +609,12 @@ tr_sys_file_t tr_sys_file_open_temp(char* path_template, tr_error* error)
         error->set_from_errno(errno);
     }
 
+    else
+    {
+        tmpmask = umask(0);
+        fchmod(ret, 0666 - tmpmask);
+        umask(tmpmask);
+    }
     set_file_for_single_pass(ret);
 
     return ret;

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -200,9 +200,9 @@ bool tr_file_save(std::string_view filename, std::string_view contents, tr_error
     // set file mode per settings umask()
     else
     {
-	mode_t val = umask(0);
-	fchmod(fd, 0666 - val);
-	::umask(val);
+        mode_t val = umask(0);
+        fchmod(fd, 0666 - val);
+        ::umask(val);
     }
 #endif
 

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -32,6 +32,7 @@
 #include <shellapi.h> /* CommandLineToArgv() */
 #else
 #include <arpa/inet.h>
+#include <sys/stat.h> /* umask() */
 #endif
 
 #define UTF_CPP_CPLUSPLUS 201703L
@@ -55,9 +56,6 @@
 #include "libtransmission/tr-strbuf.h"
 #include "libtransmission/utils.h"
 #include "libtransmission/values.h"
-#ifndef _WIN32
-#include <sys/stat.h> /* umask() */
-#endif
 
 using namespace std::literals;
 using namespace libtransmission::Values;
@@ -198,7 +196,6 @@ bool tr_file_save(std::string_view filename, std::string_view contents, tr_error
     }
 #ifndef _WIN32
     // set file mode per settings umask()
-    else
     {
         mode_t val = ::umask(0);
         fchmod(fd, 0666 - val);

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -55,6 +55,9 @@
 #include "libtransmission/tr-strbuf.h"
 #include "libtransmission/utils.h"
 #include "libtransmission/values.h"
+#ifndef _WIN32
+#include <sys/stat.h> /* umask() */
+#endif
 
 using namespace std::literals;
 using namespace libtransmission::Values;
@@ -193,6 +196,15 @@ bool tr_file_save(std::string_view filename, std::string_view contents, tr_error
     {
         return false;
     }
+#ifndef _WIN32
+    // set file mode per settings umask()
+    else
+    {
+	mode_t val = umask(0);
+	fchmod(fd, 0666 - val);
+	::umask(val);
+    }
+#endif
 
     // Save the contents. This might take >1 pass.
     auto ok = true;

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -200,7 +200,7 @@ bool tr_file_save(std::string_view filename, std::string_view contents, tr_error
     // set file mode per settings umask()
     else
     {
-        mode_t val = umask(0);
+        mode_t val = ::umask(0);
         fchmod(fd, 0666 - val);
         ::umask(val);
     }

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -197,7 +197,7 @@ bool tr_file_save(std::string_view filename, std::string_view contents, tr_error
 #ifndef _WIN32
     // set file mode per settings umask()
     {
-        mode_t val = ::umask(0);
+        auto const val = ::umask(0);
         fchmod(fd, 0666 - val);
         ::umask(val);
     }

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -198,8 +198,8 @@ bool tr_file_save(std::string_view filename, std::string_view contents, tr_error
     // set file mode per settings umask()
     {
         auto const val = ::umask(0);
-        fchmod(fd, 0666 - val);
         ::umask(val);
+        fchmod(fd, 0666 & ~val);
     }
 #endif
 

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -41,8 +41,6 @@
 
 #include <fmt/core.h>
 
-#include <sys/stat.h>
-
 #include <fast_float/fast_float.h>
 #include <wildmat.h>
 
@@ -207,14 +205,6 @@ bool tr_file_save(std::string_view filename, std::string_view contents, tr_error
             break;
         }
         contents.remove_prefix(n_written);
-    }
-
-    std::string_view daemon_config = ".config/transmission-daemon/";
-    size_t found = filename.find(daemon_config);
-
-    if (found != std::string_view::npos)
-    {
-	fchmod(fd, 0640);
     }
 
     // If we saved it to disk successfully, move it from '.tmp' to the correct filename

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -41,6 +41,8 @@
 
 #include <fmt/core.h>
 
+#include <sys/stat.h>
+
 #include <fast_float/fast_float.h>
 #include <wildmat.h>
 
@@ -205,6 +207,14 @@ bool tr_file_save(std::string_view filename, std::string_view contents, tr_error
             break;
         }
         contents.remove_prefix(n_written);
+    }
+
+    std::string_view daemon_config = ".config/transmission-daemon/";
+    size_t found = filename.find(daemon_config);
+
+    if (found != std::string_view::npos)
+    {
+	fchmod(fd, 0640);
     }
 
     // If we saved it to disk successfully, move it from '.tmp' to the correct filename


### PR DESCRIPTION
Fix #7006

Notes: New files are assigned a file mode per the process _umask_ defined in `settings.json`.