### PR TITLE
refactor: remove unused TR_SYS_FILE_LOCK_UN

### DIFF
--- a/libtransmission/file-posix.cc
+++ b/libtransmission/file-posix.cc
@@ -914,15 +914,14 @@ bool tr_sys_file_preallocate(tr_sys_file_t handle, uint64_t size, int flags, tr_
 bool tr_sys_file_lock([[maybe_unused]] tr_sys_file_t handle, [[maybe_unused]] int operation, tr_error* error)
 {
     TR_ASSERT(handle != TR_BAD_SYS_FILE);
-    TR_ASSERT((operation & ~(TR_SYS_FILE_LOCK_SH | TR_SYS_FILE_LOCK_EX | TR_SYS_FILE_LOCK_NB | TR_SYS_FILE_LOCK_UN)) == 0);
-    TR_ASSERT(
-        !!(operation & TR_SYS_FILE_LOCK_SH) + !!(operation & TR_SYS_FILE_LOCK_EX) + !!(operation & TR_SYS_FILE_LOCK_UN) == 1);
+    TR_ASSERT((operation & ~(TR_SYS_FILE_LOCK_SH | TR_SYS_FILE_LOCK_EX | TR_SYS_FILE_LOCK_NB)) == 0);
+    TR_ASSERT(!!(operation & TR_SYS_FILE_LOCK_SH) + !!(operation & TR_SYS_FILE_LOCK_EX) == 1);
 
 #if defined(F_OFD_SETLK)
 
     struct flock fl = {};
 
-    switch (operation & (TR_SYS_FILE_LOCK_SH | TR_SYS_FILE_LOCK_EX | TR_SYS_FILE_LOCK_UN))
+    switch (operation & (TR_SYS_FILE_LOCK_SH | TR_SYS_FILE_LOCK_EX))
     {
     case TR_SYS_FILE_LOCK_SH:
         fl.l_type = F_RDLCK;
@@ -930,10 +929,6 @@ bool tr_sys_file_lock([[maybe_unused]] tr_sys_file_t handle, [[maybe_unused]] in
 
     case TR_SYS_FILE_LOCK_EX:
         fl.l_type = F_WRLCK;
-        break;
-
-    case TR_SYS_FILE_LOCK_UN:
-        fl.l_type = F_UNLCK;
         break;
 
     default:
@@ -963,8 +958,7 @@ bool tr_sys_file_lock([[maybe_unused]] tr_sys_file_t handle, [[maybe_unused]] in
     int const native_operation = //
         (((operation & TR_SYS_FILE_LOCK_SH) != 0) ? LOCK_SH : 0) | //
         (((operation & TR_SYS_FILE_LOCK_EX) != 0) ? LOCK_EX : 0) | //
-        (((operation & TR_SYS_FILE_LOCK_NB) != 0) ? LOCK_NB : 0) | //
-        (((operation & TR_SYS_FILE_LOCK_UN) != 0) ? LOCK_UN : 0);
+        (((operation & TR_SYS_FILE_LOCK_NB) != 0) ? LOCK_NB : 0);
 
     auto result = std::optional<bool>{};
     while (!result)

--- a/libtransmission/file-win32.cc
+++ b/libtransmission/file-win32.cc
@@ -1054,33 +1054,24 @@ bool tr_sys_file_preallocate(tr_sys_file_t handle, uint64_t size, int flags, tr_
 bool tr_sys_file_lock(tr_sys_file_t handle, int operation, tr_error* error)
 {
     TR_ASSERT(handle != TR_BAD_SYS_FILE);
-    TR_ASSERT((operation & ~(TR_SYS_FILE_LOCK_SH | TR_SYS_FILE_LOCK_EX | TR_SYS_FILE_LOCK_NB | TR_SYS_FILE_LOCK_UN)) == 0);
-    TR_ASSERT(
-        !!(operation & TR_SYS_FILE_LOCK_SH) + !!(operation & TR_SYS_FILE_LOCK_EX) + !!(operation & TR_SYS_FILE_LOCK_UN) == 1);
+    TR_ASSERT((operation & ~(TR_SYS_FILE_LOCK_SH | TR_SYS_FILE_LOCK_EX | TR_SYS_FILE_LOCK_NB)) == 0);
+    TR_ASSERT(!!(operation & TR_SYS_FILE_LOCK_SH) + !!(operation & TR_SYS_FILE_LOCK_EX) == 1);
 
-    bool ret = false;
     auto overlapped = OVERLAPPED{};
 
-    if ((operation & TR_SYS_FILE_LOCK_UN) == 0)
+    DWORD native_flags = 0;
+
+    if ((operation & TR_SYS_FILE_LOCK_EX) != 0)
     {
-        DWORD native_flags = 0;
-
-        if ((operation & TR_SYS_FILE_LOCK_EX) != 0)
-        {
-            native_flags |= LOCKFILE_EXCLUSIVE_LOCK;
-        }
-
-        if ((operation & TR_SYS_FILE_LOCK_NB) != 0)
-        {
-            native_flags |= LOCKFILE_FAIL_IMMEDIATELY;
-        }
-
-        ret = LockFileEx(handle, native_flags, 0, MAXDWORD, MAXDWORD, &overlapped) != FALSE;
+        native_flags |= LOCKFILE_EXCLUSIVE_LOCK;
     }
-    else
+
+    if ((operation & TR_SYS_FILE_LOCK_NB) != 0)
     {
-        ret = UnlockFileEx(handle, 0, MAXDWORD, MAXDWORD, &overlapped) != FALSE;
+        native_flags |= LOCKFILE_FAIL_IMMEDIATELY;
     }
+
+    bool ret = LockFileEx(handle, native_flags, 0, MAXDWORD, MAXDWORD, &overlapped) != FALSE;
 
     if (!ret)
     {

--- a/libtransmission/file-win32.cc
+++ b/libtransmission/file-win32.cc
@@ -1071,7 +1071,7 @@ bool tr_sys_file_lock(tr_sys_file_t handle, int operation, tr_error* error)
         native_flags |= LOCKFILE_FAIL_IMMEDIATELY;
     }
 
-    bool ret = LockFileEx(handle, native_flags, 0, MAXDWORD, MAXDWORD, &overlapped) != FALSE;
+    bool const ret = LockFileEx(handle, native_flags, 0, MAXDWORD, MAXDWORD, &overlapped) != FALSE;
 
     if (!ret)
     {

--- a/libtransmission/file.h
+++ b/libtransmission/file.h
@@ -59,8 +59,7 @@ enum tr_sys_file_lock_flags_t
 {
     TR_SYS_FILE_LOCK_SH = (1 << 0),
     TR_SYS_FILE_LOCK_EX = (1 << 1),
-    TR_SYS_FILE_LOCK_NB = (1 << 2),
-    TR_SYS_FILE_LOCK_UN = (1 << 3)
+    TR_SYS_FILE_LOCK_NB = (1 << 2)
 };
 
 enum tr_sys_path_get_info_flags_t


### PR DESCRIPTION
We don't use `TR_SYS_FILE_LOCK_UN`, so let's remove it. If we ever need it in the future, we can look the code back up in the repo history and restore it.