### PR TITLE
fix: support nodejs below v20.11 for `generate_buildonly.js`

### DIFF
--- a/web/generate-buildonly.js
+++ b/web/generate-buildonly.js
@@ -1,7 +1,9 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import url from 'node:url';
 
-const __dirname = import.meta.dirname;
+const __filename = url.fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 const obj = JSON.parse(
   fs.readFileSync(path.join(__dirname, 'package.json'), 'utf8'),
 );


### PR DESCRIPTION
Fix the CI failure seen at https://github.com/transmission/transmission/actions/runs/11599451344/job/32297619804.

```
> generate-buildonly
> node generate-buildonly.js

node:internal/errors:496
    ErrorCaptureStackTrace(err);
    ^

TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received undefined
    at new NodeError (node:internal/errors:405:5)
    at validateString (node:internal/validators:162:11)
    at Object.join (node:path:1171:7)
    at file:///home/runner/work/transmission/transmission/web/generate-buildonly.js:6:24
    at ModuleJob.run (node:internal/modules/esm/module_job:195:25)
    at async ModuleLoader.import (node:internal/modules/esm/loader:337:24)
    at async loadESM (node:internal/process/esm_loader:34:7)
    at async handleMainPromise (node:internal/modules/run_main:106:12) {
  code: 'ERR_INVALID_ARG_TYPE'
}

Node.js v18.20.4
```

Turns out `import.meta.dirname` is new in nodejs v20.11.0, while `ubuntu-latest` currently has nodejs v18.20.4. So the script is changed to use functions available in the current nodejs version.

Already tested locally with nodejs v18.20.4.

https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V20.md#20.11.0