### PR TITLE
build: update web/CMakeLists.txt to reflect renamed files (Fixes #7240)

### DIFF
--- a/web/CMakeLists.txt
+++ b/web/CMakeLists.txt
@@ -65,8 +65,8 @@ add_custom_command(
         "${CMAKE_CURRENT_SOURCE_DIR}/esbuild.mjs"
         "${CMAKE_CURRENT_SOURCE_DIR}/package-lock.json"
         "${CMAKE_CURRENT_SOURCE_DIR}/package.json"
-        "${CMAKE_CURRENT_SOURCE_DIR}/prettier.config.js"
-        "${CMAKE_CURRENT_SOURCE_DIR}/stylelint.config.js"
+        "${CMAKE_CURRENT_SOURCE_DIR}/prettier.config.cjs"
+        "${CMAKE_CURRENT_SOURCE_DIR}/stylelint.config.cjs"
         "${CMAKE_CURRENT_BINARY_DIR}"
     COMMAND "${CMAKE_COMMAND}" -E copy_directory
         "${CMAKE_CURRENT_SOURCE_DIR}/assets" "assets"


### PR DESCRIPTION
the files web/prettier.config.js and web/stylelint.config.js were renamed in b9f4509, but web/CMakeLists.txt was not updated correspondingly. hence, using `REBUILD_WEB` would cause FTBFS.

Fixes #7240 