### PR TITLE
build: accept false constant other than `OFF` for `REBUILD_WEB`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -554,31 +554,35 @@ tr_add_external_auto_library(B64 libb64 b64
         -DLIBB64_SHARED:BOOL=OFF)
 
 set(TR_WEB_ASSETS ${PROJECT_SOURCE_DIR}/web/public_html)
-if(NOT ${REBUILD_WEB} STREQUAL "OFF")
+if(REBUILD_WEB)
+    tr_get_required_flag(REBUILD_WEB NPM_IS_REQUIRED)
+
     find_program(NPM npm)
     if ("${NPM}" STREQUAL "NPM-NOTFOUND")
-        if ("${REBUILD_WEB}" STREQUAL "ON")
+        set(NPM_FOUND OFF)
+        if(NPM_IS_REQUIRED)
             message(FATAL_ERROR "Could NOT find NPM, minimum required is \"${NPM_MINIMUM}\"")
-        else() # AUTO
-            set(REBUILD_WEB OFF)
         endif()
     else()
         execute_process(COMMAND "${NPM}" --version
             OUTPUT_STRIP_TRAILING_WHITESPACE
             OUTPUT_VARIABLE NPM_VERSION_STRING)
-        if ("${NPM_VERSION_STRING}" VERSION_GREATER_EQUAL "${NPM_MINIMUM}")
+        if("${NPM_VERSION_STRING}" VERSION_GREATER_EQUAL "${NPM_MINIMUM}")
             message(STATUS "Found NPM: ${NPM} (found suitable version \"${NPM_VERSION_STRING}\", minimum required is \"${NPM_MINIMUM}\")")
-            set(REBUILD_WEB ON)
-        elseif ("${REBUILD_WEB}" STREQUAL "ON")
+            set(NPM_FOUND ON)
+        elseif(NPM_IS_REQUIRED)
             message(FATAL_ERROR "Found NPM: ${NPM} Found unsuitable version \"${NPM_VERSION_STRING}\", but required is at least \"${NPM_MINIMUM}\"")
-        else() # AUTO
+        else()
             message(STATUS "Found NPM: ${NPM} Found unsuitable version \"${NPM_VERSION_STRING}\", but required is at least \"${NPM_MINIMUM}\"")
-            set(REBUILD_WEB OFF)
+            set(NPM_FOUND OFF)
         endif()
     endif()
-    if(REBUILD_WEB)
-      add_subdirectory(web)
-    endif()
+
+    tr_fixup_auto_option(REBUILD_WEB NPM_FOUND NPM_IS_REQUIRED)
+endif()
+
+if(REBUILD_WEB)
+    add_subdirectory(web)
 endif()
 
 if(WITH_INOTIFY)


### PR DESCRIPTION
Make `REBUILD_WEB` accept values other than `OFF` as False.

Apart from `OFF`, CMake accepts a variety of values as False[^1], such as `NO`. But now `-DREBUILD_WEB=NO` is equivalent to `-DREBUILD_WEB=AUTO`, very weird.

[^1]: https://cmake.org/cmake/help/v3.12/command/if.html