### PR TITLE
refactor: allow downloading torrents to steal connection slots

### DIFF
--- a/libtransmission/net.cc
+++ b/libtransmission/net.cc
@@ -233,9 +233,8 @@ tr_peer_socket tr_netOpenPeerSocket(tr_session* session, tr_socket_address const
     auto const& [addr, port] = socket_address;
 
     TR_ASSERT(addr.is_valid());
-    TR_ASSERT(!tr_peer_socket::limit_reached(session));
 
-    if (tr_peer_socket::limit_reached(session) || !session->allowsTCP() || !socket_address.is_valid())
+    if (!session->allowsTCP() || !socket_address.is_valid())
     {
         return {};
     }

--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -131,7 +131,6 @@ std::shared_ptr<tr_peerIo> tr_peerIo::new_outgoing(
     using preferred_key_t = std::underlying_type_t<tr_preferred_transport>;
     auto const preferred = session->preferred_transport();
 
-    TR_ASSERT(!tr_peer_socket::limit_reached(session));
     TR_ASSERT(session != nullptr);
     TR_ASSERT(socket_address.is_valid());
     TR_ASSERT(utp || session->allowsTCP());

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -2620,7 +2620,13 @@ void initiate_connection(tr_peerMgr* mgr, tr_swarm* s, tr_peer_info& peer_info)
     auto* const session = mgr->session;
     auto const utp = session->allowsUTP() && peer_info.supports_utp().value_or(true);
 
-    if (tr_peer_socket::limit_reached(session) || (!utp && !session->allowsTCP()))
+    // Allow downloading torrents to "steal" connection slots
+    if (tr_peer_socket::limit_reached(session) && s->tor->is_done())
+    {
+        return;
+    }
+
+    if (!utp && !session->allowsTCP())
     {
         return;
     }

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -2617,8 +2617,8 @@ void initiate_connection(tr_peerMgr* mgr, tr_swarm* s, tr_peer_info& peer_info)
     using namespace handshake_helpers;
 
     auto const now = tr_time();
-    auto const utp = mgr->session->allowsUTP() && peer_info.supports_utp().value_or(true);
     auto* const session = mgr->session;
+    auto const utp = session->allowsUTP() && peer_info.supports_utp().value_or(true);
 
     if (tr_peer_socket::limit_reached(session) || (!utp && !session->allowsTCP()))
     {


### PR DESCRIPTION
Fixes #6515.

The commit messages should be self-explanatory.

For now, I've chosen to only make the change for outgoing connections. The reason is, for incoming connections, we'd have to complete most of the BT handshake before knowing which torrent the peer is connecting for. This means a lot more fruitless handshakes than we have now.