### PR TITLE
refactor: clean up Flexbox style rules in CSS

### DIFF
--- a/web/assets/css/transmission-app.scss
+++ b/web/assets/css/transmission-app.scss
@@ -259,6 +259,10 @@ a {
   text-decoration: underline;
 }
 
+.flexible-space {
+  flex-grow: 1;
+}
+
 .hidden {
   display: none;
 }
@@ -273,16 +277,11 @@ a {
     margin: 0;
     padding: 0;
   }
-
-  .flexible-space {
-    margin-right: auto;
-  }
 }
 
 #mainwin-workarea {
   display: flex;
   flex: 1;
-  flex-direction: row;
   overflow: auto;
 }
 
@@ -302,7 +301,6 @@ a {
   background: var(--color-toolbar-background);
   border-bottom: 1px solid var(--color-border-default);
   display: flex;
-  flex-direction: row;
   height: var(--toolbar-height);
   margin: 0;
   width: 100%;
@@ -345,11 +343,6 @@ a {
     border-left: 1px solid var(--color-border-default);
     height: 25px;
     margin: 0 6px 0 0;
-
-    &:last-of-type {
-      border: 0;
-      flex-grow: 1;
-    }
   }
 }
 
@@ -381,7 +374,6 @@ a {
   background: var(--color-toolbar-background);
   border-bottom: 1px solid var(--color-border-default);
   display: flex;
-  flex-direction: row;
   height: 30px;
   padding-left: 5px;
 
@@ -533,10 +525,6 @@ a {
       text-overflow: ellipsis;
       white-space: nowrap;
       padding: 1px 0;
-
-      &.compact {
-        flex: 1;
-      }
     }
 
     .torrent-label {
@@ -612,11 +600,6 @@ a {
         width: var(--icon-size);
       }
 
-      .torrent-progress-bar {
-        display: flex;
-        flex-direction: row;
-      }
-
       > * {
         margin: 1px 0;
       }
@@ -657,7 +640,6 @@ a {
     height: 18px;
 
     &:not(.compact) {
-      flex-grow: 1;
       margin: 2px 0;
     }
 
@@ -915,7 +897,6 @@ a {
 
 .tabs-pages {
   box-sizing: border-box;
-  flex: 1;
   overflow-x: hidden;
   overflow-y: auto;
 
@@ -1410,7 +1391,6 @@ a {
     align-items: center;
     border-radius: 6px;
     display: flex;
-    flex-direction: row;
     padding: 3px 0;
   }
 
@@ -1442,7 +1422,6 @@ a {
   .input-and-label {
     align-items: center;
     display: inline-flex;
-    flex-direction: row;
   }
 
   #display-options {
@@ -1458,7 +1437,6 @@ a {
     > .speed-down {
       align-items: center;
       display: flex;
-      flex-direction: row;
       padding: 4px 0;
 
       > label {
@@ -1514,7 +1492,6 @@ a {
 
 .dialog-buttons {
   display: flex;
-  float: right;
   grid-area: buttons;
   margin: 10px 0 0;
   text-align: center;
@@ -1529,14 +1506,6 @@ a {
     padding: 8px;
     text-decoration: none;
   }
-}
-
-.dialog-buttons-begin {
-  flex-grow: 1;
-}
-
-.dialog-buttons-end {
-  display: none;
 }
 
 dialog {

--- a/web/public_html/index.html
+++ b/web/public_html/index.html
@@ -72,7 +72,7 @@
         >
           Inspector
         </button>
-        <div class="toolbar-separator"></div>
+        <span class="flexible-space"></span>
         <button
           aria-keyshortcuts="Alt+M"
           aria-label="Show sidebar menu"

--- a/web/src/utils.js
+++ b/web/src/utils.js
@@ -143,7 +143,7 @@ export function createDialogContainer(id) {
   win.append(buttons);
 
   const bbegin = document.createElement('span');
-  bbegin.classList.add('dialog-buttons-begin');
+  bbegin.className = 'flexible-space';
   buttons.append(bbegin);
 
   const dismiss = document.createElement('button');
@@ -160,10 +160,6 @@ export function createDialogContainer(id) {
       confirm.click();
     }
   });
-
-  const bend = document.createElement('span');
-  bend.classList.add('dialog-buttons-end');
-  buttons.append(bend);
 
   return {
     confirm,


### PR DESCRIPTION
- Clean up aftermath of #5828 and #7292
- Replace classNames to take advantage of `.flexible-space` for its rules in making spaces between things.
- Clean up style rules that is already default, stranded (has no `display: flex;`), or made no diffs on the UI.