### PR TITLE
ui(webui): contract main area for inspector for large viewports

### DIFF
--- a/web/assets/css/transmission-app.scss
+++ b/web/assets/css/transmission-app.scss
@@ -12,6 +12,12 @@
   }
 }
 
+@mixin viewport-large {
+  @media (width >= 950px) {
+    @content;
+  }
+}
+
 :root {
   /* z-index enum */
   --z-index-popup: 2;
@@ -813,6 +819,10 @@ a {
   @include for-tablet-portrait-up {
     border-left: 1px solid var(--color-border-default);
     width: 570px;
+  }
+
+  @include viewport-large {
+    position: initial;
   }
 }
 

--- a/web/src/inspector.js
+++ b/web/src/inspector.js
@@ -43,7 +43,7 @@ export class Inspector extends EventTarget {
     );
     this._setTorrents(this.controller.getSelectedTorrents());
 
-    document.body.append(this.elements.root);
+    document.querySelector('#mainwin-workarea').append(this.elements.root);
   }
 
   close() {


### PR DESCRIPTION
Fixes #7050

An alternative to #7051.

The main difference with @Rukario's PR is that this implementation does not create a dummy `<div>` that's hard-coded to have the same width as the inspector panel. Instead, it lets the inspector panel naturally occupy space.

A small side effect is that the inspector panel no longer covers the status bar when occupying space, but I don't think that's a bad thing.

#### Before

![image](https://github.com/user-attachments/assets/c1b14aac-28bb-498e-a686-96cbd6510dc6)

#### After

![image](https://github.com/user-attachments/assets/2d424b4a-44ca-4539-a5d1-a5849c9914c4)
