### PR TITLE
refactor: remove TR_DISABLE_COPY_MOVE macro

### DIFF
--- a/gtk/Application.cc
+++ b/gtk/Application.cc
@@ -121,9 +121,11 @@ class Application::Impl
 {
 public:
     Impl(Application& app, std::string const& config_dir, bool start_paused, bool start_iconified);
+    Impl(Impl&&) = delete;
+    Impl(Impl const&) = delete;
+    Impl& operator=(Impl&&) = delete;
+    Impl& operator=(Impl const&) = delete;
     ~Impl() = default;
-
-    TR_DISABLE_COPY_MOVE(Impl)
 
     void open_files(std::vector<Glib::RefPtr<Gio::File>> const& files);
 

--- a/gtk/Application.h
+++ b/gtk/Application.h
@@ -4,8 +4,6 @@
 
 #pragma once
 
-#include <libtransmission/tr-macros.h>
-
 #include <giomm/file.h>
 #include <glibmm/refptr.h>
 #include <glibmm/ustring.h>
@@ -19,9 +17,11 @@ class Application : public Gtk::Application
 {
 public:
     Application(std::string const& config_dir, bool start_paused, bool start_iconified);
+    Application(Application&&) = delete;
+    Application(Application const&) = delete;
+    Application& operator=(Application&&) = delete;
+    Application& operator=(Application const&) = delete;
     ~Application() override;
-
-    TR_DISABLE_COPY_MOVE(Application)
 
     friend void gtr_actions_handler(Glib::ustring const& action_name, gpointer user_data);
 

--- a/gtk/DetailsDialog.cc
+++ b/gtk/DetailsDialog.cc
@@ -79,9 +79,11 @@ class DetailsDialog::Impl
 {
 public:
     Impl(DetailsDialog& dialog, Glib::RefPtr<Gtk::Builder> const& builder, Glib::RefPtr<Session> const& core);
+    Impl(Impl&&) = delete;
+    Impl(Impl const&) = delete;
+    Impl& operator=(Impl&&) = delete;
+    Impl& operator=(Impl const&) = delete;
     ~Impl();
-
-    TR_DISABLE_COPY_MOVE(Impl)
 
     void set_torrents(std::vector<tr_torrent_id_t> const& torrent_ids);
     void refresh();
@@ -2188,9 +2190,11 @@ public:
         DetailsDialog& parent,
         Glib::RefPtr<Session> const& core,
         tr_torrent const* torrent);
+    EditTrackersDialog(EditTrackersDialog&&) = delete;
+    EditTrackersDialog(EditTrackersDialog const&) = delete;
+    EditTrackersDialog& operator=(EditTrackersDialog&&) = delete;
+    EditTrackersDialog& operator=(EditTrackersDialog const&) = delete;
     ~EditTrackersDialog() override = default;
-
-    TR_DISABLE_COPY_MOVE(EditTrackersDialog)
 
     static std::unique_ptr<EditTrackersDialog> create(
         DetailsDialog& parent,
@@ -2307,9 +2311,11 @@ public:
         DetailsDialog& parent,
         Glib::RefPtr<Session> const& core,
         tr_torrent const* torrent);
+    AddTrackerDialog(AddTrackerDialog&&) = delete;
+    AddTrackerDialog(AddTrackerDialog const&) = delete;
+    AddTrackerDialog& operator=(AddTrackerDialog&&) = delete;
+    AddTrackerDialog& operator=(AddTrackerDialog const&) = delete;
     ~AddTrackerDialog() override = default;
-
-    TR_DISABLE_COPY_MOVE(AddTrackerDialog)
 
     static std::unique_ptr<AddTrackerDialog> create(
         DetailsDialog& parent,

--- a/gtk/DetailsDialog.h
+++ b/gtk/DetailsDialog.h
@@ -6,7 +6,6 @@
 #pragma once
 
 #include <libtransmission/transmission.h>
-#include <libtransmission/tr-macros.h>
 
 #include <glibmm/refptr.h>
 #include <gtkmm/builder.h>
@@ -26,9 +25,11 @@ public:
         Glib::RefPtr<Gtk::Builder> const& builder,
         Gtk::Window& parent,
         Glib::RefPtr<Session> const& core);
+    DetailsDialog(DetailsDialog&&) = delete;
+    DetailsDialog(DetailsDialog const&) = delete;
+    DetailsDialog& operator=(DetailsDialog&&) = delete;
+    DetailsDialog& operator=(DetailsDialog const&) = delete;
     ~DetailsDialog() override;
-
-    TR_DISABLE_COPY_MOVE(DetailsDialog)
 
     static std::unique_ptr<DetailsDialog> create(Gtk::Window& parent, Glib::RefPtr<Session> const& core);
 

--- a/gtk/FileList.cc
+++ b/gtk/FileList.cc
@@ -101,9 +101,11 @@ public:
         Glib::ustring const& view_name,
         Glib::RefPtr<Session> const& core,
         tr_torrent_id_t torrent_id);
+    Impl(Impl&&) = delete;
+    Impl(Impl const&) = delete;
+    Impl& operator=(Impl&&) = delete;
+    Impl& operator=(Impl const&) = delete;
     ~Impl();
-
-    TR_DISABLE_COPY_MOVE(Impl)
 
     void set_torrent(tr_torrent_id_t torrent_id);
     void reset_torrent();

--- a/gtk/FileList.h
+++ b/gtk/FileList.h
@@ -6,7 +6,6 @@
 #pragma once
 
 #include <libtransmission/transmission.h>
-#include <libtransmission/tr-macros.h>
 
 #include <glibmm/refptr.h>
 #include <glibmm/ustring.h>
@@ -26,9 +25,11 @@ public:
         Glib::ustring const& view_name,
         Glib::RefPtr<Session> const& core,
         tr_torrent_id_t torrent_id);
+    FileList(FileList&&) = delete;
+    FileList(FileList const&) = delete;
+    FileList& operator=(FileList&&) = delete;
+    FileList& operator=(FileList const&) = delete;
     ~FileList() override;
-
-    TR_DISABLE_COPY_MOVE(FileList)
 
     void clear();
     void set_torrent(tr_torrent_id_t torrent_id);

--- a/gtk/FilterBar.cc
+++ b/gtk/FilterBar.cc
@@ -58,9 +58,11 @@ class FilterBar::Impl
 
 public:
     Impl(FilterBar& widget, Glib::RefPtr<Session> const& core);
+    Impl(Impl&&) = delete;
+    Impl(Impl const&) = delete;
+    Impl& operator=(Impl&&) = delete;
+    Impl& operator=(Impl const&) = delete;
     ~Impl();
-
-    TR_DISABLE_COPY_MOVE(Impl)
 
     [[nodiscard]] Glib::RefPtr<FilterModel> get_filter_model() const;
 

--- a/gtk/FilterBar.h
+++ b/gtk/FilterBar.h
@@ -7,8 +7,6 @@
 
 #include "GtkCompat.h"
 
-#include <libtransmission/tr-macros.h>
-
 #include <giomm/listmodel.h>
 #include <glibmm/extraclassinit.h>
 #include <glibmm/refptr.h>
@@ -40,9 +38,11 @@ public:
 public:
     FilterBar();
     FilterBar(BaseObjectType* cast_item, Glib::RefPtr<Gtk::Builder> const& builder, Glib::RefPtr<Session> const& core);
+    FilterBar(FilterBar&&) = delete;
+    FilterBar(FilterBar const&) = delete;
+    FilterBar& operator=(FilterBar&&) = delete;
+    FilterBar& operator=(FilterBar const&) = delete;
     ~FilterBar() override;
-
-    TR_DISABLE_COPY_MOVE(FilterBar)
 
     Glib::RefPtr<Model> get_filter_model() const;
 

--- a/gtk/FilterBase.h
+++ b/gtk/FilterBase.h
@@ -7,8 +7,6 @@
 
 #include "GtkCompat.h"
 
-#include <libtransmission/tr-macros.h>
-
 #if GTKMM_CHECK_VERSION(4, 0, 0)
 #include <gtkmm/filter.h>
 #else
@@ -34,9 +32,11 @@ public:
 
 public:
     FilterBase() = default;
+    FilterBase(FilterBase&&) = delete;
+    FilterBase(FilterBase const&) = delete;
+    FilterBase& operator=(FilterBase&&) = delete;
+    FilterBase& operator=(FilterBase const&) = delete;
     ~FilterBase() override = default;
-
-    TR_DISABLE_COPY_MOVE(FilterBase)
 
     virtual bool match(T const& item) const = 0;
 

--- a/gtk/FreeSpaceLabel.cc
+++ b/gtk/FreeSpaceLabel.cc
@@ -23,9 +23,11 @@ class FreeSpaceLabel::Impl
 {
 public:
     Impl(FreeSpaceLabel& label, Glib::RefPtr<Session> const& core, std::string_view dir);
+    Impl(Impl&&) = delete;
+    Impl(Impl const&) = delete;
+    Impl& operator=(Impl&&) = delete;
+    Impl& operator=(Impl const&) = delete;
     ~Impl();
-
-    TR_DISABLE_COPY_MOVE(Impl)
 
     void set_dir(std::string_view dir);
 

--- a/gtk/FreeSpaceLabel.h
+++ b/gtk/FreeSpaceLabel.h
@@ -3,8 +3,6 @@
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.
 
-#include <libtransmission/tr-macros.h>
-
 #include <glibmm/refptr.h>
 #include <gtkmm/builder.h>
 #include <gtkmm/label.h>
@@ -23,9 +21,11 @@ public:
         Glib::RefPtr<Gtk::Builder> const& builder,
         Glib::RefPtr<Session> const& core,
         std::string_view dir = {});
