### PR TITLE
feat: submenu to group away context menu items

### DIFF
--- a/web/assets/css/transmission-app.scss
+++ b/web/assets/css/transmission-app.scss
@@ -1313,9 +1313,83 @@ a {
   border-radius: 5px;
   color: var(--color-fg-on-popup);
   padding: 10px 5px;
-  z-index: 9999;
+  z-index: 2;
   user-select: none;
   -webkit-user-select: none;
+
+  .context-arrow {
+    border-top: 4px solid transparent;
+    border-bottom: 4px solid transparent;
+    border-left: 4px solid var(--color-fg-secondary);
+    float: right;
+    left: 5px;
+    pointer-events: none;
+    position: relative;
+    top: 5px;
+
+    .context-submenu {
+      display: none;
+      margin: 0 3px;
+      pointer-events: auto;
+      position: absolute;
+      overflow: hidden;
+      transform: translate(7px, -18px);
+      z-index: 3;
+      border-radius: 5px;
+      animation: shadow 400ms linear 1 normal forwards;
+
+      @keyframes shadow {
+        0% {
+          box-shadow: 0;
+        }
+        100% {
+          box-shadow:
+            0 3px 6px -4px rgba(0, 0, 0, 0.12),
+            0 6px 16px rgba(0, 0, 0, 0.08),
+            0 9px 28px 8px rgba(0, 0, 0, 0.06);
+        }
+      }
+
+      .poppy {
+        background-color: var(--color-bg-primary);
+        border-radius: 5px;
+        color: var(--color-fg-on-popup);
+        padding: 5px;
+        right: 0;
+        white-space: nowrap;
+
+        &.left {
+          position: relative;
+          display: block;
+          animation: left 200ms linear 1 normal forwards;
+        }
+
+        &.right {
+          position: relative;
+          display: block;
+          animation: right 200ms linear 1 normal forwards;
+        }
+
+        @keyframes left {
+          0% {
+            transform: translateX(100%);
+          }
+          100% {
+            transform: translateX(0%);
+          }
+        }
+        
+        @keyframes right {
+          0% {
+            transform: translateX(-100%);
+          }
+          100% {
+            transform: translateX(0%);
+          }
+        }
+      }
+    }
+  }
 
   .context-menuitem {
     font-size: 13px;

--- a/web/src/context-menu.js
+++ b/web/src/context-menu.js
@@ -73,36 +73,115 @@ export class ContextMenu extends EventTarget {
         this.close();
       });
       actions[action] = item;
-      root.append(item);
+      return item;
     };
 
     const add_separator = () => {
       const item = document.createElement('div');
       item.classList.add('context-menu-separator');
-      root.append(item);
+      return item;
     };
 
-    add_item('resume-selected-torrents');
-    add_item('resume-selected-torrents-now');
-    add_item('pause-selected-torrents');
-    add_separator();
-    add_item('move-top');
-    add_item('move-up');
-    add_item('move-down');
-    add_item('move-bottom');
-    add_separator();
-    add_item('remove-selected-torrents', true);
-    add_item('trash-selected-torrents', true);
-    add_separator();
-    add_item('verify-selected-torrents');
-    add_item('show-move-dialog');
-    add_item('show-rename-dialog');
-    add_item('show-labels-dialog');
-    add_separator();
-    add_item('reannounce-selected-torrents');
-    add_separator();
-    add_item('select-all');
-    add_item('deselect-all');
+    const add_submenu = (e) => {
+      e.addEventListener('mousedown', (e_) => {
+        const t = e.lastChild.lastChild;
+        if (
+          !e_.target.classList.contains('right') &&
+          !e_.target.parentNode.classList.contains('right') &&
+          !e_.target.classList.contains('left') &&
+          !e_.target.parentNode.classList.contains('left') &&
+          t.style.display === 'block'
+        ) {
+          root.dismissed = true;
+          t.style.display = 'none';
+        }
+      });
+
+      e.addEventListener('click', () => {
+        if (root.dismissed) {
+          root.dismissed = false;
+          return;
+        }
+
+        for (const p of document.querySelectorAll('.context-submenu')) {
+          p.style.display = 'none';
+        }
+
+        const t = e.lastChild.lastChild;
+        t.style.display = 'block';
+        const where = e.getBoundingClientRect();
+        const wheret = t.lastChild.getBoundingClientRect();
+        const y = Math.min(
+          0,
+          document.documentElement.clientHeight - window.visualViewport.offsetTop - where.top - t.clientHeight + 3,
+        );
+        const x = Math.min(
+          0,
+          document.documentElement.clientWidth - window.visualViewport.offsetLeft - where.right - t.clientWidth - 3,
+        );
+
+        t.style.top = y + 'px';
+        if (x) {
+          t.lastChild.classList = 'poppy left';
+          t.style.left = -where.width - wheret.width + 'px';
+        } else {
+          t.lastChild.classList = 'poppy right';
+          t.style.left = x + 'px';
+        }
+      });
+    };
+
+    const add_arrow = (text, ...args) => {
+      const arrow = document.createElement('DIV');
+      arrow.classList = 'poppy right';
+
+      for (const arg of args) {
+        arrow.append(add_item(arg));
+      };
+
+      const e = document.createElement('DIV');
+      e.textContent = text;
+      e.classList.add('context-menuitem');
+
+      const a = document.createElement('DIV');
+      a.classList = 'context-arrow';
+
+      const p = document.createElement('DIV');
+      p.classList = 'context-submenu';
+
+      p.append(arrow);
+      a.append(p);
+      e.append(a);
+
+      add_submenu(e);
+
+      return e;
+    }
+
+    root.dismissed = false;
+
+    root.append(
+      add_item('resume-selected-torrents'),
+      add_item('resume-selected-torrents-now'),
+      add_item('pause-selected-torrents'),
+      add_separator(),
+      add_item('move-top'),
+      add_item('move-up'),
+      add_item('move-down'),
+      add_item('move-bottom'),
+      add_separator(),
+      add_item('remove-selected-torrents', true),
+      add_item('trash-selected-torrents', true),
+      add_separator(),
+      add_item('verify-selected-torrents'),
+      add_item('show-move-dialog'),
+      add_item('show-rename-dialog'),
+      add_item('show-labels-dialog'),
+      add_separator(),
+      add_item('reannounce-selected-torrents'),
+      add_separator(),
+      add_arrow('Select operation', 'select-all', 'deselect-all'),
+    );
 
     return { actions, root };
   }


### PR DESCRIPTION
Left: This PR, Right: Original
![Transmission submenu](https://github.com/user-attachments/assets/7bfecf0e-48cd-4932-94e8-5273738ae7b7)

Submenu can come in handy for addition of new items about to be introduced by #6681
#7000 will eventually remove one context item so not good candidate for new submenu

Notes: Added submenu to group away context menu items.