### PR TITLE
fix: macOS CI

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -190,7 +190,8 @@ jobs:
           sw_vers
       - name: Get Dependencies
         run: |
-          brew install cmake gettext libdeflate libevent libpsl miniupnpc ninja node pkg-config
+          brew uninstall -f pkg-config pkg-config@0.29.2
+          brew install cmake gettext libdeflate libevent libpsl miniupnpc ninja node pkgconf
       - name: Get Source
         uses: actions/checkout@v4
         with:
@@ -343,7 +344,8 @@ jobs:
           sw_vers
       - name: Get Dependencies
         run: |
-          brew install cmake gettext libdeflate libevent libpsl miniupnpc ninja node pkg-config
+          brew uninstall -f pkg-config pkg-config@0.29.2
+          brew install cmake gettext libdeflate libevent libpsl miniupnpc ninja node pkgconf
       - name: Get Dependencies (GTK)
         if: ${{ needs.what-to-make.outputs.make-gtk == 'true' }}
         run: brew install gtkmm3
@@ -402,7 +404,8 @@ jobs:
           sw_vers
       - name: Get Dependencies
         run: |
-          brew install cmake gettext libdeflate libevent libpsl miniupnpc ninja node pkg-config
+          brew unlink pkg-config
+          brew install cmake gettext libdeflate libevent libpsl miniupnpc ninja node pkgconf
       - name: Get Source
         uses: actions/checkout@v4
         with:
@@ -620,7 +623,8 @@ jobs:
           sw_vers
       - name: Get Dependencies
         run: |
-          brew install cmake gettext ninja node pkg-config
+          brew uninstall -f pkg-config pkg-config@0.29.2
+          brew install cmake gettext ninja node pkgconf
       - name: Get Source
         uses: actions/download-artifact@v4
         with:
@@ -681,7 +685,8 @@ jobs:
           sw_vers
       - name: Get Dependencies
         run: |
-          brew install cmake gettext ninja node pkg-config
+          brew unlink pkg-config
+          brew install cmake gettext ninja node pkgconf
       - name: Get Dependencies (Qt)
         if: ${{ needs.what-to-make.outputs.make-qt == 'true' }}
         run: brew install qt
@@ -746,7 +751,8 @@ jobs:
           sw_vers
       - name: Get Dependencies
         run: |
-          brew install cmake gettext ninja node pkg-config
+          brew unlink pkg-config
+          brew install cmake gettext ninja node pkgconf
       - name: Get Dependencies (GTK)
         if: ${{ needs.what-to-make.outputs.make-gtk == 'true' }}
         run: brew install gtkmm3

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -190,8 +190,8 @@ jobs:
           sw_vers
       - name: Get Dependencies
         run: |
-          brew uninstall -f pkg-config pkg-config@0.29.2
-          brew install cmake gettext libdeflate libevent libpsl miniupnpc ninja node pkgconf
+          brew uninstall -f pkg-config pkg-config@0.29.2 # https://github.com/actions/runner-images/issues/10984
+          brew install --formulae cmake gettext libdeflate libevent libpsl miniupnpc ninja node pkgconf
       - name: Get Source
         uses: actions/checkout@v4
         with:
@@ -344,14 +344,14 @@ jobs:
           sw_vers
       - name: Get Dependencies
         run: |
-          brew uninstall -f pkg-config pkg-config@0.29.2
-          brew install cmake gettext libdeflate libevent libpsl miniupnpc ninja node pkgconf
+          brew uninstall -f pkg-config pkg-config@0.29.2 # https://github.com/actions/runner-images/issues/10984
+          brew install --formulae cmake gettext libdeflate libevent libpsl miniupnpc ninja node pkgconf
       - name: Get Dependencies (GTK)
         if: ${{ needs.what-to-make.outputs.make-gtk == 'true' }}
-        run: brew install gtkmm3
+        run: brew install --formula gtkmm3
       - name: Get Dependencies (Qt)
         if: ${{ needs.what-to-make.outputs.make-qt == 'true' }}
-        run: brew install qt
+        run: brew install --formula qt
       - name: Get Source
         uses: actions/checkout@v4
         with:
@@ -404,8 +404,8 @@ jobs:
           sw_vers
       - name: Get Dependencies
         run: |
-          brew unlink pkg-config
-          brew install cmake gettext libdeflate libevent libpsl miniupnpc ninja node pkgconf
+          brew unlink pkg-config # https://github.com/actions/runner-images/issues/10984
+          brew install --formulae cmake gettext libdeflate libevent libpsl miniupnpc ninja node pkgconf
       - name: Get Source
         uses: actions/checkout@v4
         with:
@@ -623,8 +623,8 @@ jobs:
           sw_vers
       - name: Get Dependencies
         run: |
-          brew uninstall -f pkg-config pkg-config@0.29.2
-          brew install cmake gettext ninja node pkgconf
+          brew uninstall -f pkg-config pkg-config@0.29.2 # https://github.com/actions/runner-images/issues/10984
+          brew install --formulae cmake gettext ninja node pkgconf
       - name: Get Source
         uses: actions/download-artifact@v4
         with:
@@ -685,11 +685,11 @@ jobs:
           sw_vers
       - name: Get Dependencies
         run: |
-          brew unlink pkg-config
-          brew install cmake gettext ninja node pkgconf
+          brew unlink pkg-config # https://github.com/actions/runner-images/issues/10984
+          brew install --formulae cmake gettext ninja node pkgconf
       - name: Get Dependencies (Qt)
         if: ${{ needs.what-to-make.outputs.make-qt == 'true' }}
-        run: brew install qt
+        run: brew install --formula qt
       - name: Get Source
         uses: actions/download-artifact@v4
         with:
@@ -751,11 +751,11 @@ jobs:
           sw_vers
       - name: Get Dependencies
         run: |
-          brew unlink pkg-config
-          brew install cmake gettext ninja node pkgconf
+          brew unlink pkg-config # https://github.com/actions/runner-images/issues/10984
+          brew install --formulae cmake gettext ninja node pkgconf
       - name: Get Dependencies (GTK)
         if: ${{ needs.what-to-make.outputs.make-gtk == 'true' }}
-        run: brew install gtkmm3
+        run: brew install --formula gtkmm3
       - name: Get Source
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
Fix CI build errors like https://github.com/transmission/transmission/actions/runs/11905342027/job/33175657804?pr=7252

See https://github.com/actions/runner-images/issues/10984

The brew formula `pkg-config` was recently renamed to `pkgconf`, which conflicts with the _sometimes_ preinstalled `pkg-config`/`pkg-config@0.29.2` on some containers.
- Using `uninstall -f` on macos-15 where it can't be unlinked
- Using `unlink` on macos-12 where it's can't be uninstalled

- The solution to use `brew update && brew upgrade` doesn't work: it fails to update when swiftlint is installed, and pkgconf installation is still failing