### PR TITLE
refactor: remove unused TR_SYS_FILE_APPEND

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -771,7 +771,7 @@ endif()
 
 if(RUN_CLANG_TIDY)
     message(STATUS "Looking for clang-tidy")
-    find_program(CLANG_TIDY clang-tidy)
+    find_program(CLANG_TIDY clang-tidy-20)
     if(CLANG_TIDY STREQUAL "CLANG_TIDY-NOTFOUND")
         message(STATUS "Looking for clang-tidy - not found")
     else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -771,7 +771,7 @@ endif()
 
 if(RUN_CLANG_TIDY)
     message(STATUS "Looking for clang-tidy")
-    find_program(CLANG_TIDY clang-tidy-20)
+    find_program(CLANG_TIDY clang-tidy)
     if(CLANG_TIDY STREQUAL "CLANG_TIDY-NOTFOUND")
         message(STATUS "Looking for clang-tidy - not found")
     else()

--- a/libtransmission/file-posix.cc
+++ b/libtransmission/file-posix.cc
@@ -560,7 +560,7 @@ tr_sys_file_t tr_sys_file_open(char const* path, int flags, int permissions, tr_
         int native_value;
     };
 
-    auto constexpr NativeMap = std::array<native_map_item, 8>{
+    auto constexpr NativeMap = std::array<native_map_item, 7U>{
         { { TR_SYS_FILE_READ | TR_SYS_FILE_WRITE, TR_SYS_FILE_READ | TR_SYS_FILE_WRITE, O_RDWR },
           { TR_SYS_FILE_READ | TR_SYS_FILE_WRITE, TR_SYS_FILE_READ, O_RDONLY },
           { TR_SYS_FILE_READ | TR_SYS_FILE_WRITE, TR_SYS_FILE_WRITE, O_WRONLY },

--- a/libtransmission/file-posix.cc
+++ b/libtransmission/file-posix.cc
@@ -565,7 +565,6 @@ tr_sys_file_t tr_sys_file_open(char const* path, int flags, int permissions, tr_
           { TR_SYS_FILE_READ | TR_SYS_FILE_WRITE, TR_SYS_FILE_READ, O_RDONLY },
           { TR_SYS_FILE_READ | TR_SYS_FILE_WRITE, TR_SYS_FILE_WRITE, O_WRONLY },
           { TR_SYS_FILE_CREATE, TR_SYS_FILE_CREATE, O_CREAT },
-          { TR_SYS_FILE_APPEND, TR_SYS_FILE_APPEND, O_APPEND },
           { TR_SYS_FILE_TRUNCATE, TR_SYS_FILE_TRUNCATE, O_TRUNC },
           { TR_SYS_FILE_SEQUENTIAL, TR_SYS_FILE_SEQUENTIAL, O_SEQUENTIAL } }
     };

--- a/libtransmission/file-win32.cc
+++ b/libtransmission/file-win32.cc
@@ -825,11 +825,6 @@ tr_sys_file_t tr_sys_file_open(char const* path, int flags, int /*permissions*/,
     auto ret = open_file(path, native_access, native_disposition, native_flags, error);
     auto success = ret != TR_BAD_SYS_FILE;
 
-    if (success && (flags & TR_SYS_FILE_APPEND) != 0)
-    {
-        success = SetFilePointer(ret, 0, nullptr, FILE_END) != INVALID_SET_FILE_POINTER;
-    }
-
     if (!success)
     {
         set_system_error(error, GetLastError());

--- a/libtransmission/file.h
+++ b/libtransmission/file.h
@@ -50,9 +50,8 @@ enum tr_sys_file_open_flags_t
     TR_SYS_FILE_READ = (1 << 0),
     TR_SYS_FILE_WRITE = (1 << 1),
     TR_SYS_FILE_CREATE = (1 << 2),
-    TR_SYS_FILE_APPEND = (1 << 3),
-    TR_SYS_FILE_TRUNCATE = (1 << 4),
-    TR_SYS_FILE_SEQUENTIAL = (1 << 5)
+    TR_SYS_FILE_TRUNCATE = (1 << 3),
+    TR_SYS_FILE_SEQUENTIAL = (1 << 4)
 };
 
 enum tr_sys_file_lock_flags_t

--- a/tests/libtransmission/file-test.cc
+++ b/tests/libtransmission/file-test.cc
@@ -1129,7 +1129,7 @@ TEST_F(FileTest, fileOpen)
     createFileWithContents(path1, "test");
 
     /* File gets truncated */
-    info = tr_sys_path_get_info(path1, TR_SYS_PATH_NO_FOLLOW);
+    auto info = tr_sys_path_get_info(path1, TR_SYS_PATH_NO_FOLLOW);
     EXPECT_TRUE(info.has_value());
     assert(info.has_value());
     EXPECT_EQ(5U, info->size);

--- a/tests/libtransmission/file-test.cc
+++ b/tests/libtransmission/file-test.cc
@@ -1132,7 +1132,7 @@ TEST_F(FileTest, fileOpen)
     auto info = tr_sys_path_get_info(path1, TR_SYS_PATH_NO_FOLLOW);
     EXPECT_TRUE(info.has_value());
     assert(info.has_value());
-    EXPECT_EQ(5U, info->size);
+    EXPECT_EQ(4U, info->size);
     fd = tr_sys_file_open(path1, TR_SYS_FILE_WRITE | TR_SYS_FILE_TRUNCATE, 0600, &error);
     EXPECT_NE(TR_BAD_SYS_FILE, fd);
     EXPECT_FALSE(error) << error;

--- a/tests/libtransmission/file-test.cc
+++ b/tests/libtransmission/file-test.cc
@@ -1128,17 +1128,6 @@ TEST_F(FileTest, fileOpen)
     tr_sys_path_remove(path1);
     createFileWithContents(path1, "test");
 
-    /* Pointer is at the end of file */
-    auto info = tr_sys_path_get_info(path1, TR_SYS_PATH_NO_FOLLOW);
-    EXPECT_TRUE(info.has_value());
-    assert(info.has_value());
-    EXPECT_EQ(4U, info->size);
-    fd = tr_sys_file_open(path1, TR_SYS_FILE_WRITE | TR_SYS_FILE_APPEND, 0600, &error);
-    EXPECT_NE(TR_BAD_SYS_FILE, fd);
-    EXPECT_FALSE(error) << error;
-    tr_sys_file_write(fd, "s", 1, nullptr); /* On *NIX, pointer is positioned on each write but not initially */
-    tr_sys_file_close(fd);
-
     /* File gets truncated */
     info = tr_sys_path_get_info(path1, TR_SYS_PATH_NO_FOLLOW);
     EXPECT_TRUE(info.has_value());


### PR DESCRIPTION
Title says it all: we don't use `TR_SYS_FILE_APPEND`, so this PR removes its code.

This PR does start from the assumption that unused code should be removed -- if we need it again at some point, it will still be in the repo history and can be restored. But until we need it, we shouldn't build it :man_shrugging: 