### PR TITLE
Adjust slider limits in GTK

### DIFF
--- a/gtk/MakeDialog.cc
+++ b/gtk/MakeDialog.cc
@@ -403,8 +403,8 @@ void MakeDialog::Impl::updatePiecesLabel()
 
 void MakeDialog::Impl::configurePieceSizeScale(uint32_t piece_size)
 {
-    // the below lower & upper bounds would allow piece size selection between approx 1KiB - 64MiB
-    auto adjustment = Gtk::Adjustment::create(log2(piece_size), 10, 26, 1.0, 1.0);
+    // the below lower & upper bounds would allow piece size selection between approx 16KiB - 256MiB
+    auto adjustment = Gtk::Adjustment::create(log2(piece_size), 14, 28, 1.0, 1.0);
     piece_size_scale_->set_adjustment(adjustment);
     piece_size_scale_->set_visible(true);
 }


### PR DESCRIPTION
Fix #5955.
Aligns with #6211.