### PR TITLE
fix: don't increment failure count when stopping torrent

### DIFF
--- a/libtransmission/peer-mgr.h
+++ b/libtransmission/peer-mgr.h
@@ -248,11 +248,11 @@ public:
         {
             piece_data_at_ = {};
         }
-        else if (has_transferred_piece_data() || !is_disconnecting)
+        else if (has_transferred_piece_data())
         {
             num_consecutive_fruitless_ = {};
         }
-        else
+        else if (is_disconnecting)
         {
             on_fruitless_connection();
         }

--- a/libtransmission/peer-mgr.h
+++ b/libtransmission/peer-mgr.h
@@ -233,7 +233,7 @@ public:
 
     // ---
 
-    constexpr auto set_connected(time_t now, bool is_connected = true) noexcept
+    constexpr auto set_connected(time_t now, bool is_connected = true, bool is_disconnecting = false) noexcept
     {
         if (is_connected_ == is_connected)
         {
@@ -248,7 +248,7 @@ public:
         {
             piece_data_at_ = {};
         }
-        else if (has_transferred_piece_data())
+        else if (has_transferred_piece_data() || !is_disconnecting)
         {
             num_consecutive_fruitless_ = {};
         }

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -2094,7 +2094,7 @@ tr_peerMsgs::tr_peerMsgs(
 
 tr_peerMsgs::~tr_peerMsgs()
 {
-    peer_info->set_connected(tr_time(), false);
+    peer_info->set_connected(tr_time(), false, is_disconnecting());
     TR_ASSERT(n_peers > 0U);
     --n_peers;
 }


### PR DESCRIPTION
Fixes a regression from #6917 where the "failure count" on peers are being incremented indiscriminately when stopping the torrent, causing them to have a longer reconnect timeout than they should. More details in the discussion from https://github.com/transmission/transmission/pull/6975#issuecomment-2437912381 to https://github.com/transmission/transmission/pull/6975#issuecomment-2461231249.

CC @reardonia 

P.S. The discussion took place in #6975, but this regression is not actually related to it.