### PR TITLE
build: fail or warn against libcurl versions prone to crashes

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -264,7 +264,8 @@ jobs:
             -DCMAKE_CXX_COMPILER='clang++' \
             -DCMAKE_C_COMPILER='clang' \
             -DCMAKE_INSTALL_PREFIX=pfx \
-            -DRUN_CLANG_TIDY=ON
+            -DRUN_CLANG_TIDY=ON \
+            -DALLOW_UNSAFE_LIBCURL=ON # Remove this line if curl >= 8.6.0
       - name: Make
         run: cmake --build obj --config Debug --target libtransmission.a 2>&1 | tee makelog
       - name: Test for warnings
@@ -299,7 +300,8 @@ jobs:
             -G Ninja `
             -DCMAKE_BUILD_TYPE=Debug `
             -DCMAKE_PREFIX_PATH="${Env:DEPS_PREFIX}" `
-            -DRUN_CLANG_TIDY=ON
+            -DRUN_CLANG_TIDY=ON `
+            -DALLOW_UNSAFE_LIBCURL=ON # Remove this line if curl >= 8.6.0
       - name: Make
         run: |
           Import-VisualStudioVars -VisualStudioVersion 2022 -Architecture x64
@@ -554,7 +556,8 @@ jobs:
             -DENABLE_UTILS=ON `
             -DREBUILD_WEB=${{ (needs.what-to-make.outputs.make-web == 'true') && 'ON' || 'OFF' }} `
             -DENABLE_WERROR=ON `
-            -DRUN_CLANG_TIDY=OFF
+            -DRUN_CLANG_TIDY=OFF `
+            -DALLOW_UNSAFE_LIBCURL=ON # Remove this line if curl >= 8.6.0
       - name: Make
         run: |
           Import-VisualStudioVars -VisualStudioVersion 2022 -Architecture ${{ matrix.arch }}
@@ -733,7 +736,8 @@ jobs:
             -DUSE_SYSTEM_NATPMP=OFF \
             -DUSE_SYSTEM_UTP=OFF \
             -DUSE_SYSTEM_B64=OFF \
-            -DUSE_SYSTEM_PSL=OFF
+            -DUSE_SYSTEM_PSL=OFF \
+            -DALLOW_UNSAFE_LIBCURL=ON # Remove this line if curl >= 8.6.0
       - name: Make
         run: cmake --build obj --config RelWithDebInfo
       - name: Test
@@ -828,14 +832,14 @@ jobs:
           name: binaries-${{ github.job }}
           path: pfx/**/*
 
