### PR TITLE
feat: torrent list highlight color rollback

### DIFF
--- a/web/assets/css/transmission-app.scss
+++ b/web/assets/css/transmission-app.scss
@@ -28,11 +28,11 @@
   --black: #000;
   --blue-100: #51b3f7;
   --blue-200: #357aaa;
-  --blue-300: #2c7fea;
   --blue-400: #1847d4;
   --dark-mode-black: #121212;
   --dark-mode-white: #c9d1d9;
-  --default-accent-color-dark: #0c2d6b;
+  --default-accent-color: #cdcdff;
+  --default-accent-color-strong: #b0b0ff;
   --default-border-dark: #575757;
   --default-border-light: #aeaeae;
   --default-tinted: rgba(128, 128, 144, 0.125);
@@ -95,7 +95,7 @@
     --color-bg-odd: var(--black);
     --color-bg-popup: var(--black);
     --color-bg-primary: var(--black);
-    --color-bg-selected: var(--default-accent-color-dark);
+    --color-bg-selected: var(--default-accent-color-strong);
     --color-bg-warn: #cf6679;
     --color-border-default: var(--default-border-dark);
     --color-border-stark: var(--dark-mode-white);
@@ -104,7 +104,7 @@
     --color-fg-on-popup: var(--nice-grey);
     --color-fg-primary: var(--dark-mode-white);
     --color-fg-secondary: var(--nice-grey);
-    --color-fg-selected: var(--dark-mode-white);
+    --color-fg-selected: #404040;
     --color-fg-tertiary: var(--grey-500);
     --color-fg-warn: var(--dark-mode-black);
     --color-progressbar-fg-1: #edefff;
@@ -121,7 +121,6 @@
     .contrast-more {
       --color-bg-even: var(--black);
       --color-bg-hover: var(--grey-40);
-      --color-bg-selected: var(--blue-300);
       --color-bg-tabs: var(--black);
       --color-bg-warn: #cf6679;
       --color-border-default: var(--white);
@@ -134,7 +133,7 @@
       --color-fg-port-open: var(--green-100);
       --color-fg-primary: var(--white);
       --color-fg-secondary: var(--white);
-      --color-fg-selected: var(--white);
+      --color-fg-selected: var(--black);
       --color-fg-tabs: var(--white);
       --color-fg-tertiary: var(--white);
       --color-fg-warn: var(--black);
@@ -158,7 +157,7 @@
     --color-bg-odd: var(--white);
     --color-bg-popup: var(--white);
     --color-bg-primary: var(--white);
-    --color-bg-selected: var(--blue-300);
+    --color-bg-selected: var(--default-accent-color);
     --color-bg-warn: #e4606d5b;
     --color-border-default: var(--default-border-light);
     --color-border-stark: var(--grey-500);
@@ -171,7 +170,7 @@
     --color-fg-port-open: var(--green-400);
     --color-fg-primary: #404040;
     --color-fg-secondary: var(--grey-500);
-    --color-fg-selected: var(--nice-grey);
+    --color-fg-selected: #404040;
     --color-fg-tertiary: var(--grey-500);
     --color-fg-warn: #cf212e;
     --color-progressbar-fg-1: #303030;
@@ -192,7 +191,7 @@
     .contrast-more {
       --color-bg-even: var(--white);
       --color-bg-hover: var(--grey-40);
-      --color-bg-selected: var(--blue-300);
+      --color-bg-selected: var(--default-accent-color-strong);
       --color-bg-tabs: var(--white);
       --color-bg-warn: #cf6679;
       --color-border-default: var(--black);
@@ -205,7 +204,7 @@
       --color-fg-port-open: var(--green-400);
       --color-fg-primary: var(--black);
       --color-fg-secondary: var(--black);
-      --color-fg-selected: var(--white);
+      --color-fg-selected: var(--black);
       --color-fg-tabs: var(--black);
       --color-fg-tertiary: var(--black);
       --color-fg-warn: var(--white);


### PR DESCRIPTION
I'm not satisfied with color choices for web client so I'll be rolling back colors until things are looking good enough, starting with the highlight color.

Left: This PR === Right: Transmission 3.0

![Transmission lavender legacy](https://github.com/user-attachments/assets/9ec764e9-d4d1-4713-8978-b3a32bbf01d4)

Left: This PR, Right: Original
![Transmission lavender](https://github.com/user-attachments/assets/5c8cac5c-13d8-4f94-ab33-a9d4b28c08f6)
 
Apparently it's supposed to emulate the highlight color of old Mac OS operating systems. Has the blue been doing the same thing? I'll have to look more into reasoning behind all of the color choices that changed highlight over time but it looks like lately it's emulation again. It seems to trace down to #3895. That's the thing, apparently, we CAN extract colors from system instead of emulation. Why all the changes? Now, just a big "why not" that, we'll be using the highlight color of Mac OS as fallback color not supported by browsers? I'll be making another PR soon to offer choices between "legacy" and "system" of the highlight color. I miss the old color of Transmission 3.0 too much.

Notes: Revived legacy highlight color for torrent list in Transmission web client.