### PR TITLE
fix: save resume when shutting down

### DIFF
--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -864,6 +864,7 @@ void tr_torrentFreeInSessionThread(tr_torrent* tor)
         tr_logAddInfoTor(tor, _("Removing torrent"));
     }
 
+    tor->set_dirty(!tor->is_deleting_);
     tor->stop_now();
 
     if (tor->is_deleting_)


### PR DESCRIPTION
Fixes #870
Regression from 24bb159bfe7b24c3956777e8dcca6ebb561c2a1b (2009 again!! 😄 )
Xref: https://trac.transmissionbt.com/ticket/2317

Notes: Fixed a bug where resume files are not saved when shutting down Transmission.

Cheers to @reardonia for discovering this https://github.com/transmission/transmission/pull/6992#issuecomment-2437979883.
Edit: Seems like it was reported in 2019 but no one took notice.