### PR TITLE
Fix MacStadium opensource URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ See [language translations](docs/Translating.md).
  <tbody>
   <tr>
    <td align="center"><img alt="[MacStadium]" src="https://uploads-ssl.webflow.com/5ac3c046c82724970fc60918/5c019d917bba312af7553b49_MacStadium-developerlogo.png" height="30"/></td>
-   <td>macOS CI builds are running on a M1 Mac Mini provided by <a href="https://www.macstadium.com/opensource">MacStadium</a></td>
+   <td>macOS CI builds are running on a M1 Mac Mini provided by <a href="https://www.macstadium.com/company/opensource">MacStadium</a></td>
   </tr>
   <tr>
    <td align="center"><img alt="[SignPath]" src="https://avatars.githubusercontent.com/u/34448643" height="30"/></td>


### PR DESCRIPTION
Replace https://www.macstadium.com/opensource with https://www.macstadium.com/company/opensource, as the former results in 404.