### PR TITLE
refactor: drop className `.full` in favor of `:not(.compact)`

### DIFF
--- a/web/assets/css/transmission-app.scss
+++ b/web/assets/css/transmission-app.scss
@@ -668,7 +668,7 @@ a {
     border-radius: 3px;
     height: 18px;
 
-    &.full {
+    &:not(.compact) {
       flex-grow: 1;
       margin: 2px 0;
     }

--- a/web/src/torrent-row.js
+++ b/web/src/torrent-row.js
@@ -234,7 +234,6 @@ export class TorrentRendererFull {
 
     // progressbar
     TorrentRendererHelper.renderProgressbar(controller, torrent, progressbar);
-    progressbar.classList.add('full');
 
     // peer details
     TorrentRendererFull.renderPeerDetails(torrent, peer_details);
@@ -250,7 +249,7 @@ export class TorrentRendererFull {
       ['name', 'torrent-name'],
       ['labels', 'torrent-labels'],
       ['progress_details', 'torrent-progress-details'],
-      ['progressbar', 'torrent-progress-bar full'],
+      ['progressbar', 'torrent-progress-bar'],
       ['peer_details', 'torrent-peer-details'],
     ];
 


### PR DESCRIPTION
In anticipation to #7335, some codes were pulled from there.