### PR TITLE
feat: alternative torrent selection for web client

### DIFF
--- a/web/assets/css/transmission-app.scss
+++ b/web/assets/css/transmission-app.scss
@@ -461,7 +461,7 @@ a {
       background-color: var(--color-bg-odd);
     }
 
-    .icon {
+    .select .icon {
       // color the background svg fill
       background-color: var(--color-fg-primary);
       background-position:
@@ -571,15 +571,34 @@ a {
       align-items: center;
       display: flex;
 
-      .icon {
-        -webkit-mask-size: var(--icon-size), calc(var(--icon-size) / 2);
+      .select {
+        margin: 0;
+        padding: 8px 10px 7px 5px;
         height: var(--icon-size);
-        mask-size: var(--icon-size), calc(var(--icon-size) / 2);
         width: var(--icon-size);
 
-        &[data-icon-multifile='true'] {
-          --mime-icon-url: var(--folder-image-url);
+        input[type='checkbox'] {
+          margin: 0;
         }
+
+        .icon {
+          -webkit-mask-size: var(--icon-size), calc(var(--icon-size) / 2);
+          height: var(--icon-size);
+          mask-size: var(--icon-size), calc(var(--icon-size) / 2);
+          width: var(--icon-size);
+
+          &[data-icon-multifile='true'] {
+            --mime-icon-url: var(--folder-image-url);
+          }
+        }
+      }
+
+      &.selected .select .icon {
+        display: none;
+      }
+
+      .torrent-name {
+        margin-left: 0;
       }
 
       > * {
@@ -593,36 +612,49 @@ a {
       display: grid;
       grid-column-gap: 12px;
       grid-template-areas:
-        'icon name labels'
-        'icon progress-text progress-text'
-        'icon progressbar progressbar'
-        'icon peers peers';
-      grid-template-columns: var(--icon-size) auto 1fr;
-      padding: 6px 12px;
+        'select name labels'
+        'select progress-text progress-text'
+        'select progressbar progressbar'
+        'select peers peers';
+      grid-template-columns: 44px auto 1fr;
 
-      .icon {
-        background-size: var(--icon-size), calc(var(--icon-size) / 2);
-        grid-area: icon;
-        height: var(--icon-size);
-        width: var(--icon-size);
+      .select {
+        height: 100%;
+        width: 100%;
+        grid-area: select;
+        padding-left: 12px;
+
+        input[type='checkbox'] {
+          margin: 6px 0;
+        }
+
+        .icon {
+          background-size: var(--icon-size), calc(var(--icon-size) / 2);
+          height: var(--icon-size);
+          width: var(--icon-size);
+        }
       }
 
       .torrent-name {
         grid-area: name;
+        padding-top: 6px;
       }
 
       .torrent-labels {
         grid-area: labels;
+        padding-top: 6px;
       }
 
       .torrent-peer-details {
         grid-area: peers;
+        padding-bottom: 6px;
       }
 
       .torrent-progress {
         display: flex;
         flex-direction: row;
         grid-area: progressbar;
+        padding-right: 12px;
       }
 
       .torrent-progress-details {
@@ -641,8 +673,29 @@ a {
         color: var(--color-fg-primary);
       }
 
-      .icon {
+      .select .icon {
         background-color: var(--color-fg-disabled);
+      }
+    }
+
+    .select {
+      position: relative;
+
+      .icon {
+        left: 50%;
+        top: 50%;
+        transform: translate(-50%, -50%);
+      }
+
+      input[type='checkbox'] {
+        display: none;
+        left: 50%;
+        transform: translate(-50%, 0);
+      }
+
+      > * {
+        position: absolute;
+        pointer-events: none;
       }
     }
 
@@ -650,13 +703,19 @@ a {
       background-color: var(--color-bg-selected);
       color: var(--color-fg-selected);
 
-      .icon {
-        background-color: var(--color-fg-selected);
+      .select {
+        input[type='checkbox'] {
+          display: block;
+        }
+
+        .icon {
+          background-color: var(--color-fg-selected);
+        }
       }
     }
   }
 
-  .icon {
+  .select .icon {
     background-position: center;
     background-repeat: no-repeat;
   }

--- a/web/src/torrent-row.js
+++ b/web/src/torrent-row.js
@@ -72,11 +72,17 @@ const TorrentRendererHelper = {
     progressbar.style.setProperty('--progress', pct_str);
     progressbar.dataset.progress = info.ratio ? '100%' : pct_str;
   },
-  symbol: { down: '▼', up: '▲' },
-  updateIcon: (e, torrent) => {
+  renderSelectIcon: (select, torrent) => {
+    const check = document.createElement('input');
+    check.type = 'checkbox';
+    check.checked = true;
+    const e = document.createElement('icon');
+    e.className = 'icon';
     e.dataset.iconMimeType = torrent.getPrimaryMimeType().split('/', 1).pop();
     e.dataset.iconMultifile = torrent.getFileCount() > 1 ? 'true' : 'false';
+    select.append(check, e);
   },
+  symbol: { down: '▼', up: '▲' },
 };
 
 ///
@@ -257,7 +263,7 @@ export class TorrentRendererFull {
     root.className = 'torrent';
 
     const elements = [
-      ['icon', 'icon'],
+      ['select', 'select'],
       ['name', 'torrent-name'],
       ['labels', 'torrent-labels'],
       ['progress_details', 'torrent-progress-details'],
@@ -272,7 +278,7 @@ export class TorrentRendererFull {
       root[name] = e;
     }
 
-    TorrentRendererHelper.updateIcon(root.icon, torrent);
+    TorrentRendererHelper.renderSelectIcon(root.select, torrent);
 
     const progressbar = document.createElement('div');
     progressbar.className = 'torrent-progress-bar full';
@@ -361,7 +367,7 @@ export class TorrentRendererCompact {
     root.className = 'torrent compact';
 
     const elements = [
-      ['icon', 'icon'],
+      ['select', 'select'],
       ['name', 'torrent-name compact'],
       ['labels', 'torrent-labels compact'],
       ['peer_details', 'torrent-peer-details compact'],
@@ -375,7 +381,7 @@ export class TorrentRendererCompact {
       root[name] = e;
     }
 
-    TorrentRendererHelper.updateIcon(root.icon, torrent);
+    TorrentRendererHelper.renderSelectIcon(root.select, torrent);
 
     return root;
   }

--- a/web/src/transmission.js
+++ b/web/src/transmission.js
@@ -202,8 +202,11 @@ export class Transmission extends EventTarget {
         this._deselectAll();
       }
     });
-    e.addEventListener('dblclick', () => {
-      if (!this.popup[0] || this.popup[0].name !== 'inspector') {
+    e.addEventListener('dblclick', (event_) => {
+      if (
+        !event_.target.classList.contains('select') &&
+        (!this.popup[0] || this.popup[0].name !== 'inspector')
+      ) {
         this.action_manager.click('show-inspector');
       }
     });
@@ -805,7 +808,10 @@ TODO: fix this when notifications get fixed
       window.focus();
 
       // Apple-Click, not selected
-    } else if (!row.isSelected() && meta_key) {
+    } else if (
+      !row.isSelected() &&
+      (event_.target.classList.contains('select') || meta_key)
+    ) {
       this._selectRow(row);
 
       // Regular Click, not selected
@@ -813,7 +819,10 @@ TODO: fix this when notifications get fixed
       this._setSelectedRow(row);
 
       // Apple-Click, selected
-    } else if (row.isSelected() && meta_key) {
+    } else if (
+      row.isSelected() &&
+      (event_.target.classList.contains('select') || meta_key)
+    ) {
       this._deselectRow(row);
 
       // Regular Click, selected


### PR DESCRIPTION
New checkbox appearing only when torrent is selected, they're cues to multiple torrents selection. There is a larger click area beneath supposedly taking over entire area of the torrent icon reserved for multiple torrent selection. See screenshot for click area in blue + purple.

![Transmission select area](https://github.com/user-attachments/assets/77bfae29-4f36-49fa-b6ec-88e7aa5cd77b)
![Transmission select compact area](https://github.com/user-attachments/assets/0e9c878d-0872-4515-b8a7-e0986bdd87a6)

<details>
<summary>Screenshot diffs</summary>

Top: This PR, Bottom: Original
![Transmission select](https://github.com/user-attachments/assets/e534878c-ff60-44af-b9a5-b7cbbee00b64)

Compact layout
![Transmission select compact](https://github.com/user-attachments/assets/58d6ca08-acd0-4639-8473-fb9c61f81ce4)
</details>

Notes: Select multiple torrents without keyboard by having a small portion to the left (taking over icon area) reserved for alternative selection.