+    FreeSpaceLabel(FreeSpaceLabel&&) = delete;
+    FreeSpaceLabel(FreeSpaceLabel const&) = delete;
+    FreeSpaceLabel& operator=(FreeSpaceLabel&&) = delete;
+    FreeSpaceLabel& operator=(FreeSpaceLabel const&) = delete;
     ~FreeSpaceLabel() override;
-
-    TR_DISABLE_COPY_MOVE(FreeSpaceLabel)
 
     void set_dir(std::string_view dir);
 

--- a/gtk/MainWindow.cc
+++ b/gtk/MainWindow.cc
@@ -93,9 +93,11 @@ public:
         Glib::RefPtr<Gtk::Builder> const& builder,
         Glib::RefPtr<Gio::ActionGroup> const& actions,
         Glib::RefPtr<Session> const& core);
+    Impl(Impl&&) = delete;
+    Impl(Impl const&) = delete;
+    Impl& operator=(Impl&&) = delete;
+    Impl& operator=(Impl const&) = delete;
     ~Impl();
-
-    TR_DISABLE_COPY_MOVE(Impl)
 
     [[nodiscard]] Glib::RefPtr<TorrentViewSelection> get_selection() const;
 

--- a/gtk/MainWindow.h
+++ b/gtk/MainWindow.h
@@ -4,8 +4,6 @@
 
 #pragma once
 
-#include <libtransmission/tr-macros.h>
-
 #include <giomm/actiongroup.h>
 #include <glibmm/refptr.h>
 #include <gtkmm/application.h>
@@ -26,9 +24,11 @@ public:
         Gtk::Application& app,
         Glib::RefPtr<Gio::ActionGroup> const& actions,
         Glib::RefPtr<Session> const& core);
+    MainWindow(MainWindow&&) = delete;
+    MainWindow(MainWindow const&) = delete;
+    MainWindow& operator=(MainWindow&&) = delete;
+    MainWindow& operator=(MainWindow const&) = delete;
     ~MainWindow() override;
-
-    TR_DISABLE_COPY_MOVE(MainWindow)
 
     static std::unique_ptr<MainWindow> create(
         Gtk::Application& app,

--- a/gtk/MakeDialog.cc
+++ b/gtk/MakeDialog.cc
@@ -71,9 +71,11 @@ public:
         std::future<tr_error> future,
         std::string_view target,
         Glib::RefPtr<Session> const& core);
+    MakeProgressDialog(MakeProgressDialog&&) = delete;
+    MakeProgressDialog(MakeProgressDialog const&) = delete;
+    MakeProgressDialog& operator=(MakeProgressDialog&&) = delete;
+    MakeProgressDialog& operator=(MakeProgressDialog const&) = delete;
     ~MakeProgressDialog() override;
-
-    TR_DISABLE_COPY_MOVE(MakeProgressDialog)
 
     static std::unique_ptr<MakeProgressDialog> create(
         std::string_view target,
@@ -110,9 +112,11 @@ class MakeDialog::Impl
 {
 public:
     Impl(MakeDialog& dialog, Glib::RefPtr<Gtk::Builder> const& builder, Glib::RefPtr<Session> const& core);
+    Impl(Impl&&) = delete;
+    Impl(Impl const&) = delete;
+    Impl& operator=(Impl&&) = delete;
+    Impl& operator=(Impl const&) = delete;
     ~Impl() = default;
-
-    TR_DISABLE_COPY_MOVE(Impl)
 
 private:
     void onSourceToggled(Gtk::CheckButton* tb, PathButton* chooser);

--- a/gtk/MakeDialog.h
+++ b/gtk/MakeDialog.h
@@ -5,8 +5,6 @@
 
 #pragma once
 
-#include <libtransmission/tr-macros.h>
-
 #include <glibmm/refptr.h>
 #include <gtkmm/builder.h>
 #include <gtkmm/dialog.h>
@@ -24,9 +22,11 @@ public:
         Glib::RefPtr<Gtk::Builder> const& builder,
         Gtk::Window& parent,
         Glib::RefPtr<Session> const& core);
+    MakeDialog(MakeDialog&&) = delete;
+    MakeDialog(MakeDialog const&) = delete;
+    MakeDialog& operator=(MakeDialog&&) = delete;
+    MakeDialog& operator=(MakeDialog const&) = delete;
     ~MakeDialog() override;
-
-    TR_DISABLE_COPY_MOVE(MakeDialog)
 
     static std::unique_ptr<MakeDialog> create(Gtk::Window& parent, Glib::RefPtr<Session> const& core);
 

--- a/gtk/MessageLogWindow.cc
+++ b/gtk/MessageLogWindow.cc
@@ -65,9 +65,11 @@ class MessageLogWindow::Impl
 {
 public:
     Impl(MessageLogWindow& window, Glib::RefPtr<Gtk::Builder> const& builder, Glib::RefPtr<Session> const& core);
+    Impl(Impl&&) = delete;
+    Impl(Impl const&) = delete;
+    Impl& operator=(Impl&&) = delete;
+    Impl& operator=(Impl const&) = delete;
     ~Impl();
-
-    TR_DISABLE_COPY_MOVE(Impl)
 
 private:
     bool onRefresh();

--- a/gtk/MessageLogWindow.h
+++ b/gtk/MessageLogWindow.h
@@ -5,8 +5,6 @@
 
 #pragma once
 
-#include <libtransmission/tr-macros.h>
-
 #include <glibmm/refptr.h>
 #include <gtkmm/builder.h>
 #include <gtkmm/window.h>
@@ -23,9 +21,11 @@ public:
         Glib::RefPtr<Gtk::Builder> const& builder,
         Gtk::Window& parent,
         Glib::RefPtr<Session> const& core);
+    MessageLogWindow(MessageLogWindow&&) = delete;
+    MessageLogWindow(MessageLogWindow const&) = delete;
+    MessageLogWindow& operator=(MessageLogWindow&&) = delete;
+    MessageLogWindow& operator=(MessageLogWindow const&) = delete;
     ~MessageLogWindow() override;
-
-    TR_DISABLE_COPY_MOVE(MessageLogWindow)
 
     static std::unique_ptr<MessageLogWindow> create(Gtk::Window& parent, Glib::RefPtr<Session> const& core);
 

--- a/gtk/OptionsDialog.cc
+++ b/gtk/OptionsDialog.cc
@@ -73,9 +73,11 @@ public:
         Glib::RefPtr<Gtk::Builder> const& builder,
         Glib::RefPtr<Session> const& core,
         std::unique_ptr<tr_ctor, void (*)(tr_ctor*)> ctor);
+    Impl(Impl&&) = delete;
+    Impl(Impl const&) = delete;
+    Impl& operator=(Impl&&) = delete;
+    Impl& operator=(Impl const&) = delete;
     ~Impl();
-
-    TR_DISABLE_COPY_MOVE(Impl)
 
 private:
     void sourceChanged(PathButton* b);

--- a/gtk/OptionsDialog.h
+++ b/gtk/OptionsDialog.h
@@ -5,8 +5,6 @@
 
 #pragma once
 
-#include <libtransmission/tr-macros.h>
-
 #include <glibmm/refptr.h>
 #include <gtkmm/builder.h>
 #include <gtkmm/dialog.h>
@@ -28,9 +26,11 @@ public:
         Glib::RefPtr<Gtk::Builder> const& builder,
         Gtk::Window& parent,
         Glib::RefPtr<Session> const& core);
+    TorrentUrlChooserDialog(TorrentUrlChooserDialog&&) = delete;
+    TorrentUrlChooserDialog(TorrentUrlChooserDialog const&) = delete;
+    TorrentUrlChooserDialog& operator=(TorrentUrlChooserDialog&&) = delete;
+    TorrentUrlChooserDialog& operator=(TorrentUrlChooserDialog const&) = delete;
     ~TorrentUrlChooserDialog() override = default;
-
-    TR_DISABLE_COPY_MOVE(TorrentUrlChooserDialog)
 
     static std::unique_ptr<TorrentUrlChooserDialog> create(Gtk::Window& parent, Glib::RefPtr<Session> const& core);
 
@@ -41,9 +41,11 @@ private:
 class TorrentFileChooserDialog : public Gtk::FileChooserNative
 {
 public:
+    TorrentFileChooserDialog(TorrentFileChooserDialog&&) = delete;
+    TorrentFileChooserDialog(TorrentFileChooserDialog const&) = delete;
+    TorrentFileChooserDialog& operator=(TorrentFileChooserDialog&&) = delete;
+    TorrentFileChooserDialog& operator=(TorrentFileChooserDialog const&) = delete;
     ~TorrentFileChooserDialog() override = default;
-
-    TR_DISABLE_COPY_MOVE(TorrentFileChooserDialog)
 
     static std::unique_ptr<TorrentFileChooserDialog> create(Gtk::Window& parent, Glib::RefPtr<Session> const& core);
 
@@ -63,9 +65,11 @@ public:
         Gtk::Window& parent,
         Glib::RefPtr<Session> const& core,
         std::unique_ptr<tr_ctor, void (*)(tr_ctor*)> ctor);
