### PR TITLE
feat: viewport neutral layout and style for small viewports in web app

### DIFF
--- a/web/assets/css/transmission-app.scss
+++ b/web/assets/css/transmission-app.scss
@@ -19,15 +19,9 @@
 }
 
 :root {
-  /* z-index enum */
-  --z-index-popup: 2;
-
   /* various dimensions */
-  --dialog-logo-padding: calc(var(--dialog-padding) * 0.66);
-  --dialog-padding: 20px;
   --logo-size: 64px;
   --pauseresume-size: 20px;
-  --popup-top: 82px; // TODO: ugly that this is hardcoded
   --toolbar-height: 50px;
 
   /* colors related to torrent status */
@@ -251,6 +245,7 @@ body {
   color: var(--color-fg-primary);
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica,
     Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+  -webkit-text-size-adjust: none;
   height: 100%;
   margin: 0;
 }
@@ -798,13 +793,6 @@ a {
 
 /// PREFERENCES DIALOG
 
-@include viewport-small {
-  input[type='checkbox'] {
-    height: 20px;
-    width: 20px;
-  }
-}
-
 #inspector {
   @include viewport-large {
     box-shadow: initial;
@@ -813,12 +801,6 @@ a {
 }
 
 #prefs-dialog {
-  $background-color: var(--color-bg-primary);
-  background: $background-color;
-  bottom: 0;
-  right: 0;
-  z-index: var(--z-index-popup);
-
   .tabs-page {
     grid-column-gap: 8px;
     grid-row-gap: 5px;
@@ -832,7 +814,6 @@ a {
     .section-label {
       font-weight: bold;
       grid-column: span 2;
-      // margin-left: -20px;
       padding-bottom: 5px;
 
       &:not(:first-of-type) {
@@ -928,8 +909,8 @@ a {
   flex-direction: column;
   position: absolute;
   right: 0;
-  top: var(--popup-top);
-  z-index: var(--z-index-popup);
+  top: 82px;
+  z-index: 2;
 
   @include viewport-small {
     top: 0;
@@ -1228,10 +1209,6 @@ a {
 
   .percent-done {
     width: 10%;
-
-    @include viewport-small {
-      width: 12%;
-    }
   }
 
   .speed-down,
@@ -1246,7 +1223,6 @@ a {
 
     @include viewport-small {
       text-align: left;
-      width: 20%;
     }
   }
 
@@ -1254,9 +1230,7 @@ a {
     overflow-x: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    @include viewport-medium {
-      width: 20%;
-    }
+    width: 20%;
   }
 
   .status {
@@ -1311,7 +1285,7 @@ a {
   border-radius: 5px;
   color: var(--color-fg-on-popup);
   padding: 10px 5px;
-  z-index: 9999;
+  z-index: 3;
   user-select: none;
   -webkit-user-select: none;
 
@@ -1359,11 +1333,7 @@ a {
   right: 0;
   margin: 6px;
   top: 50px;
-  z-index: var(--z-index-popup);
-
-  @include viewport-small {
-    height: 80vh;
-  }
+  z-index: 2;
 
   fieldset {
     border: 0;
@@ -1490,60 +1460,6 @@ a {
 
 /// DIALOGS
 
-@include viewport-small {
-  .dialog-buttons {
-    padding-top: var(--dialog-logo-padding);
-  }
-
-  .dialog-container {
-    opacity: 96%;
-    position: absolute;
-    top: var(--popup-top);
-    width: 100%;
-  }
-
-  .dialog-logo {
-    padding-bottom: var(--dialog-logo-padding);
-  }
-
-  .dialog-window {
-    align-items: center;
-    display: flex;
-    flex-direction: column;
-  }
-}
-
-@include viewport-medium {
-  .dialog-container {
-    min-width: 500px;
-    position: absolute;
-    top: calc(var(--popup-top) * 2);
-  }
-
-  .dialog-heading {
-    grid-area: heading;
-  }
-
-  .dialog-logo {
-    grid-area: icon;
-    padding-right: var(--dialog-logo-padding);
-  }
-
-  .dialog-window {
-    background-color: var(--color-bg-popup);
-    color: var(--color-fg-on-popup);
-    display: grid;
-    grid-column-gap: 12px;
-    grid-template-areas:
-      'icon heading'
-      'icon message'
-      'icon workarea'
-      'icon buttons';
-    grid-template-columns: var(--logo-size) 1fr;
-    padding: 2px 12px;
-  }
-}
-
 .dialog-buttons {
   display: flex;
   float: right;
@@ -1576,44 +1492,65 @@ dialog {
 }
 
 .dialog-container {
+  max-width: 500px;
+  top: 102px;
+  width: calc(100vw - 20px);
+
   color: var(--color-fg-primary);
   display: block;
   padding: 0;
-  z-index: var(--z-index-popup);
+  z-index: 1;
 
-  @include viewport-medium {
-    border: 0;
-    border-radius: 8px;
-    max-width: 50%;
-  }
+  border: 0;
+  border-radius: 8px;
 }
 
 .dialog-heading {
-  align-items: center;
   display: flex;
   font-size: 1.2em;
   font-weight: bold;
+  grid-area: heading;
   overflow-wrap: anywhere;
 }
 
 .dialog-logo {
   background: transparent url('../img/logo.png') top left no-repeat;
+  grid-area: icon;
   height: var(--logo-size);
   width: var(--logo-size);
 }
 
 .dialog-message {
-  grid-area: message;
+  width: 100%;
   margin: 10px 0 0;
 }
 
 .dialog-window {
-  background: var(--color-bg-primary);
+  background-color: var(--color-bg-popup);
+  color: var(--color-fg-on-popup);
   border-radius: 8px;
-  padding: var(--dialog-padding);
+  padding: 20px;
+
+  @include viewport-small {
+    align-items: center;
+    display: flex;
+    flex-direction: column;
+  }
+
+  @include viewport-medium {
+    display: grid;
+    grid-column-gap: 12px;
+    grid-template-areas:
+      'icon heading'
+      'icon message'
+      'icon workarea'
+      'icon buttons';
+    grid-template-columns: var(--logo-size) 1fr;
+  }
 }
 
 .dialog-workarea {
+  width: 100%;
   display: flex;
   flex-direction: column;
   grid-area: workarea;
@@ -1626,12 +1563,8 @@ dialog {
 
 /// ABOUT DIALOG
 
-.about-dialog {
-  max-width: initial;
-
-  .dialog-workarea > * {
-    margin-bottom: 10px;
-  }
+.about-dialog .dialog-workarea > * {
+  margin-bottom: 10px;
 }
 
 .about-dialog-version-number {
@@ -1677,12 +1610,6 @@ dialog {
   }
 }
 
-/// RENAME DIALOG
-
-#torrent-rename-name {
-  min-width: 400px;
-}
-
 /// SET-LOCATION DIALOG
 
 #move-container #torrent-path {
@@ -1699,14 +1626,7 @@ dialog {
     display: grid;
     grid-row-gap: 6px;
     grid-template-columns: auto 1fr;
-    margin-top: 4px;
-
-    @include viewport-small {
-      margin: 4px 0 16px;
-    }
-    @include viewport-medium {
-      margin: 4px 16px 16px;
-    }
+    margin: 4px 16px 16px;
 
     div {
       word-break: break-word;


### PR DESCRIPTION
iPhone 12 Mini is my daily driver and I see lot of unwarranted viewport-sensitive layout and style. It's really not that surprising that the mobile layout makes for crippled mobile experiences.

This PR includes QoL improvements for small viewports: resolutions for UI jumble when browser changes viewport by resizing window and, to make UI familiarize between small and big browsers on different devices.

 - Reduce vertical unnecessary scrolls for overflow menu on narrowed viewports (wide viewports are resolved long ago, missed the small viewports)
 - Uniform popup layout & style for big and small browsers
 - Remove checkbox size growth on narrowed browser
 - Maintain peer table cell width for narrowed browser

<details>
<summary>iPhone 12 Mini screenshot diffs (Left/upper: This PR, Right/bottom: Original)</summary>

![IMG_1282](https://github.com/user-attachments/assets/2c82c413-5e0a-49af-8f93-3b5017e72720)
![IMG_1284](https://github.com/user-attachments/assets/126e27d6-d92d-43c8-9a91-4377e20149f1)
![IMG_1286](https://github.com/user-attachments/assets/24f54542-58a5-435c-8cd6-f4cd61e64fb3)
![IMG_1288](https://github.com/user-attachments/assets/3420c18e-82ac-4dc5-89b3-a3ec9fe546a7)
![IMG_1292](https://github.com/user-attachments/assets/f7301300-15c4-48a2-81b0-47234e7e4094)
![IMG_1294](https://github.com/user-attachments/assets/e38c2515-45ca-4de2-a01f-3395a6b619b7)
</details>

Notes: Updated viewport-sensitive layout and style to uniform across browsers of varying viewport.