### PR TITLE
refactor: remove `TR_LIKELY` and `TR_UNLIKELY` macros

### DIFF
--- a/libtransmission/tr-assert.h
+++ b/libtransmission/tr-assert.h
@@ -13,8 +13,8 @@
 
 [[noreturn]] bool tr_assert_report(std::string_view file, long line, std::string_view message);
 
-#define TR_ASSERT(x) ((void)(TR_LIKELY(x) || tr_assert_report(__FILE__, __LINE__, #x)))
-#define TR_ASSERT_MSG(x, message) ((void)(TR_LIKELY(x) || tr_assert_report(__FILE__, __LINE__, message)))
+#define TR_ASSERT(x) ((void)((x) || tr_assert_report(__FILE__, __LINE__, #x)))
+#define TR_ASSERT_MSG(x, message) ((void)((x) || tr_assert_report(__FILE__, __LINE__, message)))
 #define TR_UNREACHABLE() tr_assert_report(__FILE__, __LINE__, "Unreachable code")
 
 #define TR_ENABLE_ASSERTS

--- a/libtransmission/tr-macros.h
+++ b/libtransmission/tr-macros.h
@@ -56,14 +56,6 @@
 
 // ---
 
-#if __has_builtin(__builtin_expect) || TR_GNUC_CHECK_VERSION(3, 0)
-#define TR_LIKELY(x) __builtin_expect((x) ? 1L : 0L, 1L)
-#else
-#define TR_LIKELY(x) (x)
-#endif
-
-// ---
-
 #define TR_INET6_ADDRSTRLEN 46
 
 #define TR_ADDRSTRLEN 64

--- a/libtransmission/tr-macros.h
+++ b/libtransmission/tr-macros.h
@@ -30,10 +30,6 @@
 
 // ---
 
-#ifndef __has_builtin
-#define __has_builtin(x) 0
-#endif
-
 #ifdef _WIN32
 #define TR_IF_WIN32(ThenValue, ElseValue) ThenValue
 #else

--- a/libtransmission/tr-macros.h
+++ b/libtransmission/tr-macros.h
@@ -58,10 +58,8 @@
 
 #if __has_builtin(__builtin_expect) || TR_GNUC_CHECK_VERSION(3, 0)
 #define TR_LIKELY(x) __builtin_expect((x) ? 1L : 0L, 1L)
-#define TR_UNLIKELY(x) __builtin_expect((x) ? 1L : 0L, 0L)
 #else
 #define TR_LIKELY(x) (x)
-#define TR_UNLIKELY(x) (x)
 #endif
 
 // ---

--- a/libtransmission/tr-macros.h
+++ b/libtransmission/tr-macros.h
@@ -40,12 +40,6 @@
 #define TR_IF_WIN32(ThenValue, ElseValue) ElseValue
 #endif
 
-#ifdef __GNUC__
-#define TR_GNUC_CHECK_VERSION(major, minor) (__GNUC__ > (major) || (__GNUC__ == (major) && __GNUC_MINOR__ >= (minor)))
-#else
-#define TR_GNUC_CHECK_VERSION(major, minor) 0
-#endif
-
 #ifdef __UCLIBC__
 #define TR_UCLIBC_CHECK_VERSION(major, minor, micro) \
     (__UCLIBC_MAJOR__ > (major) || (__UCLIBC_MAJOR__ == (major) && __UCLIBC_MINOR__ > (minor)) || \


### PR DESCRIPTION
Discussion: https://blog.aaronballman.com/2020/08/dont-use-the-likely-or-unlikely-attributes/