### PR TITLE
fix: bugprone-exception-escape warning in `Variant::make_map()`

### DIFF
--- a/libtransmission/variant.h
+++ b/libtransmission/variant.h
@@ -204,7 +204,7 @@ public:
         *this = std::forward<Val>(value);
     }
 
-    [[nodiscard]] static auto make_map(size_t const n_reserve = 0U) noexcept
+    [[nodiscard]] static auto make_map(size_t const n_reserve = 0U)
     {
         auto ret = tr_variant{};
         ret.val_.emplace<Map>(n_reserve);


### PR DESCRIPTION
Fixes this clang-tidy warning:

> libtransmission/variant.h:207:31: warning: an exception may be thrown in function 'make_map' which should not throw exceptions [bugprone-exception-escape]
