### PR TITLE
build: fail if clang-tidy is not found when `-DRUN_CLANG_TIDY=ON`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -761,19 +761,20 @@ else()
     endif()
 endif()
 
-if(RUN_CLANG_TIDY STREQUAL "AUTO")
-    if(DEFINED ENV{LGTM_SRC} OR DEFINED ENV{APPVEYOR}) # skip clang-tidy on LGTM/appveyor
-        set(RUN_CLANG_TIDY OFF)
-    else()
-        set(RUN_CLANG_TIDY ON)
-    endif()
+if(RUN_CLANG_TIDY STREQUAL "AUTO" AND (DEFINED ENV{LGTM_SRC} OR DEFINED ENV{APPVEYOR})) # skip clang-tidy on LGTM/appveyor
+    set(RUN_CLANG_TIDY OFF)
 endif()
 
 if(RUN_CLANG_TIDY)
+    tr_get_required_flag(RUN_CLANG_TIDY CLANG_TIDY_IS_REQUIRED)
+
     message(STATUS "Looking for clang-tidy")
     find_program(CLANG_TIDY clang-tidy)
     if(CLANG_TIDY STREQUAL "CLANG_TIDY-NOTFOUND")
         message(STATUS "Looking for clang-tidy - not found")
+        if(CLANG_TIDY_IS_REQUIRED)
+            message(FATAL_ERROR "clang-tidy is required but wasn't found")
+        endif()
     else()
         message(STATUS "Looking for clang-tidy - found")
         set(CMAKE_CXX_CLANG_TIDY "${CLANG_TIDY}")


### PR DESCRIPTION
Fail the CMake configuration step if clang-tidy is not found when `-DRUN_CLANG_TIDY=ON`.

Currently, `-DRUN_CLANG_TIDY=ON` and `-DRUN_CLANG_TIDY=AUTO` has no difference (if not running on LGTM/appveyor).

This causes the clang-tidy CI to silently stop functioning when it cannot find a clang-tidy installation, as demonstrated in https://github.com/transmission/transmission/actions/runs/11559805177/job/32175311506?pr=7206. The CI succeeded but clang-tidy was never run.

![image](https://github.com/user-attachments/assets/d98e7ff9-b3a8-4a24-913f-56b8761b1bcb)
