### PR TITLE
refactor: set peer io socket in constructor

### DIFF
--- a/libtransmission/net.cc
+++ b/libtransmission/net.cc
@@ -228,7 +228,7 @@ tr_socket_t createSocket(int domain, int type)
 }
 } // namespace
 
-tr_peer_socket tr_netOpenPeerSocket(tr_session* session, tr_socket_address const& socket_address, bool client_is_seed)
+tr_socket_t tr_netOpenPeerSocket(tr_session* session, tr_socket_address const& socket_address, bool client_is_seed)
 {
     auto const& [addr, port] = socket_address;
 
@@ -237,13 +237,13 @@ tr_peer_socket tr_netOpenPeerSocket(tr_session* session, tr_socket_address const
 
     if (tr_peer_socket::limit_reached(session) || !session->allowsTCP() || !socket_address.is_valid())
     {
-        return {};
+        return TR_BAD_SOCKET;
     }
 
     auto const s = createSocket(tr_ip_protocol_to_af(addr.type), SOCK_STREAM);
     if (s == TR_BAD_SOCKET)
     {
-        return {};
+        return TR_BAD_SOCKET;
     }
 
     // seeds don't need a big read buffer, so make it smaller
@@ -272,7 +272,7 @@ tr_peer_socket tr_netOpenPeerSocket(tr_session* session, tr_socket_address const
             fmt::arg("error", tr_net_strerror(sockerrno)),
             fmt::arg("error_code", sockerrno)));
         tr_net_close_socket(s);
-        return {};
+        return TR_BAD_SOCKET;
     }
 
     if (connect(s, reinterpret_cast<sockaddr const*>(&sock), addrlen) == -1 &&
@@ -294,12 +294,12 @@ tr_peer_socket tr_netOpenPeerSocket(tr_session* session, tr_socket_address const
         }
 
         tr_net_close_socket(s);
-        return {};
+        return TR_BAD_SOCKET;
     }
 
     tr_logAddTrace(fmt::format("New OUTGOING connection {} ({})", s, socket_address.display_name()));
 
-    return { session, socket_address, s };
+    return s;
 }
 
 namespace

--- a/libtransmission/net.cc
+++ b/libtransmission/net.cc
@@ -228,7 +228,7 @@ tr_socket_t createSocket(int domain, int type)
 }
 } // namespace
 