-  fedora-39-from-tarball:
+  fedora-41-from-tarball:
     needs: [ make-source-tarball, what-to-make ]
     if: ${{ needs.what-to-make.outputs.make-cli == 'true' || needs.what-to-make.outputs.make-daemon == 'true' || needs.what-to-make.outputs.make-gtk == 'true' || needs.what-to-make.outputs.make-qt == 'true' || needs.what-to-make.outputs.make-tests == 'true' || needs.what-to-make.outputs.make-utils == 'true' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     env:
       NODE_PATH: /usr/lib/nodejs:/usr/share/nodejs
     container:
-      image: fedora:39
+      image: fedora:41
     steps:
       - name: Show Configuration
         run: |

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1018,7 +1018,7 @@ jobs:
     - name: Setup vcpkg
       uses: lukka/run-vcpkg@v11
       with:
-        vcpkgGitCommitId: 53bef8994c541b6561884a8395ea35715ece75db # 2024.01.12
+        vcpkgGitCommitId: 01be99fec01f777c4113ceea192a45115c69cdb7 # 2025.01.23
 
     - name: Install vcpkg packages
       run: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -65,7 +65,8 @@ jobs:
             -DCMAKE_BUILD_TYPE=RelWithDebInfo \
             -DENABLE_TESTS=OFF \
             -DENABLE_NLS=OFF \
-            -DRUN_CLANG_TIDY=OFF
+            -DRUN_CLANG_TIDY=OFF \
+            -DALLOW_UNSAFE_LIBCURL=ON # Remove this line if curl >= 8.6.0
 
     - name: Build Dependencies
       if: ${{ matrix.language == 'cpp' }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,13 +250,13 @@ find_package(PkgConfig QUIET)
 
 find_package(CURL ${CURL_MINIMUM} REQUIRED)
 
-if(CURL_VERSION VERSION_GREATER_EQUAL 7.87.0 AND CURL_VERSION VERSION_LESS_EQUAL 8.5.0)
+if(CURL_VERSION_STRING VERSION_GREATER_EQUAL 7.87.0 AND CURL_VERSION_STRING VERSION_LESS_EQUAL 8.5.0)
     if(NOT ALLOW_UNSAFE_LIBCURL)
         message(FATAL_ERROR
             "Please don't use libcurl 7.87.0 to 8.5.0. https://github.com/curl/curl/issues/10936\n"
             "If you know what you are doing, you may bypass this error by setting ALLOW_UNSAFE_LIBCURL=ON.")
     endif()
-    message(WARNING "You are explicitly allowing unsafe libcurl version ${CURL_VERSION}. https://github.com/curl/curl/issues/10936")
+    message(WARNING "You are explicitly allowing unsafe libcurl version ${CURL_VERSION_STRING}. https://github.com/curl/curl/issues/10936")
 endif()
 
 if(ENABLE_DEPRECATED STREQUAL "AUTO")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,8 @@ set(NPM_MINIMUM 8.1.307) # Node.js 14
 set(PSL_MINIMUM 0.21.1)
 set(QT_MINIMUM 5.6)
 
+option(ALLOW_UNSAFE_LIBCURL "Allow unsafe libcurl versions" OFF)
+mark_as_advanced(ALLOW_UNSAFE_LIBCURL)
 option(ENABLE_DAEMON "Build daemon" ON)
 tr_auto_option(ENABLE_GTK "Build GTK client" AUTO)
 tr_auto_option(ENABLE_QT "Build Qt client" AUTO)
@@ -249,7 +251,12 @@ find_package(PkgConfig QUIET)
 find_package(CURL ${CURL_MINIMUM} REQUIRED)
 
 if(CURL_VERSION VERSION_GREATER_EQUAL 7.87.0 AND CURL_VERSION VERSION_LESS_EQUAL 8.5.0)
-    message(FATAL_ERROR "Please don't use libcurl 7.87.0 to 8.5.0. https://github.com/curl/curl/issues/10936")
+    if(NOT ALLOW_UNSAFE_LIBCURL)
+        message(FATAL_ERROR
+            "Please don't use libcurl 7.87.0 to 8.5.0. https://github.com/curl/curl/issues/10936\n"
+            "If you know what you are doing, you may bypass this error by setting ALLOW_UNSAFE_LIBCURL=ON.")
+    endif()
+    message(WARNING "You are explicitly allowing unsafe libcurl version ${CURL_VERSION}. https://github.com/curl/curl/issues/10936")
 endif()
 
 if(ENABLE_DEPRECATED STREQUAL "AUTO")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -248,6 +248,10 @@ find_package(PkgConfig QUIET)
 
 find_package(CURL ${CURL_MINIMUM} REQUIRED)
 
+if(CURL_VERSION VERSION_GREATER_EQUAL 7.87.0 AND CURL_VERSION VERSION_LESS_EQUAL 8.5.0)
+    message(FATAL_ERROR "Please don't use libcurl 7.87.0 to 8.5.0. https://github.com/curl/curl/issues/10936")
+endif()
+
 if(ENABLE_DEPRECATED STREQUAL "AUTO")
     if(DEFINED ENV{CI})
         set(ENABLE_DEPRECATED OFF)


### PR DESCRIPTION
This PR addresses crashes related to https://github.com/curl/curl/issues/10936. It does not fix the crashes in any way, but raises awareness about it among users.

Also added a new `ALLOW_UNSAFE_LIBCURL` CMake option to allow users to bypass the check, since the affected version range is quite wide.