### PR TITLE
fix: handle nullptr in json serde

### DIFF
--- a/libtransmission/variant-json.cc
+++ b/libtransmission/variant-json.cc
@@ -203,11 +203,11 @@ private:
 
 std::optional<tr_variant> tr_variant_serde::parse_json(std::string_view input)
 {
-    auto* const begin = std::data(input);
-    TR_ASSERT(begin != nullptr); // RapidJSON will dereference a nullptr if this is false
+    auto* begin = std::data(input);
     if (begin == nullptr)
     {
-        return {};
+        // RapidJSON will dereference a nullptr otherwise
+        begin = "";
     }
 
     auto const size = std::size(input);

--- a/tests/libtransmission/json-test.cc
+++ b/tests/libtransmission/json-test.cc
@@ -11,6 +11,7 @@
 #include <string>
 #include <string_view>
 
+#include <libtransmission/crypto-utils.h>
 #include <libtransmission/quark.h>
 #include <libtransmission/utils.h>
 #include <libtransmission/variant.h>
@@ -237,6 +238,23 @@ TEST_P(JSONTest, unescape)
     auto sv = std::string_view{};
     EXPECT_TRUE(tr_variantDictFindStrView(&var, tr_quark_new("string-1"sv), &sv));
     EXPECT_EQ("/usr/lib"sv, sv);
+}
+
+TEST_P(JSONTest, parseJsonFuzz)
+{
+    auto serde = tr_variant_serde::json().inplace();
+
+    auto var = serde.parse({ nullptr, 0U });
+    EXPECT_FALSE(var);
+
+    auto buf = std::vector<char>{};
+    for (size_t i = 0; i < 100000U; ++i)
+    {
+        buf.resize(tr_rand_int(1024U));
+        tr_rand_buffer(std::data(buf), std::size(buf));
+
+        (void)serde.parse({ std::data(buf), std::size(buf) });
+    }
 }
 
 INSTANTIATE_TEST_SUITE_P( //


### PR DESCRIPTION
Accept a `std::string_view` input that points to `nullptr` as a normal case in the json serde.

The RPC server uses `evbuffer_pullup()` to get a contiguous buffer to be passed to the json serde. Apparantly `evbuffer_pullup()` can return `nullptr` when the buffer is empty, which can be triggered using this curl command:

```console
$ curl -X POST --data '' -H "X-Transmission-Session-Id: ${session_id}" localhost:9091/transmission/rpc
```

And in the current code, this will trigger an assert failure.