### PR TITLE
fix: utilize gigabyte per second to conserve space and upload arrow clipping fix

### DIFF
--- a/web/assets/css/transmission-app.scss
+++ b/web/assets/css/transmission-app.scss
@@ -409,8 +409,8 @@ a {
     align-items: inherit;
     flex-direction: inherit;
 
-    &:not(:nth-child(1 of #mainwin-statusbar .speed-container)) {
-      width: 100px;
+    + .speed-container {
+      min-width: 100px;
     }
   }
 

--- a/web/src/formatter.js
+++ b/web/src/formatter.js
@@ -51,6 +51,11 @@ const fmt_MBps = new Intl.NumberFormat(current_locale, {
   style: 'unit',
   unit: 'megabyte-per-second',
 });
+const fmt_GBps = new Intl.NumberFormat(current_locale, {
+  maximumFractionDigits: 2,
+  style: 'unit',
+  unit: 'gigabyte-per-second',
+});
 
 export const Formatter = {
   /** Round a string of a number to a specified number of decimal places */
@@ -122,7 +127,13 @@ export const Formatter = {
   },
 
   speed(KBps) {
-    return KBps < 999.95 ? fmt_kBps.format(KBps) : fmt_MBps.format(KBps / 1000);
+    if (KBps < 999.95) {
+      return fmt_kBps.format(KBps);
+    } else if (KBps < 999950) {
+      return fmt_MBps.format(KBps / 1000);
+    } else {
+      return fmt_GBps.format(KBps / 1000000);
+    }
   },
 
   speedBps(Bps) {

--- a/web/src/formatter.js
+++ b/web/src/formatter.js
@@ -129,11 +129,10 @@ export const Formatter = {
   speed(KBps) {
     if (KBps < 999.95) {
       return fmt_kBps.format(KBps);
-    } else if (KBps < 999950) {
+    } else if (KBps < 999_950) {
       return fmt_MBps.format(KBps / 1000);
-    } else {
-      return fmt_GBps.format(KBps / 1000000);
     }
+    return fmt_GBps.format(KBps / 1_000_000);
   },
 
   speedBps(Bps) {


### PR DESCRIPTION
Top: This PR, Bottom: Original
![Transmission GBps](https://github.com/user-attachments/assets/4067c9dc-3ff5-473b-b818-c1aa531c90a5)

Additionally this includes a fix to upload arrow clipping out of bound in the right screen due to `width` disallowing growth, it's now replaced with `min-width` to allow growth.

Notes: updated displaying number in new gigabyte per second unit