+    OptionsDialog(OptionsDialog&&) = delete;
+    OptionsDialog(OptionsDialog const&) = delete;
+    OptionsDialog& operator=(OptionsDialog&&) = delete;
+    OptionsDialog& operator=(OptionsDialog const&) = delete;
     ~OptionsDialog() override;
-
-    TR_DISABLE_COPY_MOVE(OptionsDialog)
 
     static std::unique_ptr<OptionsDialog> create(
         Gtk::Window& parent,

--- a/gtk/PathButton.cc
+++ b/gtk/PathButton.cc
@@ -27,9 +27,11 @@ class PathButton::Impl
 {
 public:
     explicit Impl(PathButton& widget);
+    Impl(Impl&&) = delete;
+    Impl(Impl const&) = delete;
+    Impl& operator=(Impl&&) = delete;
+    Impl& operator=(Impl const&) = delete;
     ~Impl() = default;
-
-    TR_DISABLE_COPY_MOVE(Impl)
 
 #if GTKMM_CHECK_VERSION(4, 0, 0)
     std::string const& get_filename() const;

--- a/gtk/PathButton.h
+++ b/gtk/PathButton.h
@@ -7,8 +7,6 @@
 
 #include "GtkCompat.h"
 
-#include <libtransmission/tr-macros.h>
-
 #include <glibmm/propertyproxy.h>
 #include <glibmm/refptr.h>
 #include <glibmm/ustring.h>
@@ -33,9 +31,11 @@ class PathButton : public IF_GTKMM4(Gtk::Button, Gtk::FileChooserButton)
 public:
     PathButton();
     PathButton(BaseObjectType* cast_item, Glib::RefPtr<Gtk::Builder> const& builder);
+    PathButton(PathButton&&) = delete;
+    PathButton(PathButton const&) = delete;
+    PathButton& operator=(PathButton&&) = delete;
+    PathButton& operator=(PathButton const&) = delete;
     ~PathButton() override;
-
-    TR_DISABLE_COPY_MOVE(PathButton)
 
     void set_shortcut_folders(std::list<std::string> const& value);
 

--- a/gtk/PrefsDialog.cc
+++ b/gtk/PrefsDialog.cc
@@ -61,9 +61,11 @@ class PrefsDialog::Impl
 {
 public:
     Impl(PrefsDialog& dialog, Glib::RefPtr<Gtk::Builder> const& builder, Glib::RefPtr<Session> const& core);
+    Impl(Impl&&) = delete;
+    Impl(Impl const&) = delete;
+    Impl& operator=(Impl&&) = delete;
+    Impl& operator=(Impl const&) = delete;
     ~Impl() = default;
-
-    TR_DISABLE_COPY_MOVE(Impl)
 
 private:
     void response_cb(int response);
@@ -97,9 +99,11 @@ class PageBase : public Gtk::Box
 {
 public:
     PageBase(BaseObjectType* cast_item, Glib::RefPtr<Gtk::Builder> const& builder, Glib::RefPtr<Session> const& core);
+    PageBase(PageBase&&) = delete;
+    PageBase(PageBase const&) = delete;
+    PageBase& operator=(PageBase&&) = delete;
+    PageBase& operator=(PageBase const&) = delete;
     ~PageBase() override;
-
-    TR_DISABLE_COPY_MOVE(PageBase)
 
     Gtk::CheckButton* init_check_button(Glib::ustring const& name, tr_quark key);
     Gtk::SpinButton* init_spin_button(Glib::ustring const& name, tr_quark key, int low, int high, int step);
@@ -399,9 +403,11 @@ class DownloadingPage : public PageBase
 {
 public:
     DownloadingPage(BaseObjectType* cast_item, Glib::RefPtr<Gtk::Builder> const& builder, Glib::RefPtr<Session> const& core);
+    DownloadingPage(DownloadingPage&&) = delete;
+    DownloadingPage(DownloadingPage const&) = delete;
+    DownloadingPage& operator=(DownloadingPage&&) = delete;
+    DownloadingPage& operator=(DownloadingPage const&) = delete;
     ~DownloadingPage() override;
-
-    TR_DISABLE_COPY_MOVE(DownloadingPage)
 
 private:
     void on_core_prefs_changed(tr_quark key);
@@ -463,9 +469,11 @@ class SeedingPage : public PageBase
 {
 public:
     SeedingPage(BaseObjectType* cast_item, Glib::RefPtr<Gtk::Builder> const& builder, Glib::RefPtr<Session> const& core);
+    SeedingPage(SeedingPage&&) = delete;
+    SeedingPage(SeedingPage const&) = delete;
+    SeedingPage& operator=(SeedingPage&&) = delete;
+    SeedingPage& operator=(SeedingPage const&) = delete;
     ~SeedingPage() override = default;
-
-    TR_DISABLE_COPY_MOVE(SeedingPage)
 };
 
 SeedingPage::SeedingPage(
@@ -490,9 +498,11 @@ class DesktopPage : public PageBase
 {
 public:
     DesktopPage(BaseObjectType* cast_item, Glib::RefPtr<Gtk::Builder> const& builder, Glib::RefPtr<Session> const& core);
+    DesktopPage(DesktopPage&&) = delete;
+    DesktopPage(DesktopPage const&) = delete;
+    DesktopPage& operator=(DesktopPage&&) = delete;
+    DesktopPage& operator=(DesktopPage const&) = delete;
     ~DesktopPage() override = default;
-
-    TR_DISABLE_COPY_MOVE(DesktopPage)
 };
 
 DesktopPage::DesktopPage(
@@ -527,9 +537,11 @@ class PrivacyPage : public PageBase
 
 public:
     PrivacyPage(BaseObjectType* cast_item, Glib::RefPtr<Gtk::Builder> const& builder, Glib::RefPtr<Session> const& core);
+    PrivacyPage(PrivacyPage&&) = delete;
+    PrivacyPage(PrivacyPage const&) = delete;
+    PrivacyPage& operator=(PrivacyPage&&) = delete;
+    PrivacyPage& operator=(PrivacyPage const&) = delete;
     ~PrivacyPage() override;
-
-    TR_DISABLE_COPY_MOVE(PrivacyPage)
 
 private:
     void updateBlocklistText();
@@ -639,9 +651,11 @@ class RemotePage : public PageBase
 
 public:
     RemotePage(BaseObjectType* cast_item, Glib::RefPtr<Gtk::Builder> const& builder, Glib::RefPtr<Session> const& core);
+    RemotePage(RemotePage&&) = delete;
+    RemotePage(RemotePage const&) = delete;
+    RemotePage& operator=(RemotePage&&) = delete;
+    RemotePage& operator=(RemotePage const&) = delete;
     ~RemotePage() override = default;
-
-    TR_DISABLE_COPY_MOVE(RemotePage)
 
 private:
     void refreshWhitelist();
@@ -836,9 +850,11 @@ class SpeedPage : public PageBase
 {
 public:
     SpeedPage(BaseObjectType* cast_item, Glib::RefPtr<Gtk::Builder> const& builder, Glib::RefPtr<Session> const& core);
+    SpeedPage(SpeedPage&&) = delete;
+    SpeedPage(SpeedPage const&) = delete;
+    SpeedPage& operator=(SpeedPage&&) = delete;
+    SpeedPage& operator=(SpeedPage const&) = delete;
     ~SpeedPage() override = default;
-
-    TR_DISABLE_COPY_MOVE(SpeedPage)
 };
 
 SpeedPage::SpeedPage(BaseObjectType* cast_item, Glib::RefPtr<Gtk::Builder> const& builder, Glib::RefPtr<Session> const& core)
@@ -876,9 +892,11 @@ class NetworkPage : public PageBase
 {
 public:
     NetworkPage(BaseObjectType* cast_item, Glib::RefPtr<Gtk::Builder> const& builder, Glib::RefPtr<Session> const& core);
+    NetworkPage(NetworkPage&&) = delete;
+    NetworkPage(NetworkPage const&) = delete;
+    NetworkPage& operator=(NetworkPage&&) = delete;
+    NetworkPage& operator=(NetworkPage const&) = delete;
     ~NetworkPage() override;
-
-    TR_DISABLE_COPY_MOVE(NetworkPage)
 
 private:
     enum PortTestStatus : uint8_t

--- a/gtk/PrefsDialog.h
+++ b/gtk/PrefsDialog.h
@@ -5,8 +5,6 @@
 
 #pragma once
 
-#include <libtransmission/tr-macros.h>
-
 #include <glibmm/refptr.h>
 #include <gtkmm/builder.h>
 #include <gtkmm/dialog.h>
@@ -24,9 +22,11 @@ public:
         Glib::RefPtr<Gtk::Builder> const& builder,
         Gtk::Window& parent,
         Glib::RefPtr<Session> const& core);
+    PrefsDialog(PrefsDialog&&) = delete;
+    PrefsDialog(PrefsDialog const&) = delete;
+    PrefsDialog& operator=(PrefsDialog&&) = delete;
+    PrefsDialog& operator=(PrefsDialog const&) = delete;
     ~PrefsDialog() override;
-
-    TR_DISABLE_COPY_MOVE(PrefsDialog)
 
     static std::unique_ptr<PrefsDialog> create(Gtk::Window& parent, Glib::RefPtr<Session> const& core);
 

--- a/gtk/RelocateDialog.cc
+++ b/gtk/RelocateDialog.cc
@@ -37,9 +37,11 @@ public:
         Glib::RefPtr<Gtk::Builder> const& builder,
         Glib::RefPtr<Session> const& core,
         std::vector<tr_torrent_id_t> const& torrent_ids);
+    Impl(Impl&&) = delete;
+    Impl(Impl const&) = delete;
+    Impl& operator=(Impl&&) = delete;
+    Impl& operator=(Impl const&) = delete;
     ~Impl();
-
-    TR_DISABLE_COPY_MOVE(Impl)
 
 private:
     void onResponse(int response);

--- a/gtk/RelocateDialog.h
+++ b/gtk/RelocateDialog.h
@@ -6,7 +6,6 @@
 #pragma once
 
 #include <libtransmission/transmission.h>
-#include <libtransmission/tr-macros.h>
 
 #include <glibmm/refptr.h>
 #include <gtkmm/builder.h>
@@ -27,9 +26,11 @@ public:
         Gtk::Window& parent,
         Glib::RefPtr<Session> const& core,
         std::vector<tr_torrent_id_t> const& torrent_ids);
+    RelocateDialog(RelocateDialog&&) = delete;
+    RelocateDialog(RelocateDialog const&) = delete;
+    RelocateDialog& operator=(RelocateDialog&&) = delete;
+    RelocateDialog& operator=(RelocateDialog const&) = delete;
     ~RelocateDialog() override;
-
-    TR_DISABLE_COPY_MOVE(RelocateDialog)
 
     static std::unique_ptr<RelocateDialog> create(
         Gtk::Window& parent,

--- a/gtk/Session.cc
+++ b/gtk/Session.cc
@@ -62,9 +62,11 @@ class Session::Impl
 {
 public:
     Impl(Session& core, tr_session* session);
+    Impl& operator=(Impl&&) = delete;
+    Impl& operator=(Impl const&) = delete;
+    Impl(Impl&&) = delete;
+    Impl(Impl const&) = delete;
     ~Impl();
-
-    TR_DISABLE_COPY_MOVE(Impl)
 
     tr_session* close();
 

--- a/gtk/Session.h
+++ b/gtk/Session.h
@@ -9,7 +9,6 @@
 
 #include <libtransmission/transmission.h>
 #include <libtransmission/favicon-cache.h>
-#include <libtransmission/tr-macros.h>
 #include <libtransmission/variant.h>
 
 #include <gdkmm/pixbuf.h>
@@ -31,6 +30,11 @@
 class Session : public Glib::Object
 {
 public:
+    Session(Session&&) = delete;
+    Session(Session const&) = delete;
+    Session& operator=(Session&&) = delete;
+    Session& operator=(Session const&) = delete;
+
     enum ErrorCode : uint16_t
     {
         ERR_ADD_TORRENT_ERR = 1,
@@ -49,8 +53,6 @@ public:
 
 public:
     ~Session() override;
-
-    TR_DISABLE_COPY_MOVE(Session)
 
     static Glib::RefPtr<Session> create(tr_session* session);
 

--- a/gtk/SorterBase.h
+++ b/gtk/SorterBase.h
@@ -7,8 +7,6 @@
 
 #include "GtkCompat.h"
 
-#include <libtransmission/tr-macros.h>
-
 #if GTKMM_CHECK_VERSION(4, 0, 0)
 #include <gtkmm/sorter.h>
 #else
@@ -33,9 +31,11 @@ public:
 
 public:
     SorterBase() = default;
+    SorterBase(SorterBase&&) = delete;
+    SorterBase(SorterBase const&) = delete;
+    SorterBase& operator=(SorterBase&&) = delete;
+    SorterBase& operator=(SorterBase const&) = delete;
     ~SorterBase() override = default;
-
-    TR_DISABLE_COPY_MOVE(SorterBase)
 
     virtual int compare(T const& lhs, T const& rhs) const = 0;
 

--- a/gtk/StatsDialog.cc
+++ b/gtk/StatsDialog.cc
@@ -26,9 +26,11 @@ class StatsDialog::Impl
 {
 public:
     Impl(StatsDialog& dialog, Glib::RefPtr<Gtk::Builder> const& builder, Glib::RefPtr<Session> const& core);
+    Impl(Impl&&) = delete;
+    Impl(Impl const&) = delete;
+    Impl& operator=(Impl&&) = delete;
+    Impl& operator=(Impl const&) = delete;
     ~Impl();
-
-    TR_DISABLE_COPY_MOVE(Impl)
 
 private:
     bool updateStats();

--- a/gtk/StatsDialog.h
+++ b/gtk/StatsDialog.h
@@ -5,8 +5,6 @@
 
 #pragma once
 
-#include <libtransmission/tr-macros.h>
-
 #include <glibmm/refptr.h>
 #include <gtkmm/builder.h>
 #include <gtkmm/dialog.h>
@@ -24,9 +22,11 @@ public:
         Glib::RefPtr<Gtk::Builder> const& builder,
         Gtk::Window& parent,
         Glib::RefPtr<Session> const& core);
+    StatsDialog(StatsDialog&&) = delete;
+    StatsDialog(StatsDialog const&) = delete;
+    StatsDialog& operator=(StatsDialog&&) = delete;
+    StatsDialog& operator=(StatsDialog const&) = delete;
     ~StatsDialog() override;
-
-    TR_DISABLE_COPY_MOVE(StatsDialog)
 
     static std::unique_ptr<StatsDialog> create(Gtk::Window& parent, Glib::RefPtr<Session> const& core);
 

--- a/gtk/SystemTrayIcon.cc
+++ b/gtk/SystemTrayIcon.cc
@@ -69,9 +69,11 @@ class SystemTrayIcon::Impl
 {
 public:
     Impl(Gtk::Window& main_window, Glib::RefPtr<Session> const& core);
+    Impl(Impl&&) = delete;
+    Impl(Impl const&) = delete;
+    Impl& operator=(Impl&&) = delete;
+    Impl& operator=(Impl const&) = delete;
     ~Impl();
-
-    TR_DISABLE_COPY_MOVE(Impl)
 
     void refresh();
 

--- a/gtk/SystemTrayIcon.h
+++ b/gtk/SystemTrayIcon.h
@@ -5,8 +5,6 @@
 
 #pragma once
 
-#include <libtransmission/tr-macros.h>
-
 #include <glibmm/refptr.h>
 #include <gtkmm/window.h>
 
@@ -18,9 +16,11 @@ class SystemTrayIcon
 {
 public:
     SystemTrayIcon(Gtk::Window& main_window, Glib::RefPtr<Session> const& core);
+    SystemTrayIcon(SystemTrayIcon&&) = delete;
+    SystemTrayIcon(SystemTrayIcon const&) = delete;
+    SystemTrayIcon& operator=(SystemTrayIcon&&) = delete;
+    SystemTrayIcon& operator=(SystemTrayIcon const&) = delete;
     ~SystemTrayIcon();
-
-    TR_DISABLE_COPY_MOVE(SystemTrayIcon)
 
     void refresh();
 

--- a/gtk/TorrentCellRenderer.cc
+++ b/gtk/TorrentCellRenderer.cc
@@ -60,9 +60,11 @@ class TorrentCellRenderer::Impl
 {
 public:
     explicit Impl(TorrentCellRenderer& renderer);
+    Impl(Impl&&) = delete;
+    Impl(Impl const&) = delete;
+    Impl& operator=(Impl&&) = delete;
+    Impl& operator=(Impl const&) = delete;
     ~Impl();
-
-    TR_DISABLE_COPY_MOVE(Impl)
 
     Gtk::Requisition get_size_compact(Gtk::Widget& widget) const;
     Gtk::Requisition get_size_full(Gtk::Widget& widget) const;

--- a/gtk/TorrentCellRenderer.h
+++ b/gtk/TorrentCellRenderer.h
@@ -7,8 +7,6 @@
 
 #include "GtkCompat.h"
 
-#include <libtransmission/tr-macros.h>
-
 #include <glibmm/propertyproxy.h>
 #include <gtkmm/cellrenderer.h>
 
@@ -20,9 +18,11 @@ class TorrentCellRenderer : public Gtk::CellRenderer
 {
 public:
     TorrentCellRenderer();
+    TorrentCellRenderer(TorrentCellRenderer&&) = delete;
+    TorrentCellRenderer(TorrentCellRenderer const&) = delete;
+    TorrentCellRenderer& operator=(TorrentCellRenderer&&) = delete;
+    TorrentCellRenderer& operator=(TorrentCellRenderer const&) = delete;
     ~TorrentCellRenderer() override;
-
-    TR_DISABLE_COPY_MOVE(TorrentCellRenderer)
 
     Glib::PropertyProxy<Torrent*> property_torrent();
 

--- a/gtk/Utils.h
+++ b/gtk/Utils.h
@@ -8,7 +8,6 @@
 #include "GtkCompat.h"
 
 #include <libtransmission/transmission.h>
-#include <libtransmission/tr-macros.h>
 #include <libtransmission/values.h>
 
 #include <glibmm/objectbase.h>

--- a/libtransmission/announcer-udp.cc
+++ b/libtransmission/announcer-udp.cc
@@ -42,6 +42,7 @@
 #include "libtransmission/peer-mgr.h" // for tr_pex::fromCompact4()
 #include "libtransmission/tr-assert.h"
 #include "libtransmission/tr-buffer.h"
+#include "libtransmission/tr-macros.h"
 #include "libtransmission/tr-strbuf.h"
 #include "libtransmission/utils.h"
 #include "libtransmission/web-utils.h"

--- a/libtransmission/peer-mgr-wishlist.cc
+++ b/libtransmission/peer-mgr-wishlist.cc
@@ -18,6 +18,7 @@
 
 #include "libtransmission/bitfield.h"
 #include "libtransmission/crypto-utils.h" // for tr_salt_shaker
+#include "libtransmission/tr-macros.h"
 #include "libtransmission/peer-mgr-wishlist.h"
 
 // Asserts in this file are expensive, so hide them in #ifdef

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -23,6 +23,7 @@
 #include <small/map.hpp>
 
 #include "libtransmission/transmission.h"
+#include "libtransmission/tr-macros.h"
 
 #include "libtransmission/announcer.h"
 #include "libtransmission/bandwidth.h"

--- a/libtransmission/tr-macros.h
+++ b/libtransmission/tr-macros.h
@@ -64,12 +64,6 @@
 #define TR_UNLIKELY(x) (x)
 #endif
 
-#define TR_DISABLE_COPY_MOVE(Class) \
-    Class& operator=(Class const&) = delete; \
-    Class& operator=(Class&&) = delete; \
-    Class(Class const&) = delete; \
-    Class(Class&&) = delete;
-
 // ---
 
 #define TR_INET6_ADDRSTRLEN 46

--- a/qt/AboutDialog.h
+++ b/qt/AboutDialog.h
@@ -7,8 +7,6 @@
 
 #include <QPointer>
 
-#include <libtransmission/tr-macros.h>
-
 #include "BaseDialog.h"
 #include "ui_AboutDialog.h"
 
@@ -18,10 +16,13 @@ class Session;
 class AboutDialog : public BaseDialog
 {
     Q_OBJECT
-    TR_DISABLE_COPY_MOVE(AboutDialog)
 
 public:
     explicit AboutDialog(Session& session, QWidget* parent = nullptr);
+    AboutDialog(AboutDialog&&) = delete;
+    AboutDialog(AboutDialog const&) = delete;
+    AboutDialog& operator=(AboutDialog&&) = delete;
+    AboutDialog& operator=(AboutDialog const&) = delete;
 
 private slots:
     void showCredits();

--- a/qt/Application.h
+++ b/qt/Application.h
@@ -17,7 +17,6 @@
 #include <QTranslator>
 #include <QWeakPointer>
 
-#include <libtransmission/tr-macros.h>
 #include <libtransmission/favicon-cache.h>
 
 #include "AddData.h"
@@ -35,7 +34,6 @@ class WatchDir;
 class Application : public QApplication
 {
     Q_OBJECT
-    TR_DISABLE_COPY_MOVE(Application)
 
 public:
     Application(
@@ -45,6 +43,10 @@ public:
         QStringList const& filenames,
         int& argc,
         char** argv);
+    Application(Application&&) = delete;
+    Application(Application const&) = delete;
+    Application& operator=(Application&&) = delete;
+    Application& operator=(Application const&) = delete;
     ~Application() override;
 
     void raise() const;

--- a/qt/ColumnResizer.h
+++ b/qt/ColumnResizer.h
@@ -10,17 +10,18 @@
 #include <QObject>
 #include <QTimer>
 
-#include <libtransmission/tr-macros.h>
-
 class QGridLayout;
 
 class ColumnResizer : public QObject
 {
     Q_OBJECT
-    TR_DISABLE_COPY_MOVE(ColumnResizer)
 
 public:
     explicit ColumnResizer(QObject* parent = nullptr);
+    ColumnResizer(ColumnResizer&&) = delete;
+    ColumnResizer(ColumnResizer const&) = delete;
+    ColumnResizer& operator=(ColumnResizer&&) = delete;
+    ColumnResizer& operator=(ColumnResizer const&) = delete;
 
     void addLayout(QGridLayout* layout);
 

--- a/qt/DetailsDialog.h
+++ b/qt/DetailsDialog.h
@@ -12,8 +12,6 @@
 #include <QString>
 #include <QTimer>
 
-#include <libtransmission/tr-macros.h>
-
 #include "BaseDialog.h"
 #include "Session.h"
 #include "Typedefs.h"
@@ -34,10 +32,13 @@ class TrackerModelFilter;
 class DetailsDialog : public BaseDialog
 {
     Q_OBJECT
-    TR_DISABLE_COPY_MOVE(DetailsDialog)
 
 public:
     DetailsDialog(Session&, Prefs&, TorrentModel const&, QWidget* parent = nullptr);
+    DetailsDialog(DetailsDialog&&) = delete;
+    DetailsDialog(DetailsDialog const&) = delete;
+    DetailsDialog& operator=(DetailsDialog&&) = delete;
+    DetailsDialog& operator=(DetailsDialog const&) = delete;
     ~DetailsDialog() override;
 
     void setIds(torrent_ids_t const& ids);

--- a/qt/FileTreeDelegate.h
+++ b/qt/FileTreeDelegate.h
@@ -7,18 +7,19 @@
 
 #include <QItemDelegate>
 
-#include <libtransmission/tr-macros.h>
-
 class FileTreeDelegate : public QItemDelegate
 {
     Q_OBJECT
-    TR_DISABLE_COPY_MOVE(FileTreeDelegate)
 
 public:
     explicit FileTreeDelegate(QObject* parent = nullptr)
         : QItemDelegate{ parent }
     {
     }
+    FileTreeDelegate(FileTreeDelegate&&) = delete;
+    FileTreeDelegate(FileTreeDelegate const&) = delete;
+    FileTreeDelegate& operator=(FileTreeDelegate&&) = delete;
+    FileTreeDelegate& operator=(FileTreeDelegate const&) = delete;
 
     // QAbstractItemDelegate
     QSize sizeHint(QStyleOptionViewItem const&, QModelIndex const&) const override;

--- a/qt/FileTreeItem.h
+++ b/qt/FileTreeItem.h
@@ -14,15 +14,14 @@
 #include <QString>
 #include <QVariant>
 
-#include <libtransmission/tr-macros.h>
-
 #include "Utils.h" // for std::hash<QString>
 #include "Typedefs.h"
+
+#include "libtransmission/tr-macros.h"
 
 class FileTreeItem
 {
     Q_DECLARE_TR_FUNCTIONS(FileTreeItem)
-    TR_DISABLE_COPY_MOVE(FileTreeItem)
 
 public:
     static auto constexpr Low = int{ 1 << 0 };
@@ -36,6 +35,10 @@ public:
     {
     }
 
+    FileTreeItem& operator=(FileTreeItem&&) = delete;
+    FileTreeItem& operator=(FileTreeItem const&) = delete;
+    FileTreeItem(FileTreeItem&&) = delete;
+    FileTreeItem(FileTreeItem const&) = delete;
     ~FileTreeItem();
 
     void appendChild(FileTreeItem* child);

--- a/qt/FileTreeModel.h
+++ b/qt/FileTreeModel.h
@@ -12,8 +12,6 @@
 
 #include <QAbstractItemModel>
 
-#include <libtransmission/tr-macros.h>
-
 #include "Typedefs.h" // file_indices_t
 
 class FileTreeItem;
@@ -21,7 +19,6 @@ class FileTreeItem;
 class FileTreeModel final : public QAbstractItemModel
 {
     Q_OBJECT
-    TR_DISABLE_COPY_MOVE(FileTreeModel)
 
 public:
     enum
@@ -44,6 +41,10 @@ public:
     };
 
     FileTreeModel(QObject* parent = nullptr, bool is_editable = true);
+    FileTreeModel& operator=(FileTreeModel&&) = delete;
+    FileTreeModel& operator=(FileTreeModel const&) = delete;
+    FileTreeModel(FileTreeModel&&) = delete;
+    FileTreeModel(FileTreeModel const&) = delete;
     ~FileTreeModel() override;
 
     void setEditable(bool editable);

--- a/qt/FileTreeView.h
+++ b/qt/FileTreeView.h
@@ -7,8 +7,6 @@
 
 #include <QTreeView>
 
-#include <libtransmission/tr-macros.h>
-
 #include "Torrent.h" // FileList
 #include "Typedefs.h" // file_indices_t
 
@@ -22,10 +20,13 @@ class FileTreeModel;
 class FileTreeView : public QTreeView
 {
     Q_OBJECT
-    TR_DISABLE_COPY_MOVE(FileTreeView)
 
 public:
     FileTreeView(QWidget* parent = nullptr, bool editable = true);
+    FileTreeView(FileTreeView&&) = delete;
+    FileTreeView(FileTreeView const&) = delete;
+    FileTreeView& operator=(FileTreeView&&) = delete;
+    FileTreeView& operator=(FileTreeView const&) = delete;
 
     void clear();
     void update(FileList const& files, bool update_fields = true);

--- a/qt/FilterBar.h
+++ b/qt/FilterBar.h
@@ -14,8 +14,6 @@
 #include <QTimer>
 #include <QWidget>
 
-#include <libtransmission/tr-macros.h>
-
 #include "Torrent.h"
 #include "Typedefs.h"
 
@@ -30,10 +28,13 @@ class TorrentModel;
 class FilterBar : public QWidget
 {
     Q_OBJECT
-    TR_DISABLE_COPY_MOVE(FilterBar)
 
 public:
     FilterBar(Prefs& prefs, TorrentModel const& torrents, TorrentFilter const& filter, QWidget* parent = nullptr);
+    FilterBar(FilterBar&&) = delete;
+    FilterBar(FilterBar const&) = delete;
+    FilterBar& operator=(FilterBar&&) = delete;
+    FilterBar& operator=(FilterBar const&) = delete;
 
 public slots:
     void clear();

--- a/qt/FilterBarComboBox.h
+++ b/qt/FilterBarComboBox.h
@@ -7,12 +7,9 @@
 
 #include <QComboBox>
 
-#include <libtransmission/tr-macros.h>
-
 class FilterBarComboBox : public QComboBox
 {
     Q_OBJECT
-    TR_DISABLE_COPY_MOVE(FilterBarComboBox)
 
 public:
     enum
@@ -23,6 +20,10 @@ public:
     };
 
     explicit FilterBarComboBox(QWidget* parent = nullptr);
+    FilterBarComboBox(FilterBarComboBox&&) = delete;
+    FilterBarComboBox(FilterBarComboBox const&) = delete;
+    FilterBarComboBox& operator=(FilterBarComboBox&&) = delete;
+    FilterBarComboBox& operator=(FilterBarComboBox const&) = delete;
 
     // QWidget
     QSize minimumSizeHint() const override;

--- a/qt/FilterBarComboBoxDelegate.h
+++ b/qt/FilterBarComboBoxDelegate.h
@@ -7,18 +7,19 @@
 
 #include <QItemDelegate>
 
-#include <libtransmission/tr-macros.h>
-
 class QAbstractItemModel;
 class QComboBox;
 
 class FilterBarComboBoxDelegate : public QItemDelegate
 {
     Q_OBJECT
-    TR_DISABLE_COPY_MOVE(FilterBarComboBoxDelegate)
 
 public:
     FilterBarComboBoxDelegate(QObject* parent, QComboBox* combo);
+    FilterBarComboBoxDelegate(FilterBarComboBoxDelegate&&) = delete;
+    FilterBarComboBoxDelegate(FilterBarComboBoxDelegate const&) = delete;
+    FilterBarComboBoxDelegate& operator=(FilterBarComboBoxDelegate&&) = delete;
+    FilterBarComboBoxDelegate& operator=(FilterBarComboBoxDelegate const&) = delete;
 
     static bool isSeparator(QModelIndex const& index);
     static void setSeparator(QAbstractItemModel* model, QModelIndex const& index);

--- a/qt/FreeSpaceLabel.h
+++ b/qt/FreeSpaceLabel.h
@@ -9,8 +9,6 @@
 #include <QString>
 #include <QTimer>
 
-#include <libtransmission/tr-macros.h>
-
 class Session;
 
 extern "C"
@@ -21,10 +19,13 @@ extern "C"
 class FreeSpaceLabel : public QLabel
 {
     Q_OBJECT
-    TR_DISABLE_COPY_MOVE(FreeSpaceLabel)
 
 public:
     explicit FreeSpaceLabel(QWidget* parent = nullptr);
+    FreeSpaceLabel(FreeSpaceLabel&&) = delete;
+    FreeSpaceLabel(FreeSpaceLabel const&) = delete;
+    FreeSpaceLabel& operator=(FreeSpaceLabel&&) = delete;
+    FreeSpaceLabel& operator=(FreeSpaceLabel const&) = delete;
 
     void setSession(Session& session);
     void setPath(QString const& path);

--- a/qt/IconToolButton.h
+++ b/qt/IconToolButton.h
@@ -7,15 +7,16 @@
 
 #include <QToolButton>
 
-#include <libtransmission/tr-macros.h>
-
 class IconToolButton : public QToolButton
 {
     Q_OBJECT
-    TR_DISABLE_COPY_MOVE(IconToolButton)
 
 public:
     explicit IconToolButton(QWidget* parent = nullptr);
+    IconToolButton(IconToolButton&&) = delete;
+    IconToolButton(IconToolButton const&) = delete;
+    IconToolButton& operator=(IconToolButton&&) = delete;
+    IconToolButton& operator=(IconToolButton const&) = delete;
 
     // QWidget
     QSize sizeHint() const override;

--- a/qt/InteropObject.h
+++ b/qt/InteropObject.h
@@ -7,12 +7,9 @@
 
 #include <QObject>
 
-#include <libtransmission/tr-macros.h>
-
 class InteropObject : public QObject
 {
     Q_OBJECT
-    TR_DISABLE_COPY_MOVE(InteropObject)
 
 #ifdef ENABLE_DBUS_INTEROP
     Q_CLASSINFO("D-Bus Interface", "com.transmissionbt.Transmission")
@@ -28,6 +25,10 @@ class InteropObject : public QObject
 
 public:
     explicit InteropObject(QObject* parent = nullptr);
+    InteropObject& operator=(InteropObject&&) = delete;
+    InteropObject& operator=(InteropObject const&) = delete;
+    InteropObject(InteropObject&&) = delete;
+    InteropObject(InteropObject const&) = delete;
 
 public slots:
     bool PresentWindow() const;

--- a/qt/LicenseDialog.h
+++ b/qt/LicenseDialog.h
@@ -5,18 +5,19 @@
 
 #pragma once
 
-#include <libtransmission/tr-macros.h>
-
 #include "BaseDialog.h"
 #include "ui_LicenseDialog.h"
 
 class LicenseDialog : public BaseDialog
 {
     Q_OBJECT
-    TR_DISABLE_COPY_MOVE(LicenseDialog)
 
 public:
     explicit LicenseDialog(QWidget* parent = nullptr);
+    LicenseDialog(LicenseDialog&&) = delete;
+    LicenseDialog(LicenseDialog const&) = delete;
+    LicenseDialog& operator=(LicenseDialog&&) = delete;
+    LicenseDialog& operator=(LicenseDialog const&) = delete;
 
 private:
     Ui::LicenseDialog ui_ = {};

--- a/qt/MainWindow.h
+++ b/qt/MainWindow.h
@@ -17,8 +17,6 @@
 #include <QTimer>
 #include <QWidgetList>
 
-#include <libtransmission/tr-macros.h>
-
 #include "Filters.h"
 #include "Speed.h"
 #include "TorrentFilter.h"
@@ -50,10 +48,13 @@ extern "C"
 class MainWindow : public QMainWindow
 {
     Q_OBJECT
-    TR_DISABLE_COPY_MOVE(MainWindow)
 
 public:
     MainWindow(Session&, Prefs&, TorrentModel&, bool minimized);
+    MainWindow(MainWindow&&) = delete;
+    MainWindow(MainWindow const&) = delete;
+    MainWindow& operator=(MainWindow&&) = delete;
+    MainWindow& operator=(MainWindow const&) = delete;
 
     [[nodiscard]] constexpr QSystemTrayIcon& trayIcon() noexcept
     {

--- a/qt/MakeDialog.h
+++ b/qt/MakeDialog.h
@@ -7,7 +7,6 @@
 
 #include <optional>
 
-#include <libtransmission/tr-macros.h>
 #include <libtransmission/makemeta.h>
 
 #include "BaseDialog.h"
@@ -19,10 +18,13 @@ class Session;
 class MakeDialog : public BaseDialog
 {
     Q_OBJECT
-    TR_DISABLE_COPY_MOVE(MakeDialog)
 
 public:
     MakeDialog(Session&, QWidget* parent = nullptr);
+    MakeDialog(MakeDialog&&) = delete;
+    MakeDialog(MakeDialog const&) = delete;
+    MakeDialog& operator=(MakeDialog&&) = delete;
+    MakeDialog& operator=(MakeDialog const&) = delete;
 
 protected:
     // QWidget

--- a/qt/OptionsDialog.h
+++ b/qt/OptionsDialog.h
@@ -13,8 +13,6 @@
 #include <QString>
 #include <QTimer>
 
-#include <libtransmission/tr-macros.h>
-
 #include "AddData.h" // AddData
 #include "BaseDialog.h"
 #include "Torrent.h" // FileList
@@ -36,10 +34,13 @@ extern "C"
 class OptionsDialog : public BaseDialog
 {
     Q_OBJECT
-    TR_DISABLE_COPY_MOVE(OptionsDialog)
 
 public:
     OptionsDialog(Session& session, Prefs const& prefs, AddData addme, QWidget* parent = nullptr);
+    OptionsDialog& operator=(OptionsDialog&&) = delete;
+    OptionsDialog& operator=(OptionsDialog const&) = delete;
+    OptionsDialog(OptionsDialog&&) = delete;
+    OptionsDialog(OptionsDialog const&) = delete;
     ~OptionsDialog() override;
 
 private slots:

--- a/qt/PathButton.h
+++ b/qt/PathButton.h
@@ -7,12 +7,9 @@
 
 #include <QToolButton>
 
-#include <libtransmission/tr-macros.h>
-
 class PathButton : public QToolButton
 {
     Q_OBJECT
-    TR_DISABLE_COPY_MOVE(PathButton)
 
 public:
     enum Mode
@@ -22,6 +19,10 @@ public:
     };
 
     explicit PathButton(QWidget* parent = nullptr);
+    PathButton(PathButton&&) = delete;
+    PathButton(PathButton const&) = delete;
+    PathButton& operator=(PathButton&&) = delete;
+    PathButton& operator=(PathButton const&) = delete;
 
     void setMode(Mode mode);
     void setTitle(QString const& title);

--- a/qt/Prefs.h
+++ b/qt/Prefs.h
@@ -12,7 +12,6 @@
 #include <QVariant>
 
 #include <libtransmission/quark.h>
-#include <libtransmission/tr-macros.h>
 
 class QDateTime;
 
@@ -24,7 +23,6 @@ extern "C"
 class Prefs : public QObject
 {
     Q_OBJECT
-    TR_DISABLE_COPY_MOVE(Prefs)
 
 public:
     enum
@@ -132,6 +130,10 @@ public:
     };
 
     explicit Prefs(QString config_dir);
+    Prefs(Prefs&&) = delete;
+    Prefs(Prefs const&) = delete;
+    Prefs& operator=(Prefs&&) = delete;
+    Prefs& operator=(Prefs const&) = delete;
     ~Prefs() override;
 
     [[nodiscard]] constexpr auto isCore(int key) const noexcept

--- a/qt/PrefsDialog.h
+++ b/qt/PrefsDialog.h
@@ -9,8 +9,6 @@
 #include <map>
 #include <optional>
 
-#include <libtransmission/tr-macros.h>
-
 #include "BaseDialog.h"
 #include "Prefs.h"
 #include "Session.h"
@@ -23,10 +21,13 @@ class QString;
 class PrefsDialog : public BaseDialog
 {
     Q_OBJECT
-    TR_DISABLE_COPY_MOVE(PrefsDialog)
 
 public:
     PrefsDialog(Session&, Prefs&, QWidget* parent = nullptr);
+    PrefsDialog& operator=(PrefsDialog&&) = delete;
+    PrefsDialog& operator=(PrefsDialog const&) = delete;
+    PrefsDialog(PrefsDialog&&) = delete;
+    PrefsDialog(PrefsDialog const&) = delete;
 
 private slots:
     void focusChanged(QWidget* old, QWidget* cur);

--- a/qt/RelocateDialog.h
+++ b/qt/RelocateDialog.h
@@ -5,8 +5,6 @@
 
 #pragma once
 
-#include <libtransmission/tr-macros.h>
-
 #include "BaseDialog.h"
 #include "Typedefs.h"
 #include "ui_RelocateDialog.h"
@@ -17,10 +15,13 @@ class TorrentModel;
 class RelocateDialog : public BaseDialog
 {
     Q_OBJECT
-    TR_DISABLE_COPY_MOVE(RelocateDialog)
 
 public:
     RelocateDialog(Session&, TorrentModel const&, torrent_ids_t ids, QWidget* parent = nullptr);
+    RelocateDialog(RelocateDialog&&) = delete;
+    RelocateDialog(RelocateDialog const&) = delete;
+    RelocateDialog& operator=(RelocateDialog&&) = delete;
+    RelocateDialog& operator=(RelocateDialog const&) = delete;
 
 private slots:
     void onSetLocation();

--- a/qt/RpcClient.h
+++ b/qt/RpcClient.h
@@ -50,10 +50,13 @@ using RpcResponseFuture = QFuture<RpcResponse>;
 class RpcClient : public QObject
 {
     Q_OBJECT
-    TR_DISABLE_COPY_MOVE(RpcClient)
 
 public:
     explicit RpcClient(QObject* parent = nullptr);
+    RpcClient(RpcClient&&) = delete;
+    RpcClient(RpcClient const&) = delete;
+    RpcClient& operator=(RpcClient&&) = delete;
+    RpcClient& operator=(RpcClient const&) = delete;
 
     [[nodiscard]] constexpr auto const& url() const noexcept
     {

--- a/qt/RpcQueue.h
+++ b/qt/RpcQueue.h
@@ -15,17 +15,18 @@
 #include <QFutureWatcher>
 #include <QObject>
 
-#include <libtransmission/tr-macros.h>
-
 #include "RpcClient.h"
 
 class RpcQueue : public QObject
 {
     Q_OBJECT
-    TR_DISABLE_COPY_MOVE(RpcQueue)
 
 public:
     explicit RpcQueue(QObject* parent = nullptr);
+    RpcQueue(RpcQueue&&) = delete;
+    RpcQueue(RpcQueue const&) = delete;
+    RpcQueue& operator=(RpcQueue&&) = delete;
+    RpcQueue& operator=(RpcQueue const&) = delete;
 
     constexpr void setTolerateErrors(bool tolerate_errors = true)
     {

--- a/qt/Session.h
+++ b/qt/Session.h
@@ -20,7 +20,6 @@
 
 #include <libtransmission/transmission.h>
 #include <libtransmission/quark.h>
-#include <libtransmission/tr-macros.h>
 
 #include "RpcClient.h"
 #include "RpcQueue.h"
@@ -38,10 +37,13 @@ extern "C"
 class Session : public QObject
 {
     Q_OBJECT
-    TR_DISABLE_COPY_MOVE(Session)
 
 public:
     Session(QString config_dir, Prefs& prefs);
+    Session(Session&&) = delete;
+    Session(Session const&) = delete;
+    Session& operator=(Session&&) = delete;
+    Session& operator=(Session const&) = delete;
     ~Session() override;
 
     void stop();

--- a/qt/SessionDialog.h
+++ b/qt/SessionDialog.h
@@ -7,8 +7,6 @@
 
 #include <QWidgetList>
 
-#include <libtransmission/tr-macros.h>
-
 #include "BaseDialog.h"
 #include "ui_SessionDialog.h"
 
@@ -18,10 +16,13 @@ class Session;
 class SessionDialog : public BaseDialog
 {
     Q_OBJECT
-    TR_DISABLE_COPY_MOVE(SessionDialog)
 
 public:
     SessionDialog(Session& session, Prefs& prefs, QWidget* parent = nullptr);
+    SessionDialog(SessionDialog&&) = delete;
+    SessionDialog(SessionDialog const&) = delete;
+    SessionDialog& operator=(SessionDialog&&) = delete;
+    SessionDialog& operator=(SessionDialog const&) = delete;
 
 public slots:
     // QDialog

--- a/qt/SqueezeLabel.h
+++ b/qt/SqueezeLabel.h
@@ -43,16 +43,17 @@
 
 #include <QLabel>
 
-#include <libtransmission/tr-macros.h>
-
 class SqueezeLabel : public QLabel
 {
     Q_OBJECT
-    TR_DISABLE_COPY_MOVE(SqueezeLabel)
 
 public:
     explicit SqueezeLabel(QWidget* parent = nullptr);
     explicit SqueezeLabel(QString const& text, QWidget* parent = nullptr);
+    SqueezeLabel(SqueezeLabel&&) = delete;
+    SqueezeLabel(SqueezeLabel const&) = delete;
+    SqueezeLabel& operator=(SqueezeLabel&&) = delete;
+    SqueezeLabel& operator=(SqueezeLabel const&) = delete;
 
 protected:
     // QWidget

--- a/qt/StatsDialog.h
+++ b/qt/StatsDialog.h
@@ -7,8 +7,6 @@
 
 #include <QTimer>
 
-#include <libtransmission/tr-macros.h>
-
 #include "BaseDialog.h"
 #include "ui_StatsDialog.h"
 
@@ -17,10 +15,13 @@ class Session;
 class StatsDialog : public BaseDialog
 {
     Q_OBJECT
-    TR_DISABLE_COPY_MOVE(StatsDialog)
 
 public:
     explicit StatsDialog(Session&, QWidget* parent = nullptr);
+    StatsDialog(StatsDialog&&) = delete;
+    StatsDialog(StatsDialog const&) = delete;
+    StatsDialog& operator=(StatsDialog&&) = delete;
+    StatsDialog& operator=(StatsDialog const&) = delete;
 
     // QWidget
     void setVisible(bool visible) override;

--- a/qt/Torrent.h
+++ b/qt/Torrent.h
@@ -21,8 +21,8 @@
 #include <libtransmission/transmission.h>
 
 #include <libtransmission/crypto-utils.h>
+#include "libtransmission/tr-macros.h"
 #include <libtransmission/quark.h>
-#include <libtransmission/tr-macros.h>
 
 #include "IconCache.h"
 #include "Speed.h"
@@ -147,10 +147,13 @@ public:
 class Torrent : public QObject
 {
     Q_OBJECT
-    TR_DISABLE_COPY_MOVE(Torrent)
 
 public:
     Torrent(Prefs const&, int id);
+    Torrent(Torrent&&) = delete;
+    Torrent(Torrent const&) = delete;
+    Torrent& operator=(Torrent&&) = delete;
+    Torrent& operator=(Torrent const&) = delete;
 
     [[nodiscard]] constexpr auto getBandwidthPriority() const noexcept
     {

--- a/qt/TorrentDelegate.h
+++ b/qt/TorrentDelegate.h
@@ -9,8 +9,6 @@
 
 #include <QStyledItemDelegate>
 
-#include <libtransmission/tr-macros.h>
-
 class QStyle;
 class QStyleOptionProgressBar;
 
@@ -19,10 +17,13 @@ class Torrent;
 class TorrentDelegate : public QStyledItemDelegate
 {
     Q_OBJECT
-    TR_DISABLE_COPY_MOVE(TorrentDelegate)
 
 public:
     explicit TorrentDelegate(QObject* parent = nullptr);
+    TorrentDelegate& operator=(TorrentDelegate&&) = delete;
+    TorrentDelegate& operator=(TorrentDelegate const&) = delete;
+    TorrentDelegate(TorrentDelegate&&) = delete;
+    TorrentDelegate(TorrentDelegate const&) = delete;
 
     // QAbstractItemDelegate
     QSize sizeHint(QStyleOptionViewItem const& option, QModelIndex const& index) const override;

--- a/qt/TorrentDelegateMin.h
+++ b/qt/TorrentDelegateMin.h
@@ -5,20 +5,21 @@
 
 #pragma once
 
-#include <libtransmission/tr-macros.h>
-
 #include "TorrentDelegate.h"
 
 class TorrentDelegateMin : public TorrentDelegate
 {
     Q_OBJECT
-    TR_DISABLE_COPY_MOVE(TorrentDelegateMin)
 
 public:
     explicit TorrentDelegateMin(QObject* parent = nullptr)
         : TorrentDelegate{ parent }
     {
     }
+    TorrentDelegateMin(TorrentDelegateMin&&) = delete;
+    TorrentDelegateMin(TorrentDelegateMin const&) = delete;
+    TorrentDelegateMin& operator=(TorrentDelegateMin&&) = delete;
+    TorrentDelegateMin& operator=(TorrentDelegateMin const&) = delete;
 
 protected:
     // TorrentDelegate

--- a/qt/TorrentFilter.h
+++ b/qt/TorrentFilter.h
@@ -10,8 +10,6 @@
 #include <QSortFilterProxyModel>
 #include <QTimer>
 
-#include <libtransmission/tr-macros.h>
-
 #include "Filters.h"
 
 class QString;
@@ -23,7 +21,6 @@ class Torrent;
 class TorrentFilter : public QSortFilterProxyModel
 {
     Q_OBJECT
-    TR_DISABLE_COPY_MOVE(TorrentFilter)
 
 public:
     enum TextMode
@@ -34,6 +31,11 @@ public:
     };
 
     explicit TorrentFilter(Prefs const& prefs);
+    TorrentFilter(TorrentFilter&&) = delete;
+    TorrentFilter(TorrentFilter const&) = delete;
+    TorrentFilter& operator=(TorrentFilter&&) = delete;
+    TorrentFilter& operator=(TorrentFilter const&) = delete;
+
     [[nodiscard]] std::array<int, FilterMode::NUM_MODES> countTorrentsPerMode() const;
 
 protected:

--- a/qt/TorrentModel.h
+++ b/qt/TorrentModel.h
@@ -11,8 +11,6 @@
 
 #include <QAbstractListModel>
 
-#include <libtransmission/tr-macros.h>
-
 #include "Torrent.h"
 #include "Typedefs.h"
 
@@ -27,7 +25,6 @@ extern "C"
 class TorrentModel : public QAbstractListModel
 {
     Q_OBJECT
-    TR_DISABLE_COPY_MOVE(TorrentModel)
 
 public:
     enum Role
@@ -36,6 +33,10 @@ public:
     };
 
     explicit TorrentModel(Prefs const& prefs);
+    TorrentModel& operator=(TorrentModel&&) = delete;
+    TorrentModel& operator=(TorrentModel const&) = delete;
+    TorrentModel(TorrentModel&&) = delete;
+    TorrentModel(TorrentModel const&) = delete;
     ~TorrentModel() override;
     void clear();
 

--- a/qt/TorrentView.h
+++ b/qt/TorrentView.h
@@ -7,15 +7,16 @@
 
 #include <QListView>
 
-#include <libtransmission/tr-macros.h>
-
 class TorrentView : public QListView
 {
     Q_OBJECT
-    TR_DISABLE_COPY_MOVE(TorrentView)
 
 public:
     explicit TorrentView(QWidget* parent = nullptr);
+    TorrentView(TorrentView&&) = delete;
+    TorrentView(TorrentView const&) = delete;
+    TorrentView& operator=(TorrentView&&) = delete;
+    TorrentView& operator=(TorrentView const&) = delete;
 
 public slots:
     void setHeaderText(QString const& text);

--- a/qt/TrackerDelegate.h
+++ b/qt/TrackerDelegate.h
@@ -7,8 +7,6 @@
 
 #include <QItemDelegate>
 
-#include <libtransmission/tr-macros.h>
-
 class QStyle;
 
 class Session;
@@ -17,13 +15,16 @@ struct TrackerInfo;
 class TrackerDelegate : public QItemDelegate
 {
     Q_OBJECT
-    TR_DISABLE_COPY_MOVE(TrackerDelegate)
 
 public:
     explicit TrackerDelegate(QObject* parent = nullptr)
         : QItemDelegate{ parent }
     {
     }
+    TrackerDelegate(TrackerDelegate&&) = delete;
+    TrackerDelegate(TrackerDelegate const&) = delete;
+    TrackerDelegate& operator=(TrackerDelegate&&) = delete;
+    TrackerDelegate& operator=(TrackerDelegate const&) = delete;
 
     void setShowMore(bool b);
 

--- a/qt/TrackerModel.h
+++ b/qt/TrackerModel.h
@@ -9,8 +9,6 @@
 
 #include <QAbstractListModel>
 
-#include <libtransmission/tr-macros.h>
-
 #include "Torrent.h"
 #include "Typedefs.h"
 
@@ -27,7 +25,6 @@ Q_DECLARE_METATYPE(TrackerInfo)
 class TrackerModel : public QAbstractListModel
 {
     Q_OBJECT
-    TR_DISABLE_COPY_MOVE(TrackerModel)
 
 public:
     enum Role
@@ -36,6 +33,10 @@ public:
     };
 
     TrackerModel() = default;
+    TrackerModel(TrackerModel&&) = delete;
+    TrackerModel(TrackerModel const&) = delete;
+    TrackerModel& operator=(TrackerModel&&) = delete;
+    TrackerModel& operator=(TrackerModel const&) = delete;
 
     void refresh(TorrentModel const&, torrent_ids_t const& ids);
     int find(int torrent_id, QString const& url) const;

--- a/qt/TrackerModelFilter.h
+++ b/qt/TrackerModelFilter.h
@@ -7,15 +7,16 @@
 
 #include <QSortFilterProxyModel>
 
-#include <libtransmission/tr-macros.h>
-
 class TrackerModelFilter : public QSortFilterProxyModel
 {
     Q_OBJECT
-    TR_DISABLE_COPY_MOVE(TrackerModelFilter)
 
 public:
     explicit TrackerModelFilter(QObject* parent = nullptr);
+    TrackerModelFilter(TrackerModelFilter&&) = delete;
+    TrackerModelFilter(TrackerModelFilter const&) = delete;
+    TrackerModelFilter& operator=(TrackerModelFilter&&) = delete;
+    TrackerModelFilter& operator=(TrackerModelFilter const&) = delete;
 
     void setShowBackupTrackers(bool);
 

--- a/qt/WatchDir.h
+++ b/qt/WatchDir.h
@@ -12,17 +12,18 @@
 #include <QFileSystemWatcher>
 #include <QString>
 
-#include <libtransmission/tr-macros.h>
-
 class TorrentModel;
 
 class WatchDir : public QObject
 {
     Q_OBJECT
-    TR_DISABLE_COPY_MOVE(WatchDir)
 
 public:
     explicit WatchDir(TorrentModel const&);
+    WatchDir(WatchDir&&) = delete;
+    WatchDir(WatchDir const&) = delete;
+    WatchDir& operator=(WatchDir&&) = delete;
+    WatchDir& operator=(WatchDir const&) = delete;
 
     void setPath(QString const& path, bool is_enabled);
 

--- a/tests/libtransmission/torrent-files-test.cc
+++ b/tests/libtransmission/torrent-files-test.cc
@@ -15,6 +15,7 @@
 
 #include <libtransmission/file.h>
 #include <libtransmission/torrent-files.h>
+#include "libtransmission/tr-macros.h"
 #include <libtransmission/tr-strbuf.h>
 
 #include "gtest/gtest.h"

--- a/tests/libtransmission/watchdir-test.cc
+++ b/tests/libtransmission/watchdir-test.cc
@@ -25,7 +25,6 @@
 #include <libtransmission/file.h>
 #include <libtransmission/timer.h>
 #include <libtransmission/timer-ev.h>
-#include <libtransmission/tr-macros.h>
 #include <libtransmission/tr-strbuf.h>
 #include <libtransmission/utils.h>
 #include <libtransmission/watchdir.h>


### PR DESCRIPTION
does what it says on the tin: remove the `TR_DISABLE_COPY_MOVE` macro.

Different project, but similar to https://chromium-review.googlesource.com/c/chromium/src/+/3261552