### PR TITLE
feat: tweak font size for web app

### DIFF
--- a/web/assets/css/transmission-app.scss
+++ b/web/assets/css/transmission-app.scss
@@ -251,6 +251,7 @@ body {
   color: var(--color-fg-primary);
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica,
     Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+  -webkit-text-size-adjust: none;
   height: 100%;
   margin: 0;
 }
@@ -537,7 +538,7 @@ a {
     }
 
     .torrent-labels {
-      font-size: small;
+      font-size: 12px;
       font-weight: normal;
       margin-bottom: 2px;
       margin-top: 2px;
@@ -548,7 +549,6 @@ a {
 
       &.compact {
         flex: 1;
-        font-size: small;
       }
     }
 
@@ -965,7 +965,6 @@ a {
     border: 1px solid transparent;
     border-radius: 6px;
     color: var(--color-fg-primary);
-    font-weight: 400;
   }
 }
 
@@ -1024,10 +1023,6 @@ a {
     &:not(:first-of-type) {
       margin-top: 20px;
     }
-  }
-
-  label {
-    font-weight: 500;
   }
 
   :not(.section-label) {
@@ -1317,7 +1312,6 @@ a {
 
   .context-menuitem {
     font-size: 13px;
-    font-weight: 400;
     list-style: none;
     padding: 5px 15px;
 
@@ -1326,7 +1320,6 @@ a {
       background-color: var(--color-bg-hover);
       border-radius: 6px;
       cursor: pointer;
-      font-weight: 500;
     }
 
     &:disabled {


### PR DESCRIPTION
 - Clean up small font-weight diffs not observable in some browsers.
 - Add `text-size-adjust` to prevent iOS from changing text size.
 - Font size rollback for per-torrent labels

Left: This PR, Right: Original
![Transmission font size](https://github.com/user-attachments/assets/d20efd46-4614-4f08-b038-b8cbbab31e47)
![IMG_1292](https://github.com/user-attachments/assets/f7301300-15c4-48a2-81b0-47234e7e4094)

Notes: Tweaked font size for web app