### PR TITLE
#7290: Resolve group rows rendering incorrectly

### DIFF
--- a/macosx/TorrentTableView.mm
+++ b/macosx/TorrentTableView.mm
@@ -123,8 +123,8 @@ static NSTimeInterval const kToggleProgressSeconds = 0.175;
         NSMutableIndexSet* visibleIndexSet = [[NSMutableIndexSet alloc] init];
 
         [fullIndexSet enumerateIndexesUsingBlock:^(NSUInteger row, BOOL*) {
-            id rowView = [self rowViewAtRow:row makeIfNecessary:NO];
-            if ([rowView isGroupRowStyle])
+            id rowItem = [self itemAtRow:row];
+            if ([rowItem isKindOfClass:[TorrentGroup class]])
             {
                 [visibleIndexSet addIndex:row];
             }
@@ -149,8 +149,8 @@ static NSTimeInterval const kToggleProgressSeconds = 0.175;
     //redraw fControlButton
     BOOL minimal = [self.fDefaults boolForKey:@"SmallView"];
     [rowIndexes enumerateIndexesUsingBlock:^(NSUInteger row, BOOL*) {
-        id rowView = [self rowViewAtRow:row makeIfNecessary:NO];
-        if (![rowView isGroupRowStyle])
+        id rowItem = [self itemAtRow:row];
+        if (![rowItem isKindOfClass:[TorrentGroup class]])
         {
             if (minimal)
             {
@@ -199,11 +199,9 @@ static NSTimeInterval const kToggleProgressSeconds = 0.175;
 
 - (BOOL)outlineView:(NSOutlineView*)outlineView isGroupItem:(id)item
 {
-    if ([item isKindOfClass:[Torrent class]])
-    {
-        return NO;
-    }
-    return YES;
+    // We are implementing our own group styling.
+    // Apple's default group styling conflicts with this.
+    return NO;
 }
 
 - (CGFloat)outlineView:(NSOutlineView*)outlineView heightOfRowByItem:(id)item


### PR DESCRIPTION
The outline view was apply its own styling. Instead, don't mark our groups as groups.