### PR TITLE
fix: flush torrent files on piece completed in sequential mode

### DIFF
--- a/docs/rpc-spec.md
+++ b/docs/rpc-spec.md
@@ -344,7 +344,7 @@ Files are returned in the order they are laid out in the torrent. References to 
 | `fromTracker`  | number     | tr_stat
 
 
-`pieces`: A bitfield holding pieceCount flags which are set to 'true' if we have the piece matching that position. JSON doesn't allow raw binary data, so this is a base64-encoded string. (Source: tr_torrent)
+`pieces`: A bitfield holding pieceCount flags which are set to 'true' if we have the piece matching that position. JSON doesn't allow raw binary data, so this is a base64-encoded string. Pieces are guaranteed to be written on disk if sequential download is enabled. Otherwise, data might still be in cache only. (Source: tr_torrent)
 
 `priorities`: An array of `tr_torrentFileCount()` numbers. Each is the `tr_priority_t` mode for the corresponding file.
 

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -2053,6 +2053,10 @@ void tr_session::verify_add(tr_torrent* const tor)
 }
 
 // ---
+void tr_session::flush_torrent_files(tr_torrent_id_t const tor_id) noexcept
+{
+    this->cache->flush_torrent(tor_id);
+}
 
 void tr_session::close_torrent_files(tr_torrent_id_t const tor_id) noexcept
 {

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -760,6 +760,7 @@ public:
         return open_files_;
     }
 
+    void flush_torrent_files(tr_torrent_id_t const tor_id) noexcept;
     void close_torrent_files(tr_torrent_id_t tor_id) noexcept;
     void close_torrent_file(tr_torrent const& tor, tr_file_index_t file_num) noexcept;
 

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -2157,6 +2157,13 @@ void tr_torrent::on_piece_completed(tr_piece_index_t const piece)
     // bookkeeping
     set_needs_completeness_check();
 
+    // in sequential mode, flush files as soon a piece
+    // is completed to let other programs read the written data
+    if (is_sequential_download())
+    {
+        session->flush_torrent_files(id());
+    }
+
     // if this piece completes any file, invoke the fileCompleted func for it
     for (auto [file, file_end] = fpm_.file_span_for_piece(piece); file < file_end; ++file)
     {


### PR DESCRIPTION
In sequential download mode, I think files should be written as soon as possible to let other programs read the data early.

**Problem**
`pieces` fields returned in `RPC` responses could return `true` for some pieces, meanwhile data associated is not yet written on disk.

**Solution**
Flush files as soon a piece is completed in sequential download mode.
In sequential mode, `pieces` returned by rpc response should now be consistent with data written on disk.

I added details about the `pieces` behavior in the RPC `docs`.

**Note**: This is one of the changes I worked on Transmission `v.4.0.x` to add streaming support to [PikaTorrent](https://github.com/G-Ray/pikatorrent). See https://github.com/G-Ray/transmission/commits/4.0.x-pikatorrent.
I will try to suggest more changes upstream while porting the code to Transmission `4.1.x`.