### PR TITLE
refactor: remove unused macro `TR_UNREACHABLE`

### DIFF
--- a/libtransmission/tr-assert.h
+++ b/libtransmission/tr-assert.h
@@ -15,7 +15,6 @@
 
 #define TR_ASSERT(x) ((void)((x) || tr_assert_report(__FILE__, __LINE__, #x)))
 #define TR_ASSERT_MSG(x, message) ((void)((x) || tr_assert_report(__FILE__, __LINE__, message)))
-#define TR_UNREACHABLE() tr_assert_report(__FILE__, __LINE__, "Unreachable code")
 
 #define TR_ENABLE_ASSERTS
 
@@ -23,7 +22,6 @@
 
 #define TR_ASSERT(x) ((void)0)
 #define TR_ASSERT_MSG(x, ...) ((void)0)
-#define TR_UNREACHABLE() ((void)0)
 
 #undef TR_ENABLE_ASSERTS
 


### PR DESCRIPTION
last use was removed in 3008a99