### PR TITLE
Fixed #251 by detection of conflicts in the same directory

### DIFF
--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -1186,6 +1186,11 @@ private:
         return true;
     }
 
+    /** Get the name of the first torrent that has filename conflicts with this torrent
+        in the same download directory.
+        @return name of conflicting torrent, or empty string if no conflicts */
+    [[nodiscard]] std::string getFirstFilenameConflict() const;
+
     constexpr void set_needs_completeness_check() noexcept
     {
         needs_completeness_check_ = true;


### PR DESCRIPTION
I was experiencing #251 with `4.0.2`, but it looked like #6026.

I first tested this as a patch against transmission-gtk `4.0.6`, and then adapted it to this pull request. I then tested with transmission-gtk.

It detects the conflict, throws an error, and stops the torrent. It is then up to the user to deal with the conflict.

User options:
1. Removing the old torrent, which is part of the error message.
2. Removing the new torrent
3. Moving the files for the old torrent
4. Moving the download directory for the new torrent