### PR TITLE
fix: not correctly sending UA to trackers related to curl gh6312

### DIFF
--- a/libtransmission/web.cc
+++ b/libtransmission/web.cc
@@ -409,6 +409,13 @@ public:
         return version >= 0x075700 /* 7.87.0 */ && version <= 0x080500 /* 8.5.0 */;
     }
 
+    // https://github.com/curl/curl/issues/6312
+    [[nodiscard]] static bool check_curl_gh6312() noexcept
+    {
+        auto const version = curl_version_info(CURLVERSION_NOW)->version_num;
+        return version >= 0x074700 /* 7.71.0 */ && version <= 0x074a00 /* 7.74.0 */;
+    }
+
     static auto constexpr BandwidthPauseMsec = long{ 500 };
     static auto constexpr DnsCacheTimeoutSecs = long{ 60 * 60 };
     static auto constexpr MaxRedirects = long{ 10 };
@@ -416,7 +423,7 @@ public:
     bool const curl_verbose = tr_env_key_exists("TR_CURL_VERBOSE");
     bool const curl_ssl_verify = !tr_env_key_exists("TR_CURL_SSL_NO_VERIFY");
     bool const curl_proxy_ssl_verify = !tr_env_key_exists("TR_CURL_PROXY_SSL_NO_VERIFY");
-    bool const curl_gh10936 = check_curl_gh10936();
+    bool const curl_avoid_http2 = check_curl_gh10936() || check_curl_gh6312(); // both related to curl http2 bugs
 
     Mediator& mediator;
 
@@ -624,7 +631,7 @@ public:
             (void)curl_easy_setopt(e, CURLOPT_RANGE, range->c_str());
         }
 
-        if (curl_gh10936)
+        if (curl_avoid_http2)
         {
             (void)curl_easy_setopt(e, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1);
         }


### PR DESCRIPTION
Switch to http1.1 when curl 7.71.0-7.74.0 are used. Fix another http2 problem caused by curl. This will solve #1563.
Read more here: curl/curl#6312