### PR TITLE
Fixed missing icons in GNOME apps and overview

### DIFF
--- a/gtk/transmission-gtk.desktop.in
+++ b/gtk/transmission-gtk.desktop.in
@@ -15,6 +15,7 @@ Categories=Network;FileTransfer;P2P;GTK;
 X-Ubuntu-Gettext-Domain=transmission
 X-AppInstall-Keywords=torrent
 Actions=Pause;Minimize;
+StartupWMClass=com.transmissionbt.transmission_2049_1344295
 
 [Desktop Action Pause]
 Name=Start Transmission with All Torrents Paused


### PR DESCRIPTION
* When running transmission in at least GNOME, icons of transmission are missing in the apps menu and the GNOME overview
* Adding the correct wmclass property to the desktop file fixes this problem