### PR TITLE
Crash fix: "Invalid parameter not satisfying: aString != nil"

### DIFF
--- a/macosx/InfoGeneralViewController.mm
+++ b/macosx/InfoGeneralViewController.mm
@@ -69,7 +69,7 @@
 
     self.fLastDataLabel.hidden = location ? YES : NO;
     self.fLastDataLocationField.hidden = location ? YES : NO;
-    self.fLastDataLocationField.stringValue = location ? @"" : lastKnownDataLocation.stringByAbbreviatingWithTildeInPath;
+    self.fLastDataLocationField.stringValue = location ? @"" : lastKnownDataLocation.stringByAbbreviatingWithTildeInPath ?: @"";
     self.fLastDataLocationField.toolTip = location ? @"" : lastKnownDataLocation;
 
     self.fRevealDataButton.hidden = location ? NO : YES;


### PR DESCRIPTION
The crash happens when checking the file info of a magnet link: both location and lastKnownDataLocation are nil, but stringValue must not be nil.