### PR TITLE
chore: deprecate `torrent-get.manualAnnounceTime`

### DIFF
--- a/docs/rpc-spec.md
+++ b/docs/rpc-spec.md
@@ -244,7 +244,7 @@ The 'source' column here corresponds to the data structure there.
 | `labels` | array of strings | tr_torrent
 | `leftUntilDone` | number| tr_stat
 | `magnetLink` | string| n/a
-| `manualAnnounceTime` | number| tr_stat
+| `manualAnnounceTime` | number| **DEPRECATED** don't use it, it never worked
 | `maxConnectedPeers` | number| tr_torrent
 | `metadataPercentComplete` | double| tr_stat
 | `name` | string| tr_torrent_view
@@ -1037,3 +1037,4 @@ Transmission 4.1.0 (`rpc-version-semver` 5.4.0, `rpc-version`: 18)
 | `torrent-get` | new arg `files.begin_piece`
 | `torrent-get` | new arg `files.end_piece`
 | `port-test` | new arg `ip_protocol`
+| `torrent-get` | :warning: **DEPRECATED** `manualAnnounceTime`, it never worked


### PR DESCRIPTION
Deprecate `torrent-get.manualAnnounceTime` since it is broken and doesn't seem to be used by anyone.

Ever since 86ada1826611ec16fd9571335ad209c3448e4a41 (2009!) `torrent-get.manualAnnounceTime` will ***always*** return `-1`.

The fact that I cannot find anyone complaining about it in a quick Google search and GitHub issue search makes me think it's pretty safe to say that no one uses it.

Our clients don't use it either. It used to be in `tr_stat` but was removed in da032e38757d0abe5558f3d993844fcbec615ebe for `4.0.0`.

Notes: Deprecate `torrent-get.manualAnnounceTime`.