### PR TITLE
Use en and em dashes where appropriate

### DIFF
--- a/macosx/Info.plist
+++ b/macosx/Info.plist
@@ -70,7 +70,7 @@
 	<key>NSAppleScriptEnabled</key>
 	<string>YES</string>
 	<key>NSHumanReadableCopyright</key>
-	<string>Copyright © 2005-2025 The Transmission Project</string>
+	<string>Copyright © 2005–2025 The Transmission Project</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/macosx/InfoWindowController.mm
+++ b/macosx/InfoWindowController.mm
@@ -330,7 +330,7 @@ typedef NS_ENUM(NSUInteger, TabTag) {
     NSWindow* window = self.window;
 
     window.title = [NSString
-        stringWithFormat:@"%@ - %@", self.fViewController.title, NSLocalizedString(@"Torrent Inspector", "Inspector -> title")];
+        stringWithFormat:@"%@ — %@", self.fViewController.title, NSLocalizedString(@"Torrent Inspector", "Inspector -> title")];
 
     NSView* view = self.fViewController.view;
 

--- a/macosx/Torrent.mm
+++ b/macosx/Torrent.mm
@@ -1038,7 +1038,7 @@ bool trashDataFile(char const* filename, void* /*user_data*/, tr_error* error)
                                        [NSString percentString:self.fStat->metadataPercentComplete longDecimals:YES]] :
             NSLocalizedString(@"torrent metadata needed", "Torrent -> progress string");
 
-        return [NSString stringWithFormat:@"%@ - %@", NSLocalizedString(@"Magnetized transfer", "Torrent -> progress string"), progressString];
+        return [NSString stringWithFormat:@"%@ — %@", NSLocalizedString(@"Magnetized transfer", "Torrent -> progress string"), progressString];
     }
 
     NSString* string;
@@ -1090,7 +1090,7 @@ bool trashDataFile(char const* filename, void* /*user_data*/, tr_error* error)
     //add time when downloading or seed limit set
     if (self.shouldShowEta)
     {
-        string = [string stringByAppendingFormat:@" - %@", self.etaString];
+        string = [string stringByAppendingFormat:@" — %@", self.etaString];
     }
 
     return string;
@@ -1216,7 +1216,7 @@ bool trashDataFile(char const* filename, void* /*user_data*/, tr_error* error)
     {
         if (self.fStat->activity == TR_STATUS_DOWNLOAD)
         {
-            string = [string stringByAppendingFormat:@" - %@: %@, %@: %@",
+            string = [string stringByAppendingFormat:@" — %@: %@, %@: %@",
                                                      NSLocalizedString(@"DL", "Torrent -> status string"),
                                                      [NSString stringForSpeed:self.downloadRate],
                                                      NSLocalizedString(@"UL", "Torrent -> status string"),
@@ -1224,7 +1224,7 @@ bool trashDataFile(char const* filename, void* /*user_data*/, tr_error* error)
         }
         else
         {
-            string = [string stringByAppendingFormat:@" - %@: %@",
+            string = [string stringByAppendingFormat:@" — %@: %@",
                                                      NSLocalizedString(@"UL", "Torrent -> status string"),
                                                      [NSString stringForSpeed:self.uploadRate]];
         }


### PR DESCRIPTION
- En dash is used to separate ranges; e.g. 2024–2025
- Em dash is used to separate expressions; e.g. 100.5 GB — remaining time unknown