### PR TITLE
fix: don't double count webseed download data rate

### DIFF
--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -341,16 +341,6 @@ size_t tr_session::WebMediator::clamp(int torrent_id, size_t byte_count) const
     return tor == nullptr ? 0U : tor->bandwidth().clamp(TR_DOWN, byte_count);
 }
 
-void tr_session::WebMediator::notifyBandwidthConsumed(int torrent_id, size_t byte_count)
-{
-    auto const lock = session_->unique_lock();
-
-    if (auto* const tor = session_->torrents().get(torrent_id); tor != nullptr)
-    {
-        tor->bandwidth().notify_bandwidth_consumed(TR_DOWN, byte_count, true, tr_time_msec());
-    }
-}
-
 void tr_session::WebMediator::run(tr_web::FetchDoneFunc&& func, tr_web::FetchResponse&& response) const
 {
     session_->run_in_session_thread(std::move(func), std::move(response));

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -244,7 +244,6 @@ private:
         [[nodiscard]] std::optional<std::string_view> userAgent() const override;
         [[nodiscard]] size_t clamp(int torrent_id, size_t byte_count) const override;
         [[nodiscard]] time_t now() const override;
-        void notifyBandwidthConsumed(int torrent_id, size_t byte_count) override;
         // runs the tr_web::fetch response callback in the libtransmission thread
         void run(tr_web::FetchDoneFunc&& func, tr_web::FetchResponse&& response) const override;
 

--- a/libtransmission/web.cc
+++ b/libtransmission/web.cc
@@ -482,8 +482,6 @@ public:
                 task->impl.paused_easy_handles.emplace(task->easy(), tr_time_msec());
                 return CURL_WRITEFUNC_PAUSE;
             }
-
-            task->impl.mediator.notifyBandwidthConsumed(*tag, bytes_used);
         }
 
         evbuffer_add(task->body(), data, bytes_used);

--- a/libtransmission/web.h
+++ b/libtransmission/web.h
@@ -143,11 +143,6 @@ public:
             return std::nullopt;
         }
 
-        // Notify the system that `byte_count` of download bandwidth was used
-        virtual void notifyBandwidthConsumed([[maybe_unused]] int bandwidth_tag, [[maybe_unused]] size_t byte_count)
-        {
-        }
-
         // Return the number of bytes that should be allowed. See tr_bandwidth::clamp()
         [[nodiscard]] virtual size_t clamp([[maybe_unused]] int bandwidth_tag, size_t byte_count) const
         {


### PR DESCRIPTION
Fixes #7221.
Regression from #2633.

Notes: Fixed `4.0.0` bug where the download rate of webseeds are double-counted.

#### Side Note

The code removed in this PR were new in #2633, and I am having a really hard time figuring out what they were intended for. `webseed.cc` has been the only code using the `tr_web` speed limit features, but these lines couldn't have been written for `webseed.cc`, since `webseed.cc` were already reporting their bandwidth usage by themselves before #2633.

https://github.com/transmission/transmission/blob/2315903015dae4063338a0cce68e65a9fd5e8795/libtransmission/webseed.cc#L266