### PR TITLE
fix: CI errors related to `REBUILD_WEB`

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -66,7 +66,7 @@ jobs:
           get_changes qt         CMakeLists.txt cmake third-party libtransmission qt
           get_changes tests      CMakeLists.txt cmake third-party libtransmission utils tests
           get_changes utils      CMakeLists.txt cmake third-party libtransmission utils
-          get_changes web        CMakeLists.txt cmake third-party libtransmission web
+          get_changes web        CMakeLists.txt cmake third-party web
           get_changes ci-actions .github/workflows/actions.yml
           cat "$GITHUB_OUTPUT"
 

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -803,14 +803,14 @@ jobs:
           name: binaries-${{ github.job }}
           path: pfx/**/*
 
-  debian-11-from-tarball:
+  debian-12-from-tarball:
     needs: [ make-source-tarball, what-to-make ]
     if: ${{ needs.what-to-make.outputs.make-cli == 'true' || needs.what-to-make.outputs.make-daemon == 'true' || needs.what-to-make.outputs.make-gtk == 'true' || needs.what-to-make.outputs.make-qt == 'true' || needs.what-to-make.outputs.make-tests == 'true' || needs.what-to-make.outputs.make-utils == 'true' }}
     runs-on: ubuntu-22.04
     env:
       NODE_PATH: /usr/lib/nodejs:/usr/share/nodejs
     container:
-      image: debian:11-slim
+      image: debian:12-slim
     steps:
       - name: Show Configuration
         run: |

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -835,9 +835,12 @@ jobs:
             libpsl-dev \
             libssl-dev \
             ninja-build \
-            npm \
             pkg-config \
             xz-utils
+      - name: Get NPM
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
       - name: Get Dependencies (GTK)
         if: ${{ needs.what-to-make.outputs.make-gtk == 'true' }}
         run: apt-get install -y --no-install-recommends libglibmm-2.4-dev libgtkmm-3.0-dev

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -66,7 +66,7 @@ jobs:
           get_changes qt         CMakeLists.txt cmake third-party libtransmission qt
           get_changes tests      CMakeLists.txt cmake third-party libtransmission utils tests
           get_changes utils      CMakeLists.txt cmake third-party libtransmission utils
-          get_changes web        CMakeLists.txt cmake third-party web
+          get_changes web        CMakeLists.txt cmake web
           get_changes ci-actions .github/workflows/actions.yml
           cat "$GITHUB_OUTPUT"
 

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -803,14 +803,14 @@ jobs:
           name: binaries-${{ github.job }}
           path: pfx/**/*
 
-  debian-12-from-tarball:
+  debian-11-from-tarball:
     needs: [ make-source-tarball, what-to-make ]
     if: ${{ needs.what-to-make.outputs.make-cli == 'true' || needs.what-to-make.outputs.make-daemon == 'true' || needs.what-to-make.outputs.make-gtk == 'true' || needs.what-to-make.outputs.make-qt == 'true' || needs.what-to-make.outputs.make-tests == 'true' || needs.what-to-make.outputs.make-utils == 'true' }}
     runs-on: ubuntu-22.04
     env:
       NODE_PATH: /usr/lib/nodejs:/usr/share/nodejs
     container:
-      image: debian:12-slim
+      image: debian:11-slim
     steps:
       - name: Show Configuration
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -557,7 +557,12 @@ set(TR_WEB_ASSETS ${PROJECT_SOURCE_DIR}/web/public_html)
 if(REBUILD_WEB)
     tr_get_required_flag(REBUILD_WEB NPM_IS_REQUIRED)
 
-    find_program(NPM npm)
+    if(WIN32)
+        find_program(NPM npm.cmd)
+    else()
+        find_program(NPM npm)
+    endif()
+
     if ("${NPM}" STREQUAL "NPM-NOTFOUND")
         set(NPM_FOUND OFF)
         if(NPM_IS_REQUIRED)

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -6,8 +6,6 @@
 
 // This file defines the public API for the libtransmission library.
 
-// FIXME: trigger CI
-
 #pragma once
 
 // --- Basic Types

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -6,6 +6,8 @@
 
 // This file defines the public API for the libtransmission library.
 
+// FIXME: trigger CI
+
 #pragma once
 
 // --- Basic Types


### PR DESCRIPTION
Address the CI failures at https://github.com/transmission/transmission/actions/runs/11897556121/job/33152109063.

#### Windows

```
CMake Error at CMakeLists.txt:574 (message):
  Found NPM: C:/Program Files/nodejs/npm Found unsuitable version "", but
  required is at least "8.1.307"
```

#### Debian 11

```
CMake Error at CMakeLists.txt:574 (message):
  Found NPM: /usr/bin/npm Found unsuitable version "7.5.2", but required is
  at least "8.1.307"
```