### PR TITLE
feat: support trackers with only old BEP-7 support

### DIFF
--- a/libtransmission/announcer-http.cc
+++ b/libtransmission/announcer-http.cc
@@ -122,6 +122,11 @@ bool handleAnnounceResponse(tr_web::FetchResponse const& web_response, tr_announ
 
     tr_announcerParseHttpAnnounceResponse(response, body, log_name);
 
+    if (!std::empty(response.errmsg))
+    {
+        return false;
+    }
+
     if (!std::empty(response.pex6))
     {
         tr_logAddTrace(fmt::format("got a peers6 length of {}", std::size(response.pex6)), log_name);


### PR DESCRIPTION
This PR does 2 things:

1. Add back support for old BEP-7 query parameters (kind of reverts #4502).
2. Treat tracker responses containing the `failure reason` key as a failure (surprised this wasn't the case before).

This implementation will work with both new and old BEP-7 because:
- Old BEP-7 trackers receive both of Transmission's IP addresses as long as at least one announce succeeds.
- New BEP-7 trackers are not affected by this PR (they can ignore the query parameters).
- Transmission will consider the announce event successful as long as either the IPv4 or IPv6 announce succeeds (with old BEP-7 trackers, at most 1 of the 2 announces will succeed).

This is done because many trackers still don't support the current BEP-7 iteration, and treat the multiple announces as duplicates. See https://github.com/transmission/transmission/pull/7086#issuecomment-2709339410 and the comments above it for detailed discussion.

BEP-7 explains why they moved away from the query parameters:

> An earlier version of this BEP specified new HTTP parameters to announce an additional address of a different address family than the source IP address of the tracker connection (&ipv4= and &ipv6=). These are discouraged, as they allow an attacker to announce a victim's IP address to launch a DDoS attack.

But I think this is targeted for tracker operators and does not apply to us. In Transmission we have complete control over what to send to the tracker, and as long as we don't allow any user input on it, we should be fine.

Notes: Support trackers that only support the old BEP-7 with `&ipv4=` and `&ipv6=`.