### PR TITLE
fix: obtain session lock before getting tor ptr

### DIFF
--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1603,21 +1603,16 @@ void tr_torrentVerify(tr_torrent* tor)
     tor->session->run_in_session_thread(
         [session = tor->session, tor_id = tor->id()]()
         {
+            TR_ASSERT(session->am_in_session_thread());
+            auto const lock = session->unique_lock();
+
             auto* const tor = session->torrents().get(tor_id);
-            if (tor == nullptr)
+            if (tor == nullptr || tor->is_deleting_)
             {
                 return;
             }
 
-            TR_ASSERT(tor->session->am_in_session_thread());
-            auto const lock = tor->unique_lock();
-
-            if (tor->is_deleting_)
-            {
-                return;
-            }
-
-            tor->session->verify_remove(tor);
+            session->verify_remove(tor);
 
             if (!tor->has_metainfo())
             {
@@ -1637,7 +1632,7 @@ void tr_torrentVerify(tr_torrent* tor)
                 tor->start_when_stable_ = false;
             }
 
-            tor->session->verify_add(tor);
+            session->verify_add(tor);
         });
 }
 


### PR DESCRIPTION
Fixing up some code from affb03a8d2c7393b54542439c9c5dcfb4ded01ae.