### PR TITLE
refactor: simplify TR_CONSTEXPR20 macro

### DIFF
--- a/libtransmission/tr-macros.h
+++ b/libtransmission/tr-macros.h
@@ -11,14 +11,7 @@
 
 // ---
 
-#ifdef _MSVC_LANG
-#define TR_CPLUSPLUS _MSVC_LANG
-#else
-#define TR_CPLUSPLUS __cplusplus
-#endif
-
-#if ((TR_CPLUSPLUS >= 202002L) && (!defined(_GLIBCXX_RELEASE) || _GLIBCXX_RELEASE > 9)) || \
-    (TR_CPLUSPLUS >= 201709L && TR_GCC_VERSION >= 1002)
+#if __cplusplus >= 202002L || _MSVC_LANG >= 202002L
 #define TR_CONSTEXPR20 constexpr
 #else
 #define TR_CONSTEXPR20


### PR DESCRIPTION
Kind of a fixup to https://github.com/transmission/transmission/pull/4457. 

Looks like I (poorly) cribbed the previous implementation from an older version of fmt:

```c++
#if ((FMT_CPLUSPLUS >= 202002L) &&                            \
     (!defined(_GLIBCXX_RELEASE) || _GLIBCXX_RELEASE > 9)) || \
    (FMT_CPLUSPLUS >= 201709L && FMT_GCC_VERSION >= 1002)
```

I implemented some of this wrong, and some of it is outdated:

- `TR_GCC_VERSION` never got defined anywhere AFAICT, so that clause always evaluated false. 
- `fmt` no longer uses the `_GLIBCXX_RELEASE > 9` check
- This is the only place where the `TR_CPLUSPLUS` macro is used, so let's remove it.