### PR TITLE
ci: use Ubuntu 22.04 runner instead of Ubuntu 20.04 runner

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -905,10 +905,10 @@ jobs:
           name: binaries-${{ github.job }}
           path: pfx/**/*
 
-  ubuntu-20-04-from-tarball:
+  ubuntu-22-04-from-tarball:
     needs: [ make-source-tarball, what-to-make ]
     if: ${{ needs.what-to-make.outputs.make-cli == 'true' || needs.what-to-make.outputs.make-daemon == 'true' || needs.what-to-make.outputs.make-gtk == 'true' || needs.what-to-make.outputs.make-qt == 'true' || needs.what-to-make.outputs.make-tests == 'true' || needs.what-to-make.outputs.make-utils == 'true' }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Show Configuration
         run: |


### PR DESCRIPTION
Fixes a GitHub Actions brownout error:

> This is a scheduled Ubuntu 20.04 brownout. Ubuntu 20.04 LTS runner will be removed on 2025-04-01. For more details, see https://github.com/actions/runner-images/issues/11101

Replace the `ubuntu-20-04-from-tarball` job with `ubuntu-22-04-from-tarball`.