### PR TITLE
refactor: softcode/consolidate strings in `torrent-row.js`, normal appendChild order for compact mode

### DIFF
--- a/web/assets/css/transmission-app.scss
+++ b/web/assets/css/transmission-app.scss
@@ -570,11 +570,9 @@ a {
 
       align-items: center;
       display: flex;
-      flex-direction: row-reverse;
 
       .icon {
         -webkit-mask-size: var(--icon-size), calc(var(--icon-size) / 2);
-        flex-shrink: 0;
         height: var(--icon-size);
         mask-size: var(--icon-size), calc(var(--icon-size) / 2);
         width: var(--icon-size);

--- a/web/src/torrent-row.js
+++ b/web/src/torrent-row.js
@@ -220,19 +220,26 @@ export class TorrentRendererFull {
   render(controller, torrent, root) {
     const is_stopped = torrent.isStopped();
     root.classList.toggle('paused', is_stopped);
-    const { button, progressbar } = root;
+    const {
+      button,
+      labels,
+      name,
+      peer_details,
+      progressbar,
+      progress_details,
+    } = root;
 
     // name
-    setTextContent(root.name, torrent.getName());
+    setTextContent(name, torrent.getName());
 
     // labels
-    TorrentRendererHelper.formatLabels(torrent, root.labels);
+    TorrentRendererHelper.formatLabels(torrent, labels);
 
     // progress details
     TorrentRendererFull.renderProgressDetails(
       controller,
       torrent,
-      root.progress_details);
+      progress_details);
 
     // progressbar
     TorrentRendererHelper.renderProgressbar(controller, torrent, progressbar);
@@ -243,7 +250,7 @@ export class TorrentRendererFull {
     button.dataset.action = is_stopped ? 'resume' : 'pause';
 
     // peer details
-    TorrentRendererFull.renderPeerDetails(torrent, root.peer_details);
+    TorrentRendererFull.renderPeerDetails(torrent, peer_details);
   }
 
   // eslint-disable-next-line class-methods-use-this
@@ -334,18 +341,18 @@ export class TorrentRendererCompact {
   // eslint-disable-next-line class-methods-use-this
   render(controller, torrent, root) {
     root.classList.toggle('paused', torrent.isStopped());
+    const { labels, name, peer_details, progressbar } = root;
 
     // name
-    setTextContent(root.name, torrent.getName());
+    setTextContent(name, torrent.getName());
 
     // labels
-    TorrentRendererHelper.formatLabels(torrent, root.labels);
+    TorrentRendererHelper.formatLabels(torrent, labels);
 
     // peer details
-    TorrentRendererCompact.renderPeerDetails(torrent, root.peer_details);
+    TorrentRendererCompact.renderPeerDetails(torrent, peer_details);
 
     // progressbar
-    const { progressbar } = root;
     TorrentRendererHelper.renderProgressbar(controller, torrent, progressbar);
     progressbar.classList.add('compact');
   }

--- a/web/src/torrent-row.js
+++ b/web/src/torrent-row.js
@@ -74,10 +74,7 @@ const TorrentRendererHelper = {
   },
   symbol: { down: '▼', up: '▲' },
   updateIcon: (e, torrent) => {
-    e.dataset.iconMimeType = torrent
-      .getPrimaryMimeType()
-      .split('/', 1)
-      .pop();
+    e.dataset.iconMimeType = torrent.getPrimaryMimeType().split('/', 1).pop();
     e.dataset.iconMultifile = torrent.getFileCount() > 1 ? 'true' : 'false';
   },
 };
@@ -239,7 +236,8 @@ export class TorrentRendererFull {
     TorrentRendererFull.renderProgressDetails(
       controller,
       torrent,
-      progress_details);
+      progress_details,
+    );
 
     // progressbar
     TorrentRendererHelper.renderProgressbar(controller, torrent, progressbar);
@@ -272,7 +270,7 @@ export class TorrentRendererFull {
       e.className = className;
       root.append(e);
       root[name] = e;
-    };
+    }
 
     TorrentRendererHelper.updateIcon(root.icon, torrent);
 
@@ -375,7 +373,7 @@ export class TorrentRendererCompact {
       e.className = className;
       root.append(e);
       root[name] = e;
-    };
+    }
 
     TorrentRendererHelper.updateIcon(root.icon, torrent);
 

--- a/web/src/torrent-row.js
+++ b/web/src/torrent-row.js
@@ -19,9 +19,6 @@ const TorrentRendererHelper = {
     return icon;
   },
 
-  formatDL: (t) => {
-    return `▼ ${Formatter.speedBps(t.getDownloadSpeed())}`;
-  },
   formatETA: (t) => {
     const eta = t.getETA();
     if (eta < 0 || eta >= 999 * 60 * 60) {
@@ -39,9 +36,7 @@ const TorrentRendererHelper = {
       label.append(s);
     }
   },
-  formatUL: (t) => {
-    return `▲ ${Formatter.speedBps(t.getUploadSpeed())}`;
-  },
+
   getProgressInfo: (controller, t) => {
     const status = t.getStatus();
     const classList = ['torrent-progress-bar'];
@@ -81,7 +76,6 @@ const TorrentRendererHelper = {
       ratio,
     };
   },
-
   renderProgressbar: (controller, t, progressbar) => {
     const info = TorrentRendererHelper.getProgressInfo(controller, t);
     const percent = Math.min(info.ratio || info.percent, 100);
@@ -90,130 +84,123 @@ const TorrentRendererHelper = {
     progressbar.style.setProperty('--progress', pct_str);
     progressbar.dataset.progress = info.ratio ? '100%' : pct_str;
   },
+  symbol: { down: '▼', up: '▲' },
 };
 
 ///
 
 export class TorrentRendererFull {
-  static getPeerDetails(t) {
+  static renderPeerDetails(t, peer_details) {
     const fmt = Formatter;
+
+    const has_error = t.getError() !== Torrent._ErrNone;
+    peer_details.classList.toggle('error', has_error);
 
     const error = t.getErrorMessage();
     if (error) {
-      return error;
-    }
-
-    if (t.isDownloading()) {
+      setTextContent(peer_details, error);
+    } else if (t.isDownloading()) {
       const peer_count = t.getPeersConnected();
       const webseed_count = t.getWebseedsSendingToUs();
-
-      if (webseed_count && peer_count) {
-        // Downloading from 2 of 3 peer(s) and 2 webseed(s)
-        return [
-          'Downloading from',
+      const s = ['Downloading from'];
+      if (peer_count) {
+        s.push(
           t.getPeersSendingToUs(),
           'of',
           fmt.countString('peer', 'peers', peer_count),
-          'and',
-          fmt.countString('web seed', 'web seeds', webseed_count),
-          '–',
-          TorrentRendererHelper.formatDL(t),
-          TorrentRendererHelper.formatUL(t),
-        ].join(' ');
+        );
+        if (webseed_count) {
+          s.push('and');
+        }
       }
       if (webseed_count) {
-        // Downloading from 2 webseed(s)
-        return [
-          'Downloading from',
-          fmt.countString('web seed', 'web seeds', webseed_count),
-          '–',
-          TorrentRendererHelper.formatDL(t),
-          TorrentRendererHelper.formatUL(t),
-        ].join(' ');
+        s.push(fmt.countString('web seed', 'web seeds', webseed_count));
       }
-
-      // Downloading from 2 of 3 peer(s)
-      return [
-        'Downloading from',
-        t.getPeersSendingToUs(),
-        'of',
-        fmt.countString('peer', 'peers', peer_count),
-        '–',
-        TorrentRendererHelper.formatDL(t),
-        TorrentRendererHelper.formatUL(t),
-      ].join(' ');
-    }
-
-    if (t.isSeeding()) {
-      return [
+      s.push(
+        '-',
+        TorrentRendererHelper.symbol.down,
+        fmt.speedBps(t.getDownloadSpeed()),
+        TorrentRendererHelper.symbol.up,
+        fmt.speedBps(t.getUploadSpeed()),
+      );
+      setTextContent(peer_details, s.join(' '));
+    } else if (t.isSeeding()) {
+      const str = [
         'Seeding to',
         t.getPeersGettingFromUs(),
         'of',
         fmt.countString('peer', 'peers', t.getPeersConnected()),
         '-',
-        TorrentRendererHelper.formatUL(t),
+        TorrentRendererHelper.symbol.up,
+        fmt.speedBps(t.getUploadSpeed()),
       ].join(' ');
-    }
-
-    if (t.isChecking()) {
-      return [
+      setTextContent(peer_details, str);
+    } else if (t.isChecking()) {
+      const str = [
         'Verifying local data (',
-        Formatter.percentString(100 * t.getRecheckProgress(), 1),
+        fmt.percentString(100 * t.getRecheckProgress(), 1),
         '% tested)',
       ].join('');
+      setTextContent(peer_details, str);
+    } else {
+      setTextContent(peer_details, t.getStateString());
     }
-
-    return t.getStateString();
   }
 
-  static getProgressDetails(controller, t) {
+  static renderProgressDetails(controller, t, progress_details) {
+    const fmt = Formatter;
+
     if (t.needsMetaData()) {
       let MetaDataStatus = 'retrieving';
       if (t.isStopped()) {
         MetaDataStatus = 'needs';
       }
       const percent = 100 * t.getMetadataPercentComplete();
-      return [
-        `Magnetized transfer - ${MetaDataStatus} metadata (`,
-        Formatter.percentString(percent, 1),
+      const str = [
+        'Magnetized transfer - ',
+        MetaDataStatus,
+        ' metadata (',
+        fmt.percentString(percent, 1),
         '%)',
       ].join('');
+      setTextContent(progress_details, str);
+      return;
     }
 
     const sizeWhenDone = t.getSizeWhenDone();
     const totalSize = t.getTotalSize();
     const is_done = t.isDone() || t.isSeeding();
-    const c = [];
+    const s = [];
 
     if (is_done) {
       if (totalSize === sizeWhenDone) {
         // seed: '698.05 MiB'
-        c.push(Formatter.size(totalSize));
+        s.push(fmt.size(totalSize));
       } else {
         // partial seed: '127.21 MiB of 698.05 MiB (18.2%)'
-        c.push(
-          Formatter.size(sizeWhenDone),
+        s.push(
+          fmt.size(sizeWhenDone),
           ' of ',
-          Formatter.size(t.getTotalSize()),
+          fmt.size(t.getTotalSize()),
           ' (',
           t.getPercentDoneStr(),
           '%)',
         );
       }
       // append UL stats: ', uploaded 8.59 GiB (Ratio: 12.3)'
-      c.push(
+      s.push(
         ', uploaded ',
-        Formatter.size(t.getUploadedEver()),
-        ' (Ratio ',
-        Formatter.ratioString(t.getUploadRatio()),
+        fmt.size(t.getUploadedEver()),
+        ' (Ratio: ',
+        fmt.ratioString(t.getUploadRatio()),
         ')',
       );
     } else {
       // not done yet
-      c.push(
-        Formatter.size(sizeWhenDone - t.getLeftUntilDone()),
+      s.push(
+        fmt.size(sizeWhenDone - t.getLeftUntilDone()),
         ' of ',
-        Formatter.size(sizeWhenDone),
+        fmt.size(sizeWhenDone),
         ' (',
         t.getPercentDoneStr(),
         '%)',
@@ -222,16 +209,16 @@ export class TorrentRendererFull {
 
     // maybe append eta
     if (!t.isStopped() && (!is_done || t.seedRatioLimit(controller) > 0)) {
-      c.push(' - ');
+      s.push(' - ');
       const eta = t.getETA();
       if (eta < 0 || eta >= 999 * 60 * 60 /* arbitrary */) {
-        c.push('remaining time unknown');
+        s.push('remaining time unknown');
       } else {
-        c.push(Formatter.timeInterval(t.getETA(), 1), ' remaining');
+        s.push(fmt.timeInterval(t.getETA(), 1), ' remaining');
       }
     }
 
-    return c.join('');
+    setTextContent(progress_details, s.join(''));
   }
 
   // eslint-disable-next-line class-methods-use-this
@@ -241,30 +228,29 @@ export class TorrentRendererFull {
     root.classList.toggle('paused', is_stopped);
 
     // name
-    let e = root._name_container;
-    setTextContent(e, t.getName());
+    setTextContent(root._name_container, t.getName());
 
     // labels
     TorrentRendererHelper.formatLabels(t, root._labels_container);
 
     // progress details
-    e = root._progress_details_container;
-    e.innerHTML = TorrentRendererFull.getProgressDetails(controller, t);
+    TorrentRendererFull.renderProgressDetails(
+      controller,
+      t,
+      root._progress_details_container,
+    );
 
     // progressbar
     TorrentRendererHelper.renderProgressbar(controller, t, root._progressbar);
     root._progressbar.classList.add('full');
 
-    // peer details
-    const has_error = t.getError() !== Torrent._ErrNone;
-    e = root._peer_details_container;
-    e.classList.toggle('error', has_error);
-    setTextContent(e, TorrentRendererFull.getPeerDetails(t));
-
     // pause/resume button
-    e = root._toggle_running_button;
-    e.alt = is_stopped ? 'Resume' : 'Pause';
-    e.dataset.action = is_stopped ? 'resume' : 'pause';
+    const button = root._toggle_running_button;
+    button.alt = is_stopped ? 'Resume' : 'Pause';
+    button.dataset.action = is_stopped ? 'resume' : 'pause';
+
+    // peer details
+    TorrentRendererFull.renderPeerDetails(t, root._peer_details_container);
   }
 
   // eslint-disable-next-line class-methods-use-this
@@ -272,38 +258,42 @@ export class TorrentRendererFull {
     const root = document.createElement('li');
     root.className = 'torrent';
 
-    const icon = TorrentRendererHelper.createIcon(torrent);
-
     const name = document.createElement('div');
     name.className = 'torrent-name';
+
     const labels = document.createElement('div');
     labels.className = 'torrent-labels';
-    const details = document.createElement('div');
-    details.className = 'torrent-progress-details';
-    const progress = document.createElement('div');
-    progress.classList.add('torrent-progress');
+
+    const progress_details = document.createElement('div');
+    progress_details.className = 'torrent-progress-details';
+
     const progressbar = document.createElement('div');
-    progressbar.classList.add('torrent-progress-bar', 'full');
-    progress.append(progressbar);
-    const peers = document.createElement('div');
-    peers.className = 'torrent-peer-details';
+    progressbar.className = 'torrent-progress-bar full';
+
     const button = document.createElement('a');
     button.className = 'torrent-pauseresume-button';
-    progress.append(button);
 
-    root.append(icon);
-    root.append(name);
-    root.append(labels);
-    root.append(details);
-    root.append(progress);
-    root.append(peers);
+    const progress = document.createElement('div');
+    progress.className = 'torrent-progress';
+    progress.append(progressbar, button);
 
-    root._icon = icon;
+    const peer_details = document.createElement('div');
+    peer_details.className = 'torrent-peer-details';
+
+    root.append(
+      TorrentRendererHelper.createIcon(torrent),
+      name,
+      labels,
+      progress_details,
+      progress,
+      peer_details,
+    );
+
     root._name_container = name;
     root._labels_container = labels;
-    root._progress_details_container = details;
+    root._progress_details_container = progress_details;
     root._progressbar = progressbar;
-    root._peer_details_container = peers;
+    root._peer_details_container = peer_details;
     root._toggle_running_button = button;
 
     return root;
@@ -313,34 +303,49 @@ export class TorrentRendererFull {
 ///
 
 export class TorrentRendererCompact {
-  static getPeerDetails(t) {
-    const errorMessage = t.getErrorMessage();
-    if (errorMessage) {
-      return errorMessage;
-    }
-    if (t.isDownloading()) {
+  static renderPeerDetails(t, peer_details) {
+    const fmt = Formatter;
+
+    const has_error = t.getError() !== Torrent._ErrNone;
+    peer_details.classList.toggle('error', has_error);
+
+    const error = t.getErrorMessage();
+    if (error) {
+      setTextContent(peer_details, error);
+    } else if (t.isDownloading()) {
       const have_dn = t.getDownloadSpeed() > 0;
       const have_up = t.getUploadSpeed() > 0;
 
       if (!have_up && !have_dn) {
-        return 'Idle';
+        setTextContent(peer_details, 'Idle');
+      } else {
+        const s = [TorrentRendererHelper.formatETA(t)];
+        if (have_dn) {
+          s.push(
+            TorrentRendererHelper.symbol.down,
+            fmt.speedBps(t.getDownloadSpeed()),
+          );
+        }
+        if (have_up) {
+          s.push(
+            TorrentRendererHelper.symbol.up,
+            fmt.speedBps(t.getUploadSpeed()),
+          );
+        }
+        setTextContent(peer_details, s.join(' '));
       }
-
-      const s = [`${TorrentRendererHelper.formatETA(t)} `];
-      if (have_dn) {
-        s.push(TorrentRendererHelper.formatDL(t));
-      }
-      if (have_up) {
-        s.push(TorrentRendererHelper.formatUL(t));
-      }
-      return s.join(' ');
+    } else if (t.isSeeding()) {
+      const str = [
+        'Ratio:',
+        fmt.ratioString(t.getUploadRatio()),
+        '-',
+        TorrentRendererHelper.symbol.up,
+        fmt.speedBps(t.getUploadSpeed()),
+      ].join(' ');
+      setTextContent(peer_details, str);
+    } else {
+      setTextContent(peer_details, t.getStateString());
     }
-    if (t.isSeeding()) {
-      return `Ratio: ${Formatter.ratioString(
-        t.getUploadRatio(),
-      )}, ${TorrentRendererHelper.formatUL(t)}`;
-    }
-    return t.getStateString();
   }
 
   // eslint-disable-next-line class-methods-use-this
@@ -348,50 +353,49 @@ export class TorrentRendererCompact {
     root.classList.toggle('paused', t.isStopped());
 
     // name
-    let e = root._name_container;
-    setTextContent(e, t.getName());
+    setTextContent(root._name_container, t.getName());
 
     // labels
     TorrentRendererHelper.formatLabels(t, root._labels_container);
 
+    // peer details
+    TorrentRendererCompact.renderPeerDetails(t, root._details_container);
+
     // progressbar
     TorrentRendererHelper.renderProgressbar(controller, t, root._progressbar);
     root._progressbar.classList.add('compact');
-
-    // peer details
-    const has_error = t.getError() !== Torrent._ErrNone;
-    e = root._details_container;
-    e.classList.toggle('error', has_error);
-    setTextContent(e, TorrentRendererCompact.getPeerDetails(t));
   }
 
   // eslint-disable-next-line class-methods-use-this
   createRow(torrent) {
-    const progressbar = document.createElement('div');
-    progressbar.classList.add('torrent-progress-bar', 'compact');
-
-    const icon = TorrentRendererHelper.createIcon(torrent);
-
-    const details = document.createElement('div');
-    details.className = 'torrent-peer-details compact';
-
-    const labels = document.createElement('div');
-    labels.className = 'torrent-labels compact';
+    const root = document.createElement('li');
+    root.className = 'torrent compact';
 
     const name = document.createElement('div');
     name.className = 'torrent-name compact';
 
-    const root = document.createElement('li');
-    root.append(progressbar);
-    root.append(details);
-    root.append(labels);
-    root.append(name);
-    root.append(icon);
-    root.className = 'torrent compact';
-    root._progressbar = progressbar;
-    root._details_container = details;
-    root._labels_container = labels;
+    const labels = document.createElement('div');
+    labels.className = 'torrent-labels compact';
+
+    const peer_details = document.createElement('div');
+    peer_details.className = 'torrent-peer-details compact';
+
+    const progressbar = document.createElement('div');
+    progressbar.className = 'torrent-progress-bar compact';
+
+    root.append(
+      TorrentRendererHelper.createIcon(torrent),
+      name,
+      labels,
+      peer_details,
+      progressbar,
+    );
+
     root._name_container = name;
+    root._labels_container = labels;
+    root._details_container = peer_details;
+    root._progressbar = progressbar;
+
     return root;
   }
 }


### PR DESCRIPTION
Has also been refactored to giving parent object to respective function hence their name change `get` -> `render`. One with most returns are being replaced directly with appending method, I haven't consolidate them as in possible future there would be different mix of appending methods i.e. `appendChild()` instead of `textContent` (inside `setTextContent()`) to handle possible not text objects such as SVGs, that would allow flexible exchanging of per-torrent speed down and up symbols.