-tr_socket_t tr_netOpenPeerSocket(tr_session* session, tr_socket_address const& socket_address, bool client_is_seed)
+tr_socket_t tr_net_open_peer_socket(tr_session* session, tr_socket_address const& socket_address, bool client_is_seed)
 {
     auto const& [addr, port] = socket_address;
 

--- a/libtransmission/net.h
+++ b/libtransmission/net.h
@@ -466,6 +466,8 @@ tr_socket_t tr_netBindTCP(tr_address const& addr, tr_port port, bool suppress_ms
 
 void tr_netSetCongestionControl(tr_socket_t s, char const* algorithm);
 
+tr_socket_t tr_netOpenPeerSocket(tr_session* session, tr_socket_address const& socket_address, bool client_is_seed);
+
 void tr_net_close_socket(tr_socket_t fd);
 
 // --- TOS / DSCP

--- a/libtransmission/net.h
+++ b/libtransmission/net.h
@@ -466,7 +466,10 @@ tr_socket_t tr_netBindTCP(tr_address const& addr, tr_port port, bool suppress_ms
 
 void tr_netSetCongestionControl(tr_socket_t s, char const* algorithm);
 
-tr_socket_t tr_netOpenPeerSocket(tr_session* session, tr_socket_address const& socket_address, bool client_is_seed);
+[[nodiscard]] tr_socket_t tr_net_open_peer_socket(
+    tr_session* session,
+    tr_socket_address const& socket_address,
+    bool client_is_seed);
 
 void tr_net_close_socket(tr_socket_t fd);
 

--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -162,9 +162,9 @@ std::shared_ptr<tr_peerIo> tr_peerIo::new_outgoing(
           {
               if (!peer_io->socket_.is_valid())
               {
-                  if (auto sock = tr_netOpenPeerSocket(session, socket_address, client_is_seed); sock.is_valid())
+                  if (auto sock = tr_netOpenPeerSocket(session, socket_address, client_is_seed); sock != TR_BAD_SOCKET)
                   {
-                      peer_io->set_socket(std::move(sock));
+                      peer_io->set_socket({ session, socket_address, sock });
                       return true;
                   }
               }
@@ -254,12 +254,12 @@ bool tr_peerIo::reconnect()
 
     close();
 
-    auto sock = tr_netOpenPeerSocket(session_, socket_address(), client_is_seed());
-    if (!sock.is_tcp())
+    auto const s = tr_netOpenPeerSocket(session_, socket_address(), client_is_seed());
+    if (s == TR_BAD_SOCKET)
     {
         return false;
     }
-    set_socket(std::move(sock));
+    set_socket({ session_, socket_address(), s });
 
     event_enable(pending_events);
 

--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -124,6 +124,8 @@ std::shared_ptr<tr_peerIo> tr_peerIo::new_outgoing(
     TR_ASSERT(socket_address.is_valid());
     TR_ASSERT(utp || session->allowsTCP());
 
+    // N.B. This array needs to be kept in the same order as
+    // the tr_preferred_transport enum.
     auto const get_socket = std::array<std::function<tr_peer_socket()>, TR_NUM_PREFERRED_TRANSPORT>{
         [&]() -> tr_peer_socket
         {

--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -142,7 +142,7 @@ std::shared_ptr<tr_peerIo> tr_peerIo::new_outgoing(
         },
         [&]() -> tr_peer_socket
         {
-            if (auto sock = tr_netOpenPeerSocket(session, socket_address, client_is_seed); sock != TR_BAD_SOCKET)
+            if (auto sock = tr_net_open_peer_socket(session, socket_address, client_is_seed); sock != TR_BAD_SOCKET)
             {
                 return { session, socket_address, sock };
             }
@@ -226,7 +226,7 @@ bool tr_peerIo::reconnect()
 
     close();
 
-    auto const s = tr_netOpenPeerSocket(session_, socket_address(), client_is_seed());
+    auto const s = tr_net_open_peer_socket(session_, socket_address(), client_is_seed());
     if (s == TR_BAD_SOCKET)
     {
         return false;

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -65,11 +65,12 @@ class tr_peerIo final : public std::enable_shared_from_this<tr_peerIo>
 
 public:
     tr_peerIo(
-        tr_session* session_in,
+        tr_session* session,
+        tr_peer_socket&& socket,
+        tr_bandwidth* parent_bandwidth,
         tr_sha1_digest_t const* info_hash,
         bool is_incoming,
-        bool client_is_seed,
-        tr_bandwidth* parent_bandwidth);
+        bool client_is_seed);
 
     ~tr_peerIo();
 
@@ -353,6 +354,7 @@ private:
     // production code should use new_outgoing() or new_incoming()
     static std::shared_ptr<tr_peerIo> create(
         tr_session* session,
+        tr_peer_socket&& socket,
         tr_bandwidth* parent,
         tr_sha1_digest_t const* info_hash,
         bool is_incoming,

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -49,7 +49,6 @@ enum class ReadState : uint8_t
 
 enum tr_preferred_transport : uint8_t
 {
-    // More preferred transports goes on top
     TR_PREFER_UTP,
     TR_PREFER_TCP,
     TR_NUM_PREFERRED_TRANSPORT

--- a/libtransmission/peer-socket.h
+++ b/libtransmission/peer-socket.h
@@ -116,5 +116,3 @@ private:
 
     static inline std::atomic<size_t> n_open_sockets_ = {};
 };
-
-tr_peer_socket tr_netOpenPeerSocket(tr_session* session, tr_socket_address const& socket_address, bool client_is_seed);

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -402,6 +402,7 @@ public:
         size_t speed_limit_down = 100U;
         size_t speed_limit_up = 100U;
         size_t upload_slots_per_torrent = 8U;
+        std::array<tr_preferred_transport, TR_NUM_PREFERRED_TRANSPORT> preferred_transport = { TR_PREFER_UTP, TR_PREFER_TCP };
         std::chrono::milliseconds sleep_per_seconds_during_verify = std::chrono::milliseconds{ 100 };
         std::string announce_ip;
         std::string bind_address_ipv4;
@@ -421,7 +422,6 @@ public:
         tr_port peer_port_random_high = tr_port::from_host(65535);
         tr_port peer_port_random_low = tr_port::from_host(49152);
         tr_port peer_port = tr_port::from_host(TR_DEFAULT_PEER_PORT);
-        tr_preferred_transport preferred_transport = TR_PREFER_UTP;
         tr_tos_t peer_socket_tos{ 0x04 };
         tr_verify_added_mode torrent_added_verify_mode = TR_VERIFY_ADDED_FAST;
 
@@ -939,7 +939,7 @@ public:
 
     [[nodiscard]] bool allowsUTP() const noexcept;
 
-    [[nodiscard]] constexpr auto preferred_transport() const noexcept
+    [[nodiscard]] constexpr auto const& preferred_transport() const noexcept
     {
         return settings().preferred_transport;
     }

--- a/tests/libtransmission/handshake-test.cc
+++ b/tests/libtransmission/handshake-test.cc
@@ -180,8 +180,13 @@ public:
         EXPECT_EQ(0, evutil_socketpair(LOCAL_SOCKETPAIR_AF, SOCK_STREAM, 0, std::data(sockpair))) << tr_strerror(errno);
         EXPECT_EQ(0, evutil_make_socket_nonblocking(sockpair[0]));
         EXPECT_EQ(0, evutil_make_socket_nonblocking(sockpair[1]));
-        auto peer_io = tr_peerIo::create(session, &session->top_bandwidth_, &info_hash, false /*incoming*/, false /*seed*/);
-        peer_io->set_socket(tr_peer_socket(session, DefaultPeerSockAddr, sockpair[0]));
+        auto peer_io = tr_peerIo::create(
+            session,
+            { session, DefaultPeerSockAddr, static_cast<tr_socket_t>(sockpair[0]) },
+            &session->top_bandwidth_,
+            &info_hash,
+            false /*incoming*/,
+            false /*seed*/);
         return std::pair{ std::move(peer_io), sockpair[1] };
     }
 

--- a/tests/libtransmission/settings-test.cc
+++ b/tests/libtransmission/settings-test.cc
@@ -418,14 +418,14 @@ TEST_F(SettingsTest, canSaveVerify)
 TEST_F(SettingsTest, canLoadPreferredTransport)
 {
     static auto constexpr Key = TR_KEY_preferred_transport;
-    auto constexpr ExpectedValue = TR_PREFER_TCP;
+    static auto constexpr ExpectedValue = std::array{ TR_PREFER_TCP, TR_PREFER_UTP };
 
     auto settings = std::make_unique<tr_session::Settings>();
-    auto const default_value = settings->preferred_transport;
+    auto const& default_value = settings->preferred_transport;
     ASSERT_NE(ExpectedValue, default_value);
 
     auto map = tr_variant::Map{ 1U };
-    map.try_emplace(Key, ExpectedValue);
+    map.try_emplace(Key, ExpectedValue.front());
     settings->load(tr_variant{ std::move(map) });
     EXPECT_EQ(ExpectedValue, settings->preferred_transport);
 
@@ -439,10 +439,10 @@ TEST_F(SettingsTest, canLoadPreferredTransport)
 TEST_F(SettingsTest, canSavePreferredTransport)
 {
     static auto constexpr Key = TR_KEY_preferred_transport;
-    static auto constexpr ExpectedValue = TR_PREFER_TCP;
+    static auto constexpr ExpectedValue = std::array{ TR_PREFER_TCP, TR_PREFER_UTP };
 
     auto settings = tr_session::Settings{};
-    auto const default_value = settings.preferred_transport;
+    auto const& default_value = settings.preferred_transport;
     ASSERT_NE(ExpectedValue, default_value);
 
     settings.preferred_transport = ExpectedValue;


### PR DESCRIPTION
This PR accomplishes a few things:

- Fixes #7157. Supercedes #7348.
- Fixes regression from #4372 where Transmission will not retry the outgoing connection attempt with TCP if `utp_connect()` returns non-zero. Supercedes #7349. *Note that in practice `utp_connect()` should never return non-zero, I'm just being thorough here.*
- Removes the need for workarounds like #6881.
- Paves way for #6007 by storing the transport protocol preference in an array.