### PR TITLE
fix(web): enable/disable textbox when session changed

### DIFF
--- a/web/src/prefs-dialog.js
+++ b/web/src/prefs-dialog.js
@@ -205,7 +205,6 @@ export class PrefsDialog extends EventTarget {
         element.classList.toggle('disabled', !check.checked);
       }
     };
-    check.addEventListener('change', callback);
     check.addEventListener('session-change', callback);
     callback();
   }

--- a/web/src/prefs-dialog.js
+++ b/web/src/prefs-dialog.js
@@ -170,6 +170,8 @@ export class PrefsDialog extends EventTarget {
               break;
           }
         }
+
+        element.dispatchEvent(new Event('session-change'));
       }
     }
   }
@@ -204,6 +206,7 @@ export class PrefsDialog extends EventTarget {
       }
     };
     check.addEventListener('change', callback);
+    check.addEventListener('session-change', callback);
     callback();
   }
 


### PR DESCRIPTION
Fixes a problem where textboxes in the preferences popup that has a checkbox that enables/disables it does not respond to session changes that are not triggered by the WebUI.

This can be demonstrated by opening the preferences for speed limit, then enable/disable the speed limit by `transmission-remote -d <limit>` and `transmission-remote -D`.

### Before

![before](https://github.com/user-attachments/assets/6152675f-01c4-4763-9b36-dc367156aaa0)

### After

![after](https://github.com/user-attachments/assets/16ccbc4f-efe8-42cc-8eb9-25ec4dac7a7c)
