### PR TITLE
refactor: rename unreleased quarks to snake_case

### DIFF
--- a/cli/cli.cc
+++ b/cli/cli.cc
@@ -263,7 +263,7 @@ int parseCommandLine(tr_variant* d, int argc, char const** argv)
             break;
 
         case 500:
-            tr_variantDictAddBool(d, TR_KEY_sequentialDownload, true);
+            tr_variantDictAddBool(d, TR_KEY_sequential_download, true);
             break;
 
         case TR_OPT_UNK:

--- a/daemon/daemon.cc
+++ b/daemon/daemon.cc
@@ -491,11 +491,11 @@ bool tr_daemon::parse_args(int argc, char const* const* argv, bool* dump_setting
             break;
 
         case 994:
-            tr_variantDictAddBool(&settings_, TR_KEY_sequentialDownload, true);
+            tr_variantDictAddBool(&settings_, TR_KEY_sequential_download, true);
             break;
 
         case 995:
-            tr_variantDictAddBool(&settings_, TR_KEY_sequentialDownload, false);
+            tr_variantDictAddBool(&settings_, TR_KEY_sequential_download, false);
             break;
 
         case 'd':

--- a/docs/Editing-Configuration-Files.md
+++ b/docs/Editing-Configuration-Files.md
@@ -103,7 +103,7 @@ Here is a sample of the three basic types: respectively Boolean, Number and Stri
  * **peer-limit-per-torrent:** Number (default = 50)
  * **peer-socket-tos:** String (default = "le") Set the [DiffServ](https://en.wikipedia.org/wiki/Differentiated_services) parameter for outgoing packets. Allowed values are lowercase DSCP names. See the `tr_tos_t` class from `libtransmission/net.h` for the exact list of possible values.
  * **reqq:** Number (default = 2000) The number of outstanding block requests a peer is allowed to queue in the client. The higher this number, the higher the max possible upload speed towards each peer.
- * **sequentialDownload** Boolean (default = false) Enable sequential download by default when adding torrents.
+ * **sequential_download** Boolean (default = false) Enable sequential download by default when adding torrents.
 
 #### Peer Port
  * **peer-port:** Number (default = 51413)

--- a/docs/Editing-Configuration-Files.md
+++ b/docs/Editing-Configuration-Files.md
@@ -92,7 +92,7 @@ Here is a sample of the three basic types: respectively Boolean, Number and Stri
  * **tcp-enabled:** Boolean (default = true) Optionally disable TCP connection to other peers. Never disable TCP when you also disable µTP, because then your client would not be able to communicate. Disabling TCP might also break webseeds. Unless you have a good reason, you should not set this to false.
  * **torrent-added-verify-mode:** String ("fast", "full", default: "fast") Whether newly-added torrents' local data should be fully verified when added, or wait and verify them on-demand later. See [#2626](https://github.com/transmission/transmission/pull/2626) for more discussion.
  * **utp-enabled:** Boolean (default = true) Enable [Micro Transport Protocol (µTP)](https://en.wikipedia.org/wiki/Micro_Transport_Protocol)
- * **preferred-transport:** String ("utp" = Prefer µTP, "tcp" = Prefer TCP; default = "utp") Choose your preferred transport protocol (has no effect if one of them is disabled).
+ * **preferred_transport:** String ("utp" = Prefer µTP, "tcp" = Prefer TCP; default = "utp") Choose your preferred transport protocol (has no effect if one of them is disabled).
  * **sleep-per-seconds-during-verify:** Number (default = 100) Controls the duration in milliseconds for which the verification process will pause to reduce disk I/O pressure.
 
 #### Peers

--- a/docs/rpc-spec.md
+++ b/docs/rpc-spec.md
@@ -160,7 +160,7 @@ Request arguments:
 | `seedIdleMode`        | number   | which seeding inactivity to use. See tr_idlelimit
 | `seedRatioLimit`      | double   | torrent-level seeding ratio
 | `seedRatioMode`       | number   | which ratio to use. See tr_ratiolimit
-| `sequentialDownload`  | boolean  | download torrent pieces sequentially
+| `sequential_download` | boolean  | download torrent pieces sequentially
 | `trackerAdd`          | array    | **DEPRECATED** use trackerList instead
 | `trackerList`         | string   | string of announce URLs, one per line, and a blank line between [tiers](https://www.bittorrent.org/beps/bep_0012.html).
 | `trackerRemove`       | array    | **DEPRECATED** use trackerList instead
@@ -271,7 +271,7 @@ The 'source' column here corresponds to the data structure there.
 | `seedIdleMode`| number| tr_inactivelimit
 | `seedRatioLimit`| double| tr_torrent
 | `seedRatioMode`| number| tr_ratiolimit
-| `sequentialDownload`| boolean| tr_torrent
+| `sequential_download`| boolean| tr_torrent
 | `sizeWhenDone`| number| tr_stat
 | `startDate`| number| tr_stat
 | `status`| number (see below)| tr_stat
@@ -456,20 +456,20 @@ Request arguments:
 
 | Key | Value Type | Description
 |:--|:--|:--
-| `cookies`            | string    | pointer to a string of one or more cookies.
-| `download-dir`       | string    | path to download the torrent to
-| `filename`           | string    | filename or URL of the .torrent file
-| `labels`             | array     | array of string labels
-| `metainfo`           | string    | base64-encoded .torrent content
-| `paused`             | boolean   | if true, don't start the torrent
-| `peer-limit`         | number    | maximum number of peers
-| `bandwidthPriority`  | number    | torrent's bandwidth tr_priority_t
-| `files-wanted`       | array     | indices of file(s) to download
-| `files-unwanted`     | array     | indices of file(s) to not download
-| `priority-high`      | array     | indices of high-priority file(s)
-| `priority-low`       | array     | indices of low-priority file(s)
-| `priority-normal`    | array     | indices of normal-priority file(s)
-| `sequentialDownload` | boolean   | download torrent pieces sequentially
+| `cookies`             | string    | pointer to a string of one or more cookies.
+| `download-dir`        | string    | path to download the torrent to
+| `filename`            | string    | filename or URL of the .torrent file
+| `labels`              | array     | array of string labels
+| `metainfo`            | string    | base64-encoded .torrent content
+| `paused`              | boolean   | if true, don't start the torrent
+| `peer-limit`          | number    | maximum number of peers
+| `bandwidthPriority`   | number    | torrent's bandwidth tr_priority_t
+| `files-wanted`        | array     | indices of file(s) to download
+| `files-unwanted`      | array     | indices of file(s) to not download
+| `priority-high`       | array     | indices of high-priority file(s)
+| `priority-low`        | array     | indices of low-priority file(s)
+| `priority-normal`     | array     | indices of normal-priority file(s)
+| `sequential_download` | boolean   | download torrent pieces sequentially
 
 Either `filename` **or** `metainfo` **must** be included. All other arguments are optional.
 
@@ -573,7 +573,7 @@ Response arguments: `path`, `name`, and `id`, holding the torrent ID integer
 | `seed-queue-size` | number | max number of torrents to uploaded at once (see seed-queue-enabled)
 | `seedRatioLimit` | double | the default seed ratio for torrents to use
 | `seedRatioLimited` | boolean | true if seedRatioLimit is honored by default
-| `sequentialDownload` | boolean | true means sequential download is enabled by default for added torrents
+| `sequential_download` | boolean | true means sequential download is enabled by default for added torrents
 | `session-id` | string | the current `X-Transmission-Session-Id` value
 | `speed-limit-down-enabled` | boolean | true means enabled
 | `speed-limit-down` | number | max global download speed (KBps)
@@ -1029,11 +1029,11 @@ Transmission 4.0.0 (`rpc-version-semver` 5.3.0, `rpc-version`: 17)
 Transmission 4.1.0 (`rpc-version-semver` 5.4.0, `rpc-version`: 18)
 | Method | Description
 |:---|:---
-| `session-get` | new arg `sequentialDownload`
-| `session-set` | new arg `sequentialDownload`
-| `torrent-add` | new arg `sequentialDownload`
-| `torrent-get` | new arg `sequentialDownload`
-| `torrent-set` | new arg `sequentialDownload`
+| `session-get` | new arg `sequential_download`
+| `session-set` | new arg `sequential_download`
+| `torrent-add` | new arg `sequential_download`
+| `torrent-get` | new arg `sequential_download`
+| `torrent-set` | new arg `sequential_download`
 | `torrent-get` | new arg `files.beginPiece`
 | `torrent-get` | new arg `files.endPiece`
 | `port-test` | new arg `ipProtocol`

--- a/docs/rpc-spec.md
+++ b/docs/rpc-spec.md
@@ -297,7 +297,7 @@ The 'source' column here corresponds to the data structure there.
 | `bytesCompleted` | number | tr_file_view
 | `length` | number | tr_file_view
 | `name` | string | tr_file_view
-| `beginPiece` | number | tr_file_view
+| `begin_piece` | number | tr_file_view
 | `endPiece` | number | tr_file_view
 
 Files are returned in the order they are laid out in the torrent. References to "file indices" throughout this specification should be interpreted as the position of the file within this ordering, with the first file bearing index 0.
@@ -1034,6 +1034,6 @@ Transmission 4.1.0 (`rpc-version-semver` 5.4.0, `rpc-version`: 18)
 | `torrent-add` | new arg `sequential_download`
 | `torrent-get` | new arg `sequential_download`
 | `torrent-set` | new arg `sequential_download`
-| `torrent-get` | new arg `files.beginPiece`
+| `torrent-get` | new arg `files.begin_piece`
 | `torrent-get` | new arg `files.endPiece`
 | `port-test` | new arg `ipProtocol`

--- a/docs/rpc-spec.md
+++ b/docs/rpc-spec.md
@@ -298,7 +298,7 @@ The 'source' column here corresponds to the data structure there.
 | `length` | number | tr_file_view
 | `name` | string | tr_file_view
 | `begin_piece` | number | tr_file_view
-| `endPiece` | number | tr_file_view
+| `end_piece` | number | tr_file_view
 
 Files are returned in the order they are laid out in the torrent. References to "file indices" throughout this specification should be interpreted as the position of the file within this ordering, with the first file bearing index 0.
 
@@ -1035,5 +1035,5 @@ Transmission 4.1.0 (`rpc-version-semver` 5.4.0, `rpc-version`: 18)
 | `torrent-get` | new arg `sequential_download`
 | `torrent-set` | new arg `sequential_download`
 | `torrent-get` | new arg `files.begin_piece`
-| `torrent-get` | new arg `files.endPiece`
+| `torrent-get` | new arg `files.end_piece`
 | `port-test` | new arg `ipProtocol`

--- a/docs/rpc-spec.md
+++ b/docs/rpc-spec.md
@@ -670,8 +670,8 @@ from the outside world.
 
 Method name: `port-test`
 
-Request arguments: an optional argument `ipProtocol`.
-`ipProtocol` is a string specifying the IP protocol version to be used for the port test.
+Request arguments: an optional argument `ip_protocol`.
+`ip_protocol` is a string specifying the IP protocol version to be used for the port test.
 Set to `ipv4` to check IPv4, or set to `ipv6` to check IPv6.
 For backwards compatibility, it is allowed to omit this argument to get the behaviour before Transmission `4.1.0`,
 which is to check whichever IP protocol the OS happened to use to connect to our port test service,
@@ -682,7 +682,7 @@ Response arguments:
 | Key | Value Type | Description
 | :-- | :-- | :--
 | `port-is-open` | boolean | true if port is open, false if port is closed
-| `ipProtocol` | string | `ipv4` if the test was carried out on IPv4, `ipv6` if the test was carried out on IPv6, unset if it cannot be determined
+| `ip_protocol` | string | `ipv4` if the test was carried out on IPv4, `ipv6` if the test was carried out on IPv6, unset if it cannot be determined
 
 ### 4.5 Session shutdown
 This method tells the transmission session to shut down.
@@ -1036,4 +1036,4 @@ Transmission 4.1.0 (`rpc-version-semver` 5.4.0, `rpc-version`: 18)
 | `torrent-set` | new arg `sequential_download`
 | `torrent-get` | new arg `files.begin_piece`
 | `torrent-get` | new arg `files.end_piece`
-| `port-test` | new arg `ipProtocol`
+| `port-test` | new arg `ip_protocol`

--- a/gtk/Session.cc
+++ b/gtk/Session.cc
@@ -1284,7 +1284,7 @@ void Session::port_test(PortTestIpProtocol const ip_protocol)
     auto const tag = nextTag++;
 
     auto arguments_map = tr_variant::Map{ 1U };
-    arguments_map.try_emplace(TR_KEY_ipProtocol, tr_variant::unmanaged_string(IpStr[ip_protocol]));
+    arguments_map.try_emplace(TR_KEY_ip_protocol, tr_variant::unmanaged_string(IpStr[ip_protocol]));
 
     auto request_map = tr_variant::Map{ 3U };
     request_map.try_emplace(TR_KEY_method, tr_variant::unmanaged_string("port-test"sv));

--- a/libtransmission/quark.cc
+++ b/libtransmission/quark.cc
@@ -335,7 +335,7 @@ auto constexpr MyStatic = std::array<std::string_view, TR_N_KEYS>{
     "seedRatioMode"sv,
     "seederCount"sv,
     "seeding-time-seconds"sv,
-    "sequentialDownload"sv,
+    "sequential_download"sv,
     "session-count"sv,
     "session-id"sv,
     "sessionCount"sv,

--- a/libtransmission/quark.cc
+++ b/libtransmission/quark.cc
@@ -110,7 +110,7 @@ auto constexpr MyStatic = std::array<std::string_view, TR_N_KEYS>{
     "editDate"sv,
     "encoding"sv,
     "encryption"sv,
-    "endPiece"sv,
+    "end_piece"sv,
     "error"sv,
     "errorString"sv,
     "eta"sv,

--- a/libtransmission/quark.cc
+++ b/libtransmission/quark.cc
@@ -253,7 +253,7 @@ auto constexpr MyStatic = std::array<std::string_view, TR_N_KEYS>{
     "port-forwarding-enabled"sv,
     "port-is-open"sv,
     "preallocation"sv,
-    "preferred-transport"sv,
+    "preferred_transport"sv,
     "primary-mime-type"sv,
     "priorities"sv,
     "priority"sv,

--- a/libtransmission/quark.cc
+++ b/libtransmission/quark.cc
@@ -158,7 +158,7 @@ auto constexpr MyStatic = std::array<std::string_view, TR_N_KEYS>{
     "incomplete-dir-enabled"sv,
     "info"sv,
     "inhibit-desktop-hibernation"sv,
-    "ipProtocol"sv,
+    "ip_protocol"sv,
     "ipv4"sv,
     "ipv6"sv,
     "isBackup"sv,

--- a/libtransmission/quark.cc
+++ b/libtransmission/quark.cc
@@ -48,7 +48,7 @@ auto constexpr MyStatic = std::array<std::string_view, TR_N_KEYS>{
     "availability"sv,
     "bandwidth-priority"sv,
     "bandwidthPriority"sv,
-    "beginPiece"sv,
+    "begin_piece"sv,
     "bind-address-ipv4"sv,
     "bind-address-ipv6"sv,
     "bitfield"sv,

--- a/libtransmission/quark.h
+++ b/libtransmission/quark.h
@@ -160,7 +160,7 @@ enum
     TR_KEY_incomplete_dir_enabled,
     TR_KEY_info,
     TR_KEY_inhibit_desktop_hibernation,
-    TR_KEY_ipProtocol,
+    TR_KEY_ip_protocol,
     TR_KEY_ipv4,
     TR_KEY_ipv6,
     TR_KEY_isBackup,

--- a/libtransmission/quark.h
+++ b/libtransmission/quark.h
@@ -337,7 +337,7 @@ enum
     TR_KEY_seedRatioMode,
     TR_KEY_seederCount,
     TR_KEY_seeding_time_seconds,
-    TR_KEY_sequentialDownload,
+    TR_KEY_sequential_download,
     TR_KEY_session_count,
     TR_KEY_session_id,
     TR_KEY_sessionCount,

--- a/libtransmission/quark.h
+++ b/libtransmission/quark.h
@@ -112,7 +112,7 @@ enum
     TR_KEY_editDate,
     TR_KEY_encoding,
     TR_KEY_encryption,
-    TR_KEY_endPiece,
+    TR_KEY_end_piece,
     TR_KEY_error,
     TR_KEY_errorString,
     TR_KEY_eta,

--- a/libtransmission/quark.h
+++ b/libtransmission/quark.h
@@ -50,7 +50,7 @@ enum
     TR_KEY_availability, // rpc
     TR_KEY_bandwidth_priority,
     TR_KEY_bandwidthPriority,
-    TR_KEY_beginPiece,
+    TR_KEY_begin_piece,
     TR_KEY_bind_address_ipv4,
     TR_KEY_bind_address_ipv6,
     TR_KEY_bitfield,

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -764,7 +764,7 @@ tr_resume::fields_t load_from_file(tr_torrent* tor, tr_torrent::ResumeHelper& he
 
     if ((fields_to_load & tr_resume::SequentialDownload) != 0)
     {
-        if (auto b = map.value_if<bool>(TR_KEY_sequentialDownload); b)
+        if (auto b = map.value_if<bool>(TR_KEY_sequential_download); b)
         {
             tor->set_sequential_download(*b);
             fields_loaded |= tr_resume::SequentialDownload;
@@ -944,7 +944,7 @@ void save(tr_torrent* const tor, tr_torrent::ResumeHelper const& helper)
     map.try_emplace(TR_KEY_max_peers, tor->peer_limit());
     map.try_emplace(TR_KEY_bandwidth_priority, tor->get_priority());
     map.try_emplace(TR_KEY_paused, !helper.start_when_stable());
-    map.try_emplace(TR_KEY_sequentialDownload, tor->is_sequential_download());
+    map.try_emplace(TR_KEY_sequential_download, tor->is_sequential_download());
     save_peers(map, tor);
 
     if (tor->has_metainfo())

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -347,7 +347,7 @@ namespace make_torrent_field_helpers
     {
         auto const file = tr_torrentFile(&tor, idx);
         auto file_map = tr_variant::Map{ 5U };
-        file_map.try_emplace(TR_KEY_beginPiece, file.beginPiece);
+        file_map.try_emplace(TR_KEY_begin_piece, file.beginPiece);
         file_map.try_emplace(TR_KEY_bytesCompleted, file.have);
         file_map.try_emplace(TR_KEY_endPiece, file.endPiece);
         file_map.try_emplace(TR_KEY_length, file.length);

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -563,7 +563,7 @@ namespace make_torrent_field_helpers
     case TR_KEY_seedIdleMode:
     case TR_KEY_seedRatioLimit:
     case TR_KEY_seedRatioMode:
-    case TR_KEY_sequentialDownload:
+    case TR_KEY_sequential_download:
     case TR_KEY_sizeWhenDone:
     case TR_KEY_source:
     case TR_KEY_startDate:
@@ -657,7 +657,7 @@ namespace make_torrent_field_helpers
     case TR_KEY_seedIdleMode: return tor.idle_limit_mode();
     case TR_KEY_seedRatioLimit: return tor.seed_ratio();
     case TR_KEY_seedRatioMode: return tor.seed_ratio_mode();
-    case TR_KEY_sequentialDownload: return tor.is_sequential_download();
+    case TR_KEY_sequential_download: return tor.is_sequential_download();
     case TR_KEY_sizeWhenDone: return st.sizeWhenDone;
     case TR_KEY_source: return tor.source();
     case TR_KEY_startDate: return st.startDate;
@@ -1008,7 +1008,7 @@ char const* torrentSet(tr_session* session, tr_variant::Map const& args_in, tr_v
             tr_torrentSetSpeedLimit_KBps(tor, TR_DOWN, *val);
         }
 
-        if (auto const val = args_in.value_if<bool>(TR_KEY_sequentialDownload))
+        if (auto const val = args_in.value_if<bool>(TR_KEY_sequential_download))
         {
             tor->set_sequential_download(*val);
         }
@@ -1452,7 +1452,7 @@ char const* torrentAdd(tr_session* session, tr_variant::Map const& args_in, tr_r
         ctor.set_labels(std::move(labels));
     }
 
-    if (auto const val = args_in.value_if<bool>(TR_KEY_sequentialDownload); val)
+    if (auto const val = args_in.value_if<bool>(TR_KEY_sequential_download); val)
     {
         ctor.set_sequential_download(TR_FORCE, *val);
     }
@@ -1844,7 +1844,7 @@ char const* sessionSet(tr_session* session, tr_variant::Map const& args_in, tr_v
         tr_sessionSetAntiBruteForceEnabled(session, *val);
     }
 
-    if (auto const val = args_in.value_if<bool>(TR_KEY_sequentialDownload); val)
+    if (auto const val = args_in.value_if<bool>(TR_KEY_sequential_download); val)
     {
         session->set_sequential_download(*val);
     }
@@ -1984,7 +1984,7 @@ char const* sessionStats(tr_session* session, tr_variant::Map const& /*args_in*/
     case TR_KEY_seedRatioLimited: return session.isRatioLimited();
     case TR_KEY_seed_queue_enabled: return session.queueEnabled(TR_UP);
     case TR_KEY_seed_queue_size: return session.queueSize(TR_UP);
-    case TR_KEY_sequentialDownload: return session.sequential_download();
+    case TR_KEY_sequential_download: return session.sequential_download();
     case TR_KEY_session_id: return session.sessionId();
     case TR_KEY_speed_limit_down: return session.speed_limit(TR_DOWN).count(Speed::Units::KByps);
     case TR_KEY_speed_limit_down_enabled: return session.is_speed_limited(TR_DOWN);

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -349,7 +349,7 @@ namespace make_torrent_field_helpers
         auto file_map = tr_variant::Map{ 5U };
         file_map.try_emplace(TR_KEY_begin_piece, file.beginPiece);
         file_map.try_emplace(TR_KEY_bytesCompleted, file.have);
-        file_map.try_emplace(TR_KEY_endPiece, file.endPiece);
+        file_map.try_emplace(TR_KEY_end_piece, file.endPiece);
         file_map.try_emplace(TR_KEY_length, file.length);
         file_map.try_emplace(TR_KEY_name, file.name);
         vec.emplace_back(std::move(file_map));

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -1145,9 +1145,9 @@ void onPortTested(tr_web::FetchResponse const& web_response)
     auto* data = static_cast<tr_rpc_idle_data*>(user_data);
 
     if (auto const addr = tr_address::from_string(primary_ip);
-        data->args_out.find_if<std::string_view>(TR_KEY_ipProtocol) == nullptr && addr && addr->is_valid())
+        data->args_out.find_if<std::string_view>(TR_KEY_ip_protocol) == nullptr && addr && addr->is_valid())
     {
-        data->args_out.try_emplace(TR_KEY_ipProtocol, addr->is_ipv4() ? "ipv4"sv : "ipv6"sv);
+        data->args_out.try_emplace(TR_KEY_ip_protocol, addr->is_ipv4() ? "ipv4"sv : "ipv6"sv);
     }
 
     if (status != 200)
@@ -1174,17 +1174,17 @@ char const* portTest(tr_session* session, tr_variant::Map const& args_in, struct
     auto options = tr_web::FetchOptions{ url, onPortTested, idle_data };
     options.timeout_secs = TimeoutSecs;
 
-    if (auto const val = args_in.value_if<std::string_view>(TR_KEY_ipProtocol))
+    if (auto const val = args_in.value_if<std::string_view>(TR_KEY_ip_protocol))
     {
         if (*val == "ipv4"sv)
         {
             options.ip_proto = tr_web::FetchOptions::IPProtocol::V4;
-            idle_data->args_out.try_emplace(TR_KEY_ipProtocol, "ipv4"sv);
+            idle_data->args_out.try_emplace(TR_KEY_ip_protocol, "ipv4"sv);
         }
         else if (*val == "ipv6"sv)
         {
             options.ip_proto = tr_web::FetchOptions::IPProtocol::V6;
-            idle_data->args_out.try_emplace(TR_KEY_ipProtocol, "ipv6"sv);
+            idle_data->args_out.try_emplace(TR_KEY_ip_protocol, "ipv6"sv);
         }
         else
         {

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -496,7 +496,7 @@ public:
                 { TR_KEY_script_torrent_done_seeding_filename, &script_torrent_done_seeding_filename },
                 { TR_KEY_seed_queue_enabled, &seed_queue_enabled },
                 { TR_KEY_seed_queue_size, &seed_queue_size },
-                { TR_KEY_sequentialDownload, &sequential_download },
+                { TR_KEY_sequential_download, &sequential_download },
                 { TR_KEY_sleep_per_seconds_during_verify, &sleep_per_seconds_during_verify },
                 { TR_KEY_speed_limit_down, &speed_limit_down },
                 { TR_KEY_speed_limit_down_enabled, &speed_limit_down_enabled },

--- a/qt/Session.cc
+++ b/qt/Session.cc
@@ -94,7 +94,7 @@ void Session::portTest(Session::PortTestIpProtocol const ip_protocol)
     port_test_pending_[ip_protocol] = true;
 
     auto args = tr_variant::make_map(1U);
-    tr_variantDictAddStrView(&args, TR_KEY_ipProtocol, IpStr[ip_protocol]);
+    tr_variantDictAddStrView(&args, TR_KEY_ip_protocol, IpStr[ip_protocol]);
 
     auto const response_func = [this, ip_protocol](RpcResponse const& r)
     {

--- a/tests/libtransmission/rpc-test.cc
+++ b/tests/libtransmission/rpc-test.cc
@@ -223,7 +223,7 @@ TEST_F(RpcTest, sessionGet)
         TR_KEY_seed_queue_size,
         TR_KEY_seedRatioLimit,
         TR_KEY_seedRatioLimited,
-        TR_KEY_sequentialDownload,
+        TR_KEY_sequential_download,
         TR_KEY_session_id,
         TR_KEY_speed_limit_down,
         TR_KEY_speed_limit_down_enabled,

--- a/utils/remote.cc
+++ b/utils/remote.cc
@@ -737,7 +737,7 @@ auto constexpr DetailsKeys = std::array<tr_quark, 55>{
     TR_KEY_seedIdleLimit,
     TR_KEY_seedRatioMode,
     TR_KEY_seedRatioLimit,
-    TR_KEY_sequentialDownload,
+    TR_KEY_sequential_download,
     TR_KEY_sizeWhenDone,
     TR_KEY_source,
     TR_KEY_startDate,
@@ -963,7 +963,7 @@ void print_details(tr_variant::Map const& map)
             fmt::print("  Location: {:s}\n", *sv);
         }
 
-        if (auto b = t->value_if<bool>(TR_KEY_sequentialDownload); b)
+        if (auto b = t->value_if<bool>(TR_KEY_sequential_download); b)
         {
             fmt::print("  Sequential Download: {:s}\n", *b ? "Yes" : "No");
         }
@@ -1837,7 +1837,7 @@ void print_session(tr_variant::Map const& map)
         fmt::print("  Maximum memory cache size: {:s}\n", Memory{ *i, Memory::Units::MBytes }.to_string());
     }
 
-    if (auto b = args->value_if<bool>(TR_KEY_sequentialDownload); b)
+    if (auto b = args->value_if<bool>(TR_KEY_sequential_download); b)
     {
         fmt::print("  Sequential download: {:s}\n", *b ? "Yes" : "No");
     }
@@ -3140,11 +3140,11 @@ int process_args(char const* rpcurl, int argc, char const* const* argv, RemoteCo
             switch (c)
             {
             case 994:
-                args.insert_or_assign(TR_KEY_sequentialDownload, true);
+                args.insert_or_assign(TR_KEY_sequential_download, true);
                 break;
 
             case 995:
-                args.insert_or_assign(TR_KEY_sequentialDownload, false);
+                args.insert_or_assign(TR_KEY_sequential_download, false);
                 break;
 
             default:

--- a/web/src/prefs-dialog.js
+++ b/web/src/prefs-dialog.js
@@ -56,12 +56,12 @@ export class PrefsDialog extends EventTarget {
     }
   }
 
-  _onPortChecked(ipProtocol, response) {
+  _onPortChecked(ip_protocol, response) {
     if (this.closed) {
       return;
     }
 
-    const element = this.elements.network.port_status_label[ipProtocol];
+    const element = this.elements.network.port_status_label[ip_protocol];
     const is_open = response.arguments['port-is-open'] || false;
     element.dataset.open = is_open;
     if ('port-is-open' in response.arguments) {

--- a/web/src/remote.js
+++ b/web/src/remote.js
@@ -89,10 +89,10 @@ export class Remote {
     this.sendRequest(o, callback, context);
   }
 
-  checkPort(ipProtocol, callback, context) {
+  checkPort(ip_protocol, callback, context) {
     const o = {
       arguments: {
-        ipProtocol,
+        ip_protocol,
       },
       method: 'port-test',
     };


### PR DESCRIPTION
Rename any new quarks in `4.1.0` to snake_case so that they don't have to be changed later.