### PR TITLE
fix: clang-tidy header warnings, pt. 1

### DIFF
--- a/libtransmission/bandwidth.h
+++ b/libtransmission/bandwidth.h
@@ -30,8 +30,8 @@ class tr_peerIo;
 
 struct tr_bandwidth_limits
 {
-    libtransmission::Values::Speed up_limit = {};
-    libtransmission::Values::Speed down_limit = {};
+    libtransmission::Values::Speed up_limit;
+    libtransmission::Values::Speed down_limit;
     bool up_limited = false;
     bool down_limited = false;
 };

--- a/libtransmission/cache.h
+++ b/libtransmission/cache.h
@@ -81,7 +81,7 @@ private:
 
     tr_torrents const& torrents_;
 
-    Blocks blocks_ = {};
+    Blocks blocks_;
     size_t max_blocks_ = 0;
 
     mutable size_t disk_writes_ = 0;

--- a/libtransmission/error-types.h
+++ b/libtransmission/error-types.h
@@ -26,7 +26,7 @@
 
 #endif /* _WIN32 */
 
-constexpr inline bool tr_error_is_enoent(int code) noexcept
+constexpr bool tr_error_is_enoent(int code) noexcept
 {
 #ifdef _WIN32
     return code == ERROR_FILE_NOT_FOUND || code == ERROR_PATH_NOT_FOUND;
@@ -35,7 +35,7 @@ constexpr inline bool tr_error_is_enoent(int code) noexcept
 #endif
 }
 
