### PR TITLE
fix: cert-oop54-cpp warnings about self-assignment in strbuf

### DIFF
--- a/libtransmission/tr-strbuf.h
+++ b/libtransmission/tr-strbuf.h
@@ -35,12 +35,19 @@ public:
 
     tr_strbuf(tr_strbuf const& other)
     {
-        assign(other.sv());
+        if (this != &other)
+        {
+            assign(other.sv());
+        }
     }
 
     tr_strbuf& operator=(tr_strbuf const& other)
     {
-        assign(other.sv());
+        if (this != &other)
+        {
+            assign(other.sv());
+        }
+
         return *this;
     }
 


### PR DESCRIPTION
Warning generated by clang-tidy-20, e.g.:

> ../libtransmission/tr-strbuf.h:41:16: warning: operator=() does not handle self-assignment properly [cert-oop54-cpp]
