### PR TITLE
feat: rename or copy name of individual file in web app

### DIFF
--- a/web/assets/css/transmission-app.scss
+++ b/web/assets/css/transmission-app.scss
@@ -1036,6 +1036,8 @@ a {
   padding: 0;
 
   .inspector-torrent-file-list-entry {
+    user-select: none;
+    -webkit-user-select: none;
     display: grid;
     grid-column-gap: 5px;
     grid-template-areas:
@@ -1053,32 +1055,44 @@ a {
       background-color: var(--color-bg-odd);
     }
 
+    .inspector-torrent-file-list-entry-name {
+      cursor: pointer;
+      font-size: 14px;
+      grid-area: name;
+      overflow-wrap: anywhere;
+    }
+
+    .inspector-torrent-file-list-entry-progress {
+      font-size: 12px;
+      grid-area: info;
+    }
+
+    .file-wanted-control {
+      grid-area: check;
+    }
+
     &.skip {
       opacity: 0.5;
+
+      > .inspector-torrent-file-list-entry-name {
+        color: var(--color-fg-disabled);
+      }
     }
-  }
 
-  .file-wanted-control {
-    grid-area: check;
-  }
-
-  .inspector-torrent-file-list-entry-name {
-    color: var(--color-fg-primary);
-    cursor: pointer;
-    font-size: 14px;
-    grid-area: name;
-    overflow-wrap: anywhere;
-  }
-
-  .inspector-torrent-file-list-entry.skip
-    > .inspector-torrent-file-list-entry-name {
-    color: var(--color-fg-disabled);
-  }
-
-  .inspector-torrent-file-list-entry-progress {
-    color: var(--color-fg-secondary);
-    font-size: 12px;
-    grid-area: info;
+    &:not(.selected) {
+      .inspector-torrent-file-list-entry-name {
+        color: var(--color-fg-primary);
+      }
+    
+      .inspector-torrent-file-list-entry-progress {
+        color: var(--color-fg-secondary);
+      }
+    }
+    
+    &.selected {
+      background: var(--color-bg-selected);
+      color: var(--color-fg-selected);
+    }
   }
 
   .single-file .inspector-torrent-file-list-entry,

--- a/web/src/action-manager.js
+++ b/web/src/action-manager.js
@@ -7,6 +7,10 @@ export class ActionManager extends EventTarget {
   constructor() {
     super();
     this.actions = Object.seal({
+      'copy-name': {
+        enabled: true,
+        text: 'Copy name',
+      },
       'deselect-all': {
         enabled: false,
         shortcut: 'D',

--- a/web/src/context-menu.js
+++ b/web/src/context-menu.js
@@ -6,17 +6,25 @@
 import { OutsideClickListener, setEnabled } from './utils.js';
 
 export class ContextMenu extends EventTarget {
-  constructor(action_manager) {
+  constructor(controller, menu_items) {
     super();
 
     this.action_listener = this._update.bind(this);
-    this.action_manager = action_manager;
+    this.controller = controller;
+    this.action_manager = controller.action_manager;
     this.action_manager.addEventListener('change', this.action_listener);
+    this.handler = controller.handler;
+    this.menu_items = menu_items;
 
     Object.assign(this, this._create());
 
     this.outside = new OutsideClickListener(this.root);
-    this.outside.addEventListener('click', () => this.close());
+    this.outside.addEventListener('click', () => {
+      if (this.handler) {
+        this.handler.classList.remove('selected');
+      }
+      this.close();
+    });
 
     this.show();
   }
@@ -87,27 +95,37 @@ export class ContextMenu extends EventTarget {
       root.append(item);
     };
 
-    add_item('resume-selected-torrents');
-    add_item('resume-selected-torrents-now');
-    add_item('pause-selected-torrents');
-    add_separator();
-    add_item('move-top');
-    add_item('move-up');
-    add_item('move-down');
-    add_item('move-bottom');
-    add_separator();
-    add_item('remove-selected-torrents', true);
-    add_item('trash-selected-torrents', true);
-    add_separator();
-    add_item('verify-selected-torrents');
-    add_item('show-move-dialog');
-    add_item('show-rename-dialog');
-    add_item('show-labels-dialog');
-    add_separator();
-    add_item('reannounce-selected-torrents');
-    add_separator();
-    add_item('select-all');
-    add_item('deselect-all');
+    if (this.menu_items) {
+      for (const item of this.menu_items) {
+        if (item) {
+          add_item(item);
+        } else {
+          add_separator();
+        }
+      }
+    } else {
+      add_item('resume-selected-torrents');
+      add_item('resume-selected-torrents-now');
+      add_item('pause-selected-torrents');
+      add_separator();
+      add_item('move-top');
+      add_item('move-up');
+      add_item('move-down');
+      add_item('move-bottom');
+      add_separator();
+      add_item('remove-selected-torrents', true);
+      add_item('trash-selected-torrents', true);
+      add_separator();
+      add_item('verify-selected-torrents');
+      add_item('show-move-dialog');
+      add_item('show-rename-dialog');
+      add_item('show-labels-dialog');
+      add_separator();
+      add_item('reannounce-selected-torrents');
+      add_separator();
+      add_item('select-all');
+      add_item('deselect-all');
+    }
 
     return { actions, root };
   }

--- a/web/src/inspector.js
+++ b/web/src/inspector.js
@@ -927,8 +927,8 @@ export class Inspector extends EventTarget {
     return tree;
   }
 
-  addNodeToView(tor, parent, sub) {
-    const row = new FileRow(tor, sub.depth, sub.name, sub.file_indices);
+  addNodeToView(tor, parent, subtree) {
+    const row = new FileRow(this.controller, tor, subtree);
     row.addEventListener('wantedToggled', this._onFileWantedToggled.bind(this));
     row.addEventListener(
       'priorityToggled',

--- a/web/src/rename-dialog.js
+++ b/web/src/rename-dialog.js
@@ -3,7 +3,7 @@
    or any future license endorsed by Mnemosyne LLC.
    License text can be found in the licenses/ folder. */
 
-import { createDialogContainer } from './utils.js';
+import { createDialogContainer, setTextContent } from './utils.js';
 
 export class RenameDialog extends EventTarget {
   constructor(controller, remote) {
@@ -24,17 +24,24 @@ export class RenameDialog extends EventTarget {
       return;
     }
 
+    const { handler } = this.controller;
     this.torrents = torrents;
     this.elements = RenameDialog._create();
     this.elements.dismiss.addEventListener('click', () => this._onDismiss());
     this.elements.confirm.addEventListener('click', () => this._onConfirm());
-    this.elements.entry.value = torrents[0].getName();
+    this.elements.entry.value = handler === null
+      ? torrents[0].getName()
+      : handler.subtree.name;
     document.body.append(this.elements.root);
 
     this.elements.entry.focus();
   }
 
   close() {
+    const { handler } = this.controller;
+    if (handler) {
+      handler.classList.remove('selected');
+    }
     this.elements.root.remove();
 
     this.dispatchEvent(new Event('close'));
@@ -50,12 +57,28 @@ export class RenameDialog extends EventTarget {
   }
 
   _onConfirm() {
+    const { handler } = this.controller;
     const [tor] = this.torrents;
-    const old_name = tor.getName();
+    const file_path = handler ? handler.file_path : tor.getName();
     const new_name = this.elements.entry.value;
-    this.remote.renameTorrent([tor.getId()], old_name, new_name, (response) => {
+    this.remote.renameTorrent([tor.getId()], file_path, new_name, (response) => {
       if (response.result === 'success') {
-        tor.refresh(response.arguments);
+        const args = response.arguments;
+        if (handler) {
+          handler.subtree.name = args.name;
+          setTextContent(handler.name_container, args.name);
+          if (handler.subdir) {
+            const file = tor.getIndividualFile(file_path);
+            if (file) {
+              const dir = file.name.substring(0, file.name.lastIndexOf('/') + 1);
+              file.name = `${dir}${args.name}`;
+            }
+          } else {
+            tor.refresh(args);
+          }
+        } else {
+          tor.refresh(args);
+        }
       }
     });
 

--- a/web/src/torrent.js
+++ b/web/src/torrent.js
@@ -100,6 +100,10 @@ export class Torrent extends EventTarget {
     }
   }
 
+  getIndividualFile(file_path) {
+    return this.fields.files.find((f) => f.name === file_path);
+  }
+
   ///
 
   // simple accessors

--- a/web/src/transmission.js
+++ b/web/src/transmission.js
@@ -31,6 +31,7 @@ export class Transmission extends EventTarget {
 
     // Initialize the helper classes
     this.action_manager = action_manager;
+    this.handler = null;
     this.notifications = notifications;
     this.prefs = prefs;
     this.remote = new Remote(this);
@@ -85,6 +86,16 @@ export class Transmission extends EventTarget {
 
     this.action_manager.addEventListener('click', (event_) => {
       switch (event_.action) {
+        case 'copy-name':
+          if (navigator.clipboard) {
+            navigator.clipboard.writeText(this.handler.subtree.name);
+          } else {
+            // navigator.clipboard requires HTTPS or localhost
+            // Emergency approach
+            prompt('Select all then copy', this.handler.subtree.name);
+          }
+          this.handler.classList.remove('selected');
+          break;
         case 'deselect-all':
           this._deselectAll();
           break;
@@ -221,30 +232,7 @@ export class Transmission extends EventTarget {
       torrent_list: document.querySelector('#torrent-list'),
     };
 
-    const context_menu = () => {
-      // open context menu
-      const popup = new ContextMenu(this.action_manager);
-      this.setCurrentPopup(popup);
-
-      const boundingElement = document.querySelector('#torrent-container');
-      const bounds = boundingElement.getBoundingClientRect();
-      const x = Math.min(
-        this.pointer_device.x,
-        bounds.right + globalThis.scrollX - popup.root.clientWidth,
-      );
-      const y = Math.min(
-        this.pointer_device.y,
-        bounds.bottom + globalThis.scrollY - popup.root.clientHeight,
-      );
-      popup.root.style.left = `${Math.max(x, 0)}px`;
-      popup.root.style.top = `${Math.max(y, 0)}px`;
-    };
-
     const right_click = (event_) => {
-      if (this.pointer_device.is_touch_device && event_.touches.length > 1) {
-        return;
-      }
-
       // if not already, highlight the torrent
       let row_element = event_.target;
       while (row_element && !row_element.classList.contains('torrent')) {
@@ -254,61 +242,13 @@ export class Transmission extends EventTarget {
       if (row && !row.isSelected()) {
         this._setSelectedRow(row);
       }
+      this.handler = null;
 
-      context_menu();
+      this.context_menu('#torrent-container');
       event_.preventDefault();
     };
 
-    if (this.pointer_device.is_touch_device) {
-      const touch = this.pointer_device;
-      this.elements.torrent_list.addEventListener('touchstart', (event_) => {
-        touch.x = event_.touches[0].pageX;
-        touch.y = event_.touches[0].pageY;
-
-        if (touch.long_press_callback) {
-          clearTimeout(touch.long_press_callback);
-          touch.long_press_callback = null;
-        } else {
-          touch.long_press_callback = setTimeout(
-            right_click.bind(this),
-            500,
-            event_,
-          );
-        }
-      });
-      this.elements.torrent_list.addEventListener('touchend', () => {
-        clearTimeout(touch.long_press_callback);
-        touch.long_press_callback = null;
-        setTimeout(() => {
-          const popup = this.popup[Transmission.default_popup_level];
-          if (popup) {
-            popup.root.style.pointerEvents = 'auto';
-          }
-        }, 1);
-      });
-      this.elements.torrent_list.addEventListener('touchmove', (event_) => {
-        touch.x = event_.touches[0].pageX;
-        touch.y = event_.touches[0].pageY;
-
-        clearTimeout(touch.long_press_callback);
-        touch.long_press_callback = null;
-      });
-      this.elements.torrent_list.addEventListener('contextmenu', (event_) => {
-        event_.preventDefault();
-      });
-    } else {
-      this.elements.torrent_list.addEventListener('mousemove', (event_) => {
-        this.pointer_device.x = event_.pageX;
-        this.pointer_device.y = event_.pageY;
-      });
-      this.elements.torrent_list.addEventListener('contextmenu', (event_) => {
-        right_click(event_);
-        const popup = this.popup[Transmission.default_popup_level];
-        if (popup) {
-          popup.root.style.pointerEvents = 'auto';
-        }
-      });
-    }
+    this.pointer_event(this.elements.torrent_list, right_click);
 
     // Get preferences & torrents from the daemon
     this.loadDaemonPrefs();
@@ -410,6 +350,77 @@ export class Transmission extends EventTarget {
       default:
         /*noop*/
         break;
+    }
+  }
+
+  context_menu(container_id, menu_items) {
+    // open context menu
+    const popup = new ContextMenu(this, menu_items);
+    this.setCurrentPopup(popup);
+
+    const bounds = document.querySelector(container_id).getBoundingClientRect();
+    const x = Math.min(
+      this.pointer_device.x,
+      bounds.right + globalThis.scrollX - popup.root.clientWidth,
+    );
+    const y = Math.min(
+      this.pointer_device.y,
+      bounds.bottom + globalThis.scrollY - popup.root.clientHeight,
+    );
+    popup.root.style.left = `${Math.max(x, 0)}px`;
+    popup.root.style.top = `${Math.max(y, 0)}px`;
+  };
+
+  pointer_event(e_, right_click) {
+    if (this.pointer_device.is_touch_device) {
+      const touch = this.pointer_device;
+      e_.addEventListener('touchstart', (event_) => {
+        touch.x = event_.touches[0].pageX;
+        touch.y = event_.touches[0].pageY;
+
+        if (touch.long_press_callback) {
+          clearTimeout(touch.long_press_callback);
+          touch.long_press_callback = null;
+        } else {
+          touch.long_press_callback = setTimeout(() => {
+            if (event_.touches.length === 1) {
+              right_click(event_);
+            }
+          }, 500);
+        }
+      });
+      e_.addEventListener('touchend', () => {
+        clearTimeout(touch.long_press_callback);
+        touch.long_press_callback = null;
+        setTimeout(() => {
+          const popup = this.popup[Transmission.default_popup_level];
+          if (popup) {
+            popup.root.style.pointerEvents = 'auto';
+          }
+        }, 1);
+      });
+      e_.addEventListener('touchmove', (event_) => {
+        touch.x = event_.touches[0].pageX;
+        touch.y = event_.touches[0].pageY;
+
+        clearTimeout(touch.long_press_callback);
+        touch.long_press_callback = null;
+      });
+      e_.addEventListener('contextmenu', (event_) => {
+        event_.preventDefault();
+      });
+    } else {
+      e_.addEventListener('mousemove', (event_) => {
+        this.pointer_device.x = event_.pageX;
+        this.pointer_device.y = event_.pageY;
+      });
+      e_.addEventListener('contextmenu', (event_) => {
+        right_click(event_);
+        const popup = this.popup[Transmission.default_popup_level];
+        if (popup) {
+          popup.root.style.pointerEvents = 'auto';
+        }
+      });
     }
   }
 
@@ -1194,6 +1205,8 @@ TODO: fix this when notifications get fixed
         }
       };
       this.popup[level].addEventListener('close', listener);
+    } else if (this.handler) {
+      this.handler.classList.remove('selected');
     }
   }
 }


### PR DESCRIPTION
This is preliminary implementation to rename or copy name of an individual file from file list using context menu, everything is working as I wanted, there may be some bugs and behind the scenes (code) could see some clean up, so testing is needed. The context menu can be brought up by right-click (long press on touchscreen) on a file, click outside to cancel.

Tested on Firefox for Windows PC and Safari on iPhone 12 Mini.

Please report back when you find some bugs! There may be some bugs not related to this PR e.g. file list does not see update when renaming from torrent list.

Torrent with multiple nested subfolder is untested.

![IMG_1300 cen](https://github.com/user-attachments/assets/c90d768b-b1e3-4001-b8fe-b81af2b67e3e)

Notes: Implemented a context menu for file list in web app making way to rename or copy name of individual file.