-constexpr inline bool tr_error_is_enospc(int code) noexcept
+constexpr bool tr_error_is_enospc(int code) noexcept
 {
 #ifdef _WIN32
     return code == ERROR_DISK_FULL;

--- a/libtransmission/file.h
+++ b/libtransmission/file.h
@@ -45,7 +45,7 @@ using tr_sys_dir_t = tr_sys_dir_win32*;
 /** @brief Platform-specific invalid directory descriptor constant. */
 #define TR_BAD_SYS_DIR ((tr_sys_dir_t) nullptr)
 
-enum tr_sys_file_open_flags_t
+enum tr_sys_file_open_flags_t : uint8_t
 {
     TR_SYS_FILE_READ = (1 << 0),
     TR_SYS_FILE_WRITE = (1 << 1),
@@ -54,29 +54,29 @@ enum tr_sys_file_open_flags_t
     TR_SYS_FILE_SEQUENTIAL = (1 << 4)
 };
 
-enum tr_sys_file_lock_flags_t
+enum tr_sys_file_lock_flags_t : uint8_t
 {
     TR_SYS_FILE_LOCK_SH = (1 << 0),
     TR_SYS_FILE_LOCK_EX = (1 << 1),
     TR_SYS_FILE_LOCK_NB = (1 << 2)
 };
 
-enum tr_sys_path_get_info_flags_t
+enum tr_sys_path_get_info_flags_t : uint8_t
 {
     TR_SYS_PATH_NO_FOLLOW = (1 << 0)
 };
 
-enum tr_sys_file_preallocate_flags_t
+enum tr_sys_file_preallocate_flags_t : uint8_t
 {
     TR_SYS_FILE_PREALLOC_SPARSE = (1 << 0)
 };
 
-enum tr_sys_dir_create_flags_t
+enum tr_sys_dir_create_flags_t : uint8_t
 {
     TR_SYS_DIR_CREATE_PARENTS = (1 << 0)
 };
 
-enum tr_sys_path_type_t
+enum tr_sys_path_type_t : uint8_t
 {
     TR_SYS_PATH_IS_FILE,
     TR_SYS_PATH_IS_DIRECTORY,

--- a/libtransmission/handshake.h
+++ b/libtransmission/handshake.h
@@ -320,7 +320,7 @@ private:
 
     ///
 
-    std::optional<DH> dh_{};
+    std::optional<DH> dh_;
 
     DoneFunc on_done_;
 

--- a/libtransmission/log.h
+++ b/libtransmission/log.h
@@ -14,7 +14,7 @@
 
 // ---
 
-enum tr_log_level
+enum tr_log_level : uint8_t
 {
     // No logging at all
     TR_LOG_OFF,

--- a/libtransmission/open-files.h
+++ b/libtransmission/open-files.h
@@ -24,7 +24,7 @@
 class tr_open_files
 {
 public:
-    enum class Preallocation
+    enum class Preallocation : uint8_t
     {
         None,
         Sparse,

--- a/libtransmission/peer-common.h
+++ b/libtransmission/peer-common.h
@@ -72,7 +72,7 @@ public:
     uint32_t offset = 0; // for GotBlock
     uint32_t length = 0; // for GotBlock, GotPieceData
     int err = 0; // errno for GotError
-    tr_port port = {}; // for GotPort
+    tr_port port; // for GotPort
 
     [[nodiscard]] constexpr static auto GotBlock(tr_block_info const& block_info, tr_block_index_t block) noexcept
     {

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -363,7 +363,7 @@ private:
 
     std::deque<std::pair<size_t /*n_bytes*/, bool /*is_piece_data*/>> outbuf_info_;
 
-    tr_peer_socket socket_ = {};
+    tr_peer_socket socket_;
 
     tr_bandwidth bandwidth_;
 

--- a/libtransmission/peer-mse.h
+++ b/libtransmission/peer-mse.h
@@ -131,8 +131,8 @@ private:
         }
     }
 
-    tr_arc4 dec_key_ = {};
-    tr_arc4 enc_key_ = {};
+    tr_arc4 dec_key_;
+    tr_arc4 enc_key_;
     bool dec_active_ = false;
     bool enc_active_ = false;
 };

--- a/libtransmission/port-forwarding-natpmp.h
+++ b/libtransmission/port-forwarding-natpmp.h
@@ -40,8 +40,8 @@ public:
     {
         tr_port_forwarding_state state = TR_PORT_ERROR;
 
-        tr_port local_port = {};
-        tr_port advertised_port = {};
+        tr_port local_port;
+        tr_port advertised_port;
     };
 
     PulseResult pulse(tr_port local_port, bool is_enabled);
@@ -68,8 +68,8 @@ private:
 
     natpmp_t natpmp_ = {};
 
-    tr_port local_port_ = {};
-    tr_port advertised_port_ = {};
+    tr_port local_port_;
+    tr_port advertised_port_;
 
     time_t renew_time_ = 0;
     time_t command_time_ = 0;

--- a/libtransmission/session-alt-speeds.h
+++ b/libtransmission/session-alt-speeds.h
@@ -187,7 +187,7 @@ private:
     // bitfield of all the minutes in a week.
     // Each bit's value indicates whether the scheduler wants
     // alt speeds on or off at that given minute.
-    std::bitset<10080> minutes_{};
+    std::bitset<10080> minutes_;
 
     // recent change that was made by the scheduler
     std::optional<bool> scheduler_set_is_active_to_;

--- a/libtransmission/torrent-ctor.h
+++ b/libtransmission/torrent-ctor.h
@@ -29,7 +29,7 @@ struct tr_torrent;
 struct tr_ctor
 {
 public:
-    explicit tr_ctor(tr_session* const session);
+    explicit tr_ctor(tr_session* session);
 
     [[nodiscard]] constexpr auto* session() const noexcept
     {

--- a/libtransmission/torrent-ctor.h
+++ b/libtransmission/torrent-ctor.h
@@ -219,7 +219,7 @@ private:
 
     tr_torrent::VerifyDoneCallback verify_done_callback_;
 
-    tr_torrent::labels_t labels_ = {};
+    tr_torrent::labels_t labels_;
 
     std::vector<tr_file_index_t> wanted_;
     std::vector<tr_file_index_t> unwanted_;

--- a/libtransmission/torrent-metainfo.h
+++ b/libtransmission/torrent-metainfo.h
@@ -199,7 +199,7 @@ private:
     static bool parse_impl(tr_torrent_metainfo& setme, std::string_view benc, tr_error* error);
     static std::string fix_webseed_url(tr_torrent_metainfo const& tm, std::string_view url);
 
-    enum class BasenameFormat
+    enum class BasenameFormat : uint8_t
     {
         Hash,
         NameAndPartialHash

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -948,7 +948,7 @@ struct tr_torrent
         return queue_position_;
     }
 
-    void set_unique_queue_position(size_t const new_pos);
+    void set_unique_queue_position(size_t new_pos);
 
     static constexpr struct
     {
@@ -1281,7 +1281,7 @@ private:
         std::string_view oldpath,
         std::string_view newname,
         tr_torrent_rename_done_func callback,
-        void* const callback_user_data);
+        void* callback_user_data);
 
     void start_in_session_thread();
 

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -950,7 +950,7 @@ struct tr_torrent
 
     void set_unique_queue_position(size_t const new_pos);
 
-    static inline constexpr struct
+    static constexpr struct
     {
         constexpr bool operator()(tr_torrent const* a, tr_torrent const* b) const noexcept
         {

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -1087,7 +1087,7 @@ private:
         static auto constexpr MinUpdateMSec = 800U;
 
         uint64_t timestamp_msec_ = {};
-        Speed speed_ = {};
+        Speed speed_;
     };
 
     [[nodiscard]] constexpr auto seconds_downloading(time_t now) const noexcept

--- a/libtransmission/tr-popcount.h
+++ b/libtransmission/tr-popcount.h
@@ -62,7 +62,7 @@ struct tr_popcnt
 #elif defined(TR_HAVE_BUILTIN_POPCOUNT)
     /* Use __builtin as opposed to straight assembly to avoid any
        strain the latter puts on the optimized. */
-    static inline unsigned count(T v)
+    static unsigned count(T v)
     {
         /* Make sure we know how to find that right __builtin_popcount. */
         static_assert(

--- a/libtransmission/utils.h
+++ b/libtransmission/utils.h
@@ -306,14 +306,15 @@ class tr_net_init_mgr
 {
 public:
     ~tr_net_init_mgr();
-    static std::unique_ptr<tr_net_init_mgr> create();
-
-private:
-    tr_net_init_mgr();
     tr_net_init_mgr(tr_net_init_mgr&&) = delete;
     tr_net_init_mgr(tr_net_init_mgr const&) = delete;
     tr_net_init_mgr& operator=(tr_net_init_mgr&&) = delete;
     tr_net_init_mgr& operator=(tr_net_init_mgr const&) = delete;
+
+    static std::unique_ptr<tr_net_init_mgr> create();
+
+private:
+    tr_net_init_mgr();
 
     static bool initialised;
 };

--- a/libtransmission/values.h
+++ b/libtransmission/values.h
@@ -16,7 +16,7 @@
 
 namespace libtransmission::Values
 {
-enum class MemoryUnits
+enum class MemoryUnits : uint8_t
 {
     Bytes,
     KBytes,
@@ -27,7 +27,7 @@ enum class MemoryUnits
 
 using StorageUnits = MemoryUnits;
 
-enum class SpeedUnits
+enum class SpeedUnits : uint8_t
 {
     Byps,
     KByps,
@@ -38,7 +38,7 @@ enum class SpeedUnits
 
 struct Config
 {
-    enum class Base
+    enum class Base : uint8_t
     {
         Kilo = 1000U,
         Kibi = 1024U

--- a/libtransmission/values.h
+++ b/libtransmission/values.h
@@ -38,7 +38,7 @@ enum class SpeedUnits : uint8_t
 
 struct Config
 {
-    enum class Base : uint8_t
+    enum class Base : uint16_t
     {
         Kilo = 1000U,
         Kibi = 1024U

--- a/libtransmission/variant.h
+++ b/libtransmission/variant.h
@@ -554,7 +554,7 @@ public:
     // ---
 
     // Tracks errors when parsing / saving
-    tr_error error_ = {};
+    tr_error error_;
 
 private:
     friend tr_variant;

--- a/libtransmission/watchdir-base.h
+++ b/libtransmission/watchdir-base.h
@@ -82,9 +82,9 @@ private:
     struct Pending
     {
         size_t strikes = 0U;
-        Timestamp first_kick_at = {};
-        Timestamp last_kick_at = {};
-        Timestamp next_kick_at = {};
+        Timestamp first_kick_at;
+        Timestamp last_kick_at;
+        Timestamp next_kick_at;
     };
 
     void setNextKickTime(Pending& item)

--- a/libtransmission/web.h
+++ b/libtransmission/web.h
@@ -91,7 +91,7 @@ public:
         // IP protocol to use when making the request
         IPProtocol ip_proto = IPProtocol::ANY;
 
-        static auto inline constexpr DefaultTimeoutSecs = std::chrono::seconds{ 120 };
+        static auto constexpr DefaultTimeoutSecs = std::chrono::seconds{ 120 };
     };
 
     void fetch(FetchOptions&& options);


### PR DESCRIPTION
I've started running `clang-tidy` on our header files. This PR cleans up some warnings in `libtransmission/*h` and `qt/*h`

The full list of warnings is super noisy right now, so (a) I'm not going to push up a PR enabling them yet, and (b) this will take a small series of PRs to clean 'em all up