### PR TITLE
fix: close context menu with a click outside listener

### DIFF
--- a/web/src/context-menu.js
+++ b/web/src/context-menu.js
@@ -3,7 +3,7 @@
    or any future license endorsed by Mnemosyne LLC.
    License text can be found in the licenses/ folder. */
 
-import { setEnabled } from './utils.js';
+import { OutsideClickListener, setEnabled } from './utils.js';
 
 export class ContextMenu extends EventTarget {
   constructor(action_manager) {
@@ -14,6 +14,10 @@ export class ContextMenu extends EventTarget {
     this.action_manager.addEventListener('change', this.action_listener);
 
     Object.assign(this, this._create());
+
+    this.outside = new OutsideClickListener(this.root);
+    this.outside.addEventListener('click', () => this.close());
+
     this.show();
   }
 
@@ -26,6 +30,7 @@ export class ContextMenu extends EventTarget {
 
   close() {
     if (!this.closed) {
+      this.outside.stop();
       this.action_manager.removeEventListener('change', this.action_listener);
       this.root.remove();
       this.dispatchEvent(new Event('close'));


### PR DESCRIPTION
The issue became pronounced when I work on another PR that allows multiple popups. Problem isn't easily apparent but if you click anywhere other than the torrent list e.g. into the toolbar, the context menu does not always dismiss. This should fix it.

Notes: Fixed an issue where Transmission web's custom context menu does not close when clicking on some outside element.