### PR TITLE
fix: Take into account only the private that is inside info.

### DIFF
--- a/libtransmission/torrent-metainfo.cc
+++ b/libtransmission/torrent-metainfo.cc
@@ -219,7 +219,7 @@ struct MetainfoHandler final : public transmission::benc::BasicHandler<MaxBencDe
         {
             tm_.date_created_ = value;
         }
-        else if (pathIs(PrivateKey) || pathIs(InfoKey, PrivateKey))
+        else if (pathIs(InfoKey, PrivateKey))
         {
             tm_.is_private_ = value != 0;
         }


### PR DESCRIPTION
Fixes: #7302 
Take into account only the `private` flag that is inside the `info` dictionary and not elsewhere.