### PR TITLE
compatibility with clang-format 20

### DIFF
--- a/daemon/daemon.cc
+++ b/daemon/daemon.cc
@@ -196,11 +196,12 @@ auto onFileAdded(tr_session* session, std::string_view dirname, std::string_view
         auto error = tr_error{};
         if (!tr_file_read(filename, content, &error))
         {
-            tr_logAddWarn(fmt::format(
-                fmt::runtime(_("Couldn't read '{path}': {error} ({error_code})")),
-                fmt::arg("path", basename),
-                fmt::arg("error", error.message()),
-                fmt::arg("error_code", error.code())));
+            tr_logAddWarn(
+                fmt::format(
+                    fmt::runtime(_("Couldn't read '{path}': {error} ({error_code})")),
+                    fmt::arg("path", basename),
+                    fmt::arg("error", error.message()),
+                    fmt::arg("error_code", error.code())));
             retry = true;
         }
         else
@@ -235,11 +236,12 @@ auto onFileAdded(tr_session* session, std::string_view dirname, std::string_view
 
             if (auto error = tr_error{}; !tr_sys_path_remove(filename, &error))
             {
-                tr_logAddError(fmt::format(
-                    fmt::runtime(_("Couldn't remove '{path}': {error} ({error_code})")),
-                    fmt::arg("path", basename),
-                    fmt::arg("error", error.message()),
-                    fmt::arg("error_code", error.code())));
+                tr_logAddError(
+                    fmt::format(
+                        fmt::runtime(_("Couldn't remove '{path}': {error} ({error_code})")),
+                        fmt::arg("path", basename),
+                        fmt::arg("error", error.message()),
+                        fmt::arg("error_code", error.code())));
             }
         }
         else
@@ -769,11 +771,12 @@ int tr_daemon::start([[maybe_unused]] bool foreground)
         }
         else
         {
-            tr_logAddError(fmt::format(
-                fmt::runtime(_("Couldn't save '{path}': {error} ({error_code})")),
-                fmt::arg("path", sz_pid_filename),
-                fmt::arg("error", error.message()),
-                fmt::arg("error_code", error.code())));
+            tr_logAddError(
+                fmt::format(
+                    fmt::runtime(_("Couldn't save '{path}': {error} ({error_code})")),
+                    fmt::arg("path", sz_pid_filename),
+                    fmt::arg("error", error.message()),
+                    fmt::arg("error_code", error.code())));
         }
     }
 
@@ -845,20 +848,22 @@ int tr_daemon::start([[maybe_unused]] bool foreground)
         if (status_ev == nullptr)
         {
             auto const error_code = errno;
-            tr_logAddError(fmt::format(
-                fmt::runtime(_("Couldn't create event: {error} ({error_code})")),
-                fmt::arg("error", tr_strerror(error_code)),
-                fmt::arg("error_code", error_code)));
+            tr_logAddError(
+                fmt::format(
+                    fmt::runtime(_("Couldn't create event: {error} ({error_code})")),
+                    fmt::arg("error", tr_strerror(error_code)),
+                    fmt::arg("error_code", error_code)));
             goto CLEANUP;
         }
 
         if (event_add(status_ev, &one_sec) == -1)
         {
             auto const error_code = errno;
-            tr_logAddError(fmt::format(
-                fmt::runtime(_("Couldn't add event: {error} ({error_code})")),
-                fmt::arg("error", tr_strerror(error_code)),
-                fmt::arg("error_code", error_code)));
+            tr_logAddError(
+                fmt::format(
+                    fmt::runtime(_("Couldn't add event: {error} ({error_code})")),
+                    fmt::arg("error", tr_strerror(error_code)),
+                    fmt::arg("error_code", error_code)));
             goto CLEANUP;
         }
     }
@@ -869,10 +874,11 @@ int tr_daemon::start([[maybe_unused]] bool foreground)
     if (event_base_dispatch(ev_base_) == -1)
     {
         auto const error_code = errno;
-        tr_logAddError(fmt::format(
-            fmt::runtime(_("Couldn't launch daemon event loop: {error} ({error_code})")),
-            fmt::arg("error", tr_strerror(error_code)),
-            fmt::arg("error_code", error_code)));
+        tr_logAddError(
+            fmt::format(
+                fmt::runtime(_("Couldn't launch daemon event loop: {error} ({error_code})")),
+                fmt::arg("error", tr_strerror(error_code)),
+                fmt::arg("error_code", error_code)));
         goto CLEANUP;
     }
 

--- a/gtk/Actions.cc
+++ b/gtk/Actions.cc
@@ -238,9 +238,10 @@ Glib::RefPtr<Gio::ListModel> gtr_shortcuts_get_from_menu(Glib::RefPtr<Gio::MenuM
 
             if (!action_name.empty() && !action_accel.empty())
             {
-                result->append(Gtk::Shortcut::create(
-                    Gtk::ShortcutTrigger::parse_string(action_accel),
-                    Gtk::NamedAction::create(action_name)));
+                result->append(
+                    Gtk::Shortcut::create(
+                        Gtk::ShortcutTrigger::parse_string(action_accel),
+                        Gtk::NamedAction::create(action_name)));
             }
 
             for (auto it = link->iterate_item_links(i); it->next();)

--- a/gtk/Application.cc
+++ b/gtk/Application.cc
@@ -396,11 +396,12 @@ void register_magnet_link_handler()
     }
     catch (Gio::Error const& e)
     {
-        gtr_warning(fmt::format(
-            fmt::runtime(_("Couldn't register Transmission as a {content_type} handler: {error} ({error_code})")),
-            fmt::arg("content_type", content_type),
-            fmt::arg("error", e.what()),
-            fmt::arg("error_code", static_cast<int>(e.code()))));
+        gtr_warning(
+            fmt::format(
+                fmt::runtime(_("Couldn't register Transmission as a {content_type} handler: {error} ({error_code})")),
+                fmt::arg("content_type", content_type),
+                fmt::arg("error", e.what()),
+                fmt::arg("error_code", static_cast<int>(e.code()))));
     }
 }
 

--- a/gtk/DetailsDialog.cc
+++ b/gtk/DetailsDialog.cc
@@ -976,11 +976,12 @@ void DetailsDialog::Impl::refreshInfo(std::vector<tr_torrent*> const& torrents)
     }
     else
     {
-        auto const downloaded_str = tr_strlsize(std::accumulate(
-            std::begin(stats),
-            std::end(stats),
-            uint64_t{ 0 },
-            [](auto sum, auto const* st) { return sum + st->downloadedEver; }));
+        auto const downloaded_str = tr_strlsize(
+            std::accumulate(
+                std::begin(stats),
+                std::end(stats),
+                uint64_t{ 0 },
+                [](auto sum, auto const* st) { return sum + st->downloadedEver; }));
 
         auto const failed = std::accumulate(
             std::begin(stats),

--- a/gtk/FileList.cc
+++ b/gtk/FileList.cc
@@ -821,13 +821,14 @@ struct rename_data
 
 void FileList::Impl::on_rename_done(Glib::ustring const& path_string, Glib::ustring const& newname, int error)
 {
-    rename_done_tags_.push(Glib::signal_idle().connect(
-        [this, path_string, newname, error]()
-        {
-            rename_done_tags_.pop();
-            on_rename_done_idle(path_string, newname, error);
-            return false;
-        }));
+    rename_done_tags_.push(
+        Glib::signal_idle().connect(
+            [this, path_string, newname, error]()
+            {
+                rename_done_tags_.pop();
+                on_rename_done_idle(path_string, newname, error);
+                return false;
+            }));
 }
 
 void FileList::Impl::on_rename_done_idle(Glib::ustring const& path_string, Glib::ustring const& newname, int error)

--- a/gtk/MainWindow.cc
+++ b/gtk/MainWindow.cc
@@ -379,12 +379,13 @@ void MainWindow::Impl::syncAltSpeedButton()
 {
     bool const b = gtr_pref_flag_get(TR_KEY_alt_speed_enabled);
     alt_speed_button_->set_active(b);
-    alt_speed_button_->set_tooltip_text(fmt::format(
-        fmt::runtime(
-            b ? _("Click to disable Alternative Speed Limits\n ({download_speed} down, {upload_speed} up)") :
-                _("Click to enable Alternative Speed Limits\n ({download_speed} down, {upload_speed} up)")),
-        fmt::arg("download_speed", Speed{ gtr_pref_int_get(TR_KEY_alt_speed_down), Speed::Units::KByps }.to_string()),
-        fmt::arg("upload_speed", Speed{ gtr_pref_int_get(TR_KEY_alt_speed_up), Speed::Units::KByps }.to_string())));
+    alt_speed_button_->set_tooltip_text(
+        fmt::format(
+            fmt::runtime(
+                b ? _("Click to disable Alternative Speed Limits\n ({download_speed} down, {upload_speed} up)") :
+                    _("Click to enable Alternative Speed Limits\n ({download_speed} down, {upload_speed} up)")),
+            fmt::arg("download_speed", Speed{ gtr_pref_int_get(TR_KEY_alt_speed_down), Speed::Units::KByps }.to_string()),
+            fmt::arg("upload_speed", Speed{ gtr_pref_int_get(TR_KEY_alt_speed_up), Speed::Units::KByps }.to_string())));
 }
 
 void MainWindow::Impl::alt_speed_toggled_cb()

--- a/gtk/MessageLogWindow.cc
+++ b/gtk/MessageLogWindow.cc
@@ -491,9 +491,10 @@ MessageLogWindow::Impl::Impl(
     , filter_(Gtk::TreeModelFilter::create(store_))
     , sort_(Gtk::TreeModelSort::create(filter_))
     , maxLevel_(static_cast<tr_log_level>(gtr_pref_int_get(TR_KEY_message_level)))
-    , refresh_tag_(Glib::signal_timeout().connect_seconds(
-          sigc::mem_fun(*this, &Impl::onRefresh),
-          SECONDARY_WINDOW_REFRESH_INTERVAL_SECONDS))
+    , refresh_tag_(
+          Glib::signal_timeout().connect_seconds(
+              sigc::mem_fun(*this, &Impl::onRefresh),
+              SECONDARY_WINDOW_REFRESH_INTERVAL_SECONDS))
 {
     /**
     ***  toolbar

--- a/gtk/Notify.cc
+++ b/gtk/Notify.cc
@@ -144,11 +144,12 @@ void dbus_proxy_ready_callback(Glib::RefPtr<Gio::AsyncResult>& res)
     }
     catch (Glib::Error const& e)
     {
-        gtr_warning(fmt::format(
-            fmt::runtime(_("Couldn't create proxy for '{bus}': {error} ({error_code})")),
-            fmt::arg("bus", NotificationsDbusName),
-            fmt::arg("error", TR_GLIB_EXCEPTION_WHAT(e)),
-            fmt::arg("error_code", e.code())));
+        gtr_warning(
+            fmt::format(
+                fmt::runtime(_("Couldn't create proxy for '{bus}': {error} ({error_code})")),
+                fmt::arg("bus", NotificationsDbusName),
+                fmt::arg("error", TR_GLIB_EXCEPTION_WHAT(e)),
+                fmt::arg("error_code", e.code())));
         return;
     }
 

--- a/gtk/Session.cc
+++ b/gtk/Session.cc
@@ -318,12 +318,13 @@ void rename_torrent(Glib::RefPtr<Gio::File> const& file)
     }
     catch (Glib::Error const& e)
     {
-        gtr_message(fmt::format(
-            fmt::runtime(_("Couldn't rename '{old_path}' as '{path}': {error} ({error_code})")),
-            fmt::arg("old_path", old_name),
-            fmt::arg("path", new_name),
-            fmt::arg("error", e.what()),
-            fmt::arg("error_code", e.code())));
+        gtr_message(
+            fmt::format(
+                fmt::runtime(_("Couldn't rename '{old_path}' as '{path}': {error} ({error_code})")),
+                fmt::arg("old_path", old_name),
+                fmt::arg("path", new_name),
+                fmt::arg("error", e.what()),
+                fmt::arg("error_code", e.code())));
     }
 }
 
@@ -807,11 +808,12 @@ void Session::Impl::add_file_async_callback(
     }
     catch (Glib::Error const& e)
     {
-        gtr_message(fmt::format(
-            fmt::runtime(_("Couldn't read '{path}': {error} ({error_code})")),
-            fmt::arg("path", file->get_parse_name()),
-            fmt::arg("error", e.what()),
-            fmt::arg("error_code", e.code())));
+        gtr_message(
+            fmt::format(
+                fmt::runtime(_("Couldn't read '{path}': {error} ({error_code})")),
+                fmt::arg("path", file->get_parse_name()),
+                fmt::arg("error", e.what()),
+                fmt::arg("error_code", e.code())));
     }
 
     dec_busy();
@@ -1070,12 +1072,13 @@ bool gtr_inhibit_hibernation(guint32& cookie)
             std::string(SessionManagerObjectPath),
             std::string(SessionManagerInterface),
             "Inhibit",
-            Glib::VariantContainerBase::create_tuple({
-                Glib::Variant<Glib::ustring>::create(application),
-                Glib::Variant<guint32>::create(toplevel_xid),
-                Glib::Variant<Glib::ustring>::create(reason),
-                Glib::Variant<guint32>::create(flags),
-            }),
+            Glib::VariantContainerBase::create_tuple(
+                {
+                    Glib::Variant<Glib::ustring>::create(application),
+                    Glib::Variant<guint32>::create(toplevel_xid),
+                    Glib::Variant<Glib::ustring>::create(reason),
+                    Glib::Variant<guint32>::create(flags),
+                }),
             std::string(SessionManagerServiceName),
             1000);
 

--- a/gtk/Torrent.cc
+++ b/gtk/Torrent.cc
@@ -273,10 +273,11 @@ Torrent::ChangeFlags Torrent::Impl::update_cache()
     update_cache_value(cache_.activity, stats->activity, result, ChangeFlag::ACTIVITY);
     update_cache_value(
         cache_.activity_percent_done,
-        Percents(std::clamp(
-            stats->activity == TR_STATUS_SEED && has_seed_ratio ? stats->seedRatioPercentDone : stats->percentDone,
-            0.0F,
-            1.0F)),
+        Percents(
+            std::clamp(
+                stats->activity == TR_STATUS_SEED && has_seed_ratio ? stats->seedRatioPercentDone : stats->percentDone,
+                0.0F,
+                1.0F)),
         result,
         ChangeFlag::PERCENT_DONE);
     update_cache_value(cache_.finished, stats->finished, result, ChangeFlag::FINISHED);

--- a/gtk/Utils.cc
+++ b/gtk/Utils.cc
@@ -541,11 +541,12 @@ bool gtr_file_trash_or_remove(std::string const& filename, tr_error* error)
         catch (Glib::Error const& e)
         {
             error->set(e.code(), TR_GLIB_EXCEPTION_WHAT(e));
-            gtr_message(fmt::format(
-                fmt::runtime(_("Couldn't move '{path}' to trash: {error} ({error_code})")),
-                fmt::arg("path", filename),
-                fmt::arg("error", error->message()),
-                fmt::arg("error_code", error->code())));
+            gtr_message(
+                fmt::format(
+                    fmt::runtime(_("Couldn't move '{path}' to trash: {error} ({error_code})")),
+                    fmt::arg("path", filename),
+                    fmt::arg("error", error->message()),
+                    fmt::arg("error_code", error->code())));
         }
     }
 
@@ -559,11 +560,12 @@ bool gtr_file_trash_or_remove(std::string const& filename, tr_error* error)
         catch (Glib::Error const& e)
         {
             error->set(e.code(), TR_GLIB_EXCEPTION_WHAT(e));
-            gtr_message(fmt::format(
-                fmt::runtime(_("Couldn't remove '{path}': {error} ({error_code})")),
-                fmt::arg("path", filename),
-                fmt::arg("error", error->message()),
-                fmt::arg("error_code", error->code())));
+            gtr_message(
+                fmt::format(
+                    fmt::runtime(_("Couldn't remove '{path}': {error} ({error_code})")),
+                    fmt::arg("path", filename),
+                    fmt::arg("error", error->message()),
+                    fmt::arg("error_code", error->code())));
             result = false;
         }
     }

--- a/libtransmission/blocklist.cc
+++ b/libtransmission/blocklist.cc
@@ -58,30 +58,33 @@ void save(std::string_view filename, address_range_t const* ranges, size_t n_ran
     auto out = std::ofstream{ tr_pathbuf{ filename }, std::ios_base::out | std::ios_base::trunc | std::ios_base::binary };
     if (!out.is_open())
     {
-        tr_logAddWarn(fmt::format(
-            fmt::runtime(_("Couldn't read '{path}': {error} ({error_code})")),
-            fmt::arg("path", filename),
-            fmt::arg("error", tr_strerror(errno)),
-            fmt::arg("error_code", errno)));
+        tr_logAddWarn(
+            fmt::format(
+                fmt::runtime(_("Couldn't read '{path}': {error} ({error_code})")),
+                fmt::arg("path", filename),
+                fmt::arg("error", tr_strerror(errno)),
+                fmt::arg("error_code", errno)));
         return;
     }
 
     if (!out.write(std::data(BinContentsPrefix), std::size(BinContentsPrefix)) ||
         !out.write(reinterpret_cast<char const*>(ranges), n_ranges * sizeof(*ranges)))
     {
-        tr_logAddWarn(fmt::format(
-            fmt::runtime(_("Couldn't save '{path}': {error} ({error_code})")),
-            fmt::arg("path", filename),
-            fmt::arg("error", tr_strerror(errno)),
-            fmt::arg("error_code", errno)));
+        tr_logAddWarn(
+            fmt::format(
+                fmt::runtime(_("Couldn't save '{path}': {error} ({error_code})")),
+                fmt::arg("path", filename),
+                fmt::arg("error", tr_strerror(errno)),
+                fmt::arg("error_code", errno)));
     }
     else
     {
-        tr_logAddInfo(fmt::format(
-            fmt::runtime(
-                tr_ngettext("Blocklist '{path}' has {count} entry", "Blocklist '{path}' has {count} entries", n_ranges)),
-            fmt::arg("path", tr_sys_path_basename(filename)),
-            fmt::arg("count", n_ranges)));
+        tr_logAddInfo(
+            fmt::format(
+                fmt::runtime(
+                    tr_ngettext("Blocklist '{path}' has {count} entry", "Blocklist '{path}' has {count} entries", n_ranges)),
+                fmt::arg("path", tr_sys_path_basename(filename)),
+                fmt::arg("count", n_ranges)));
     }
 
     out.close();
@@ -237,11 +240,12 @@ auto parseFile(std::string_view filename)
     auto in = std::ifstream{ tr_pathbuf{ filename } };
     if (!in.is_open())
     {
-        tr_logAddWarn(fmt::format(
-            fmt::runtime(_("Couldn't read '{path}': {error} ({error_code})")),
-            fmt::arg("path", filename),
-            fmt::arg("error", tr_strerror(errno)),
-            fmt::arg("error_code", errno)));
+        tr_logAddWarn(
+            fmt::format(
+                fmt::runtime(_("Couldn't read '{path}': {error} ({error_code})")),
+                fmt::arg("path", filename),
+                fmt::arg("error", tr_strerror(errno)),
+                fmt::arg("error_code", errno)));
         return ranges;
     }
 
@@ -335,11 +339,12 @@ void Blocklists::Blocklist::ensureLoaded() const
     auto const file_info = tr_sys_path_get_info(bin_file_, 0, &error);
     if (error)
     {
-        tr_logAddWarn(fmt::format(
-            fmt::runtime(_("Couldn't read '{path}': {error} ({error_code})")),
-            fmt::arg("path", bin_file_),
-            fmt::arg("error", error.message()),
-            fmt::arg("error_code", error.code())));
+        tr_logAddWarn(
+            fmt::format(
+                fmt::runtime(_("Couldn't read '{path}': {error} ({error_code})")),
+                fmt::arg("path", bin_file_),
+                fmt::arg("error", error.message()),
+                fmt::arg("error_code", error.code())));
     }
     if (!file_info)
     {
@@ -350,11 +355,12 @@ void Blocklists::Blocklist::ensureLoaded() const
     auto in = std::ifstream{ bin_file_, std::ios_base::in | std::ios_base::binary };
     if (!in)
     {
-        tr_logAddWarn(fmt::format(
-            fmt::runtime(_("Couldn't read '{path}': {error} ({error_code})")),
-            fmt::arg("path", bin_file_),
-            fmt::arg("error", tr_strerror(errno)),
-            fmt::arg("error_code", errno)));
+        tr_logAddWarn(
+            fmt::format(
+                fmt::runtime(_("Couldn't read '{path}': {error} ({error_code})")),
+                fmt::arg("path", bin_file_),
+                fmt::arg("error", tr_strerror(errno)),
+                fmt::arg("error_code", errno)));
         return;
     }
 
@@ -400,11 +406,14 @@ void Blocklists::Blocklist::ensureLoaded() const
         rules_.emplace_back(range);
     }
 
-    tr_logAddInfo(fmt::format(
-        fmt::runtime(
-            tr_ngettext("Blocklist '{path}' has {count} entry", "Blocklist '{path}' has {count} entries", std::size(rules_))),
-        fmt::arg("path", tr_sys_path_basename(bin_file_)),
-        fmt::arg("count", std::size(rules_))));
+    tr_logAddInfo(
+        fmt::format(
+            fmt::runtime(tr_ngettext(
+                "Blocklist '{path}' has {count} entry",
+                "Blocklist '{path}' has {count} entries",
+                std::size(rules_))),
+            fmt::arg("path", tr_sys_path_basename(bin_file_)),
+            fmt::arg("count", std::size(rules_))));
 }
 
 bool Blocklists::Blocklist::contains(tr_address const& addr) const
@@ -471,11 +480,12 @@ std::optional<Blocklists::Blocklist> Blocklists::Blocklist::saveNew(
     auto const copied = tr_sys_path_copy(tr_pathbuf{ external_file }, src_file.c_str(), &error);
     if (error)
     {
-        tr_logAddWarn(fmt::format(
-            fmt::runtime(_("Couldn't save '{path}': {error} ({error_code})")),
-            fmt::arg("path", src_file),
-            fmt::arg("error", error.message()),
-            fmt::arg("error_code", error.code())));
+        tr_logAddWarn(
+            fmt::format(
+                fmt::runtime(_("Couldn't save '{path}': {error} ({error_code})")),
+                fmt::arg("path", src_file),
+                fmt::arg("error", error.message()),
+                fmt::arg("error_code", error.code())));
     }
     if (!copied)
     {

--- a/libtransmission/ip-cache.cc
+++ b/libtransmission/ip-cache.cc
@@ -270,10 +270,11 @@ void tr_ip_cache::update_source_addr(tr_address_type type) noexcept
     if (source_addr)
     {
         set_source_addr(*source_addr);
-        tr_logAddDebug(fmt::format(
-            fmt::runtime(_("Successfully updated source {protocol} address to {ip}")),
-            fmt::arg("protocol", protocol),
-            fmt::arg("ip", source_addr->display_name())));
+        tr_logAddDebug(
+            fmt::format(
+                fmt::runtime(_("Successfully updated source {protocol} address to {ip}")),
+                fmt::arg("protocol", protocol),
+                fmt::arg("ip", source_addr->display_name())));
     }
     else
     {
@@ -310,11 +311,12 @@ void tr_ip_cache::on_response_ip_query(tr_address_type type, tr_web::FetchRespon
             success = true;
             upkeep_timers_[type]->set_interval(UpkeepInterval);
 
-            tr_logAddDebug(fmt::format(
-                fmt::runtime(_("Successfully updated global {type} address to {ip} using {url}")),
-                fmt::arg("type", protocol),
-                fmt::arg("ip", addr->display_name()),
-                fmt::arg("url", IPQueryServices[type][ix_service])));
+            tr_logAddDebug(
+                fmt::format(
+                    fmt::runtime(_("Successfully updated global {type} address to {ip} using {url}")),
+                    fmt::arg("type", protocol),
+                    fmt::arg("ip", addr->display_name()),
+                    fmt::arg("url", IPQueryServices[type][ix_service])));
         }
     }
 

--- a/libtransmission/makemeta.cc
+++ b/libtransmission/makemeta.cc
@@ -76,11 +76,12 @@ void walkTree(std::string_view const top, std::string_view const subpath, std::s
     auto const info = tr_sys_path_get_info(path, 0, &error);
     if (error)
     {
-        tr_logAddWarn(fmt::format(
-            fmt::runtime(_("Skipping '{path}': {error} ({error_code})")),
-            fmt::arg("path", path),
-            fmt::arg("error", error.message()),
-            fmt::arg("error_code", error.code())));
+        tr_logAddWarn(
+            fmt::format(
+                fmt::runtime(_("Skipping '{path}': {error} ({error_code})")),
+                fmt::arg("path", path),
+                fmt::arg("error", error.message()),
+                fmt::arg("error_code", error.code())));
     }
     if (!info)
     {

--- a/libtransmission/net.cc
+++ b/libtransmission/net.cc
@@ -188,10 +188,11 @@ tr_socket_t createSocket(int domain, int type)
     {
         if (sockerrno != EAFNOSUPPORT)
         {
-            tr_logAddWarn(fmt::format(
-                fmt::runtime(_("Couldn't create socket: {error} ({error_code})")),
-                fmt::arg("error", tr_net_strerror(sockerrno)),
-                fmt::arg("error_code", sockerrno)));
+            tr_logAddWarn(
+                fmt::format(
+                    fmt::runtime(_("Couldn't create socket: {error} ({error_code})")),
+                    fmt::arg("error", tr_net_strerror(sockerrno)),
+                    fmt::arg("error_code", sockerrno)));
         }
 
         return TR_BAD_SOCKET;
@@ -265,12 +266,13 @@ tr_socket_t tr_net_open_peer_socket(tr_session* session, tr_socket_address const
 
     if (bind(s, reinterpret_cast<sockaddr const*>(&source_sock), sourcelen) == -1)
     {
-        tr_logAddWarn(fmt::format(
-            fmt::runtime(_("Couldn't set source address {address} on {socket}: {error} ({error_code})")),
-            fmt::arg("address", source_addr.display_name()),
-            fmt::arg("socket", s),
-            fmt::arg("error", tr_net_strerror(sockerrno)),
-            fmt::arg("error_code", sockerrno)));
+        tr_logAddWarn(
+            fmt::format(
+                fmt::runtime(_("Couldn't set source address {address} on {socket}: {error} ({error_code})")),
+                fmt::arg("address", source_addr.display_name()),
+                fmt::arg("socket", s),
+                fmt::arg("error", tr_net_strerror(sockerrno)),
+                fmt::arg("error_code", sockerrno)));
         tr_net_close_socket(s);
         return TR_BAD_SOCKET;
     }
@@ -284,13 +286,14 @@ tr_socket_t tr_net_open_peer_socket(tr_session* session, tr_socket_address const
         if (auto const tmperrno = sockerrno;
             (tmperrno != ECONNREFUSED && tmperrno != ENETUNREACH && tmperrno != EHOSTUNREACH) || addr.is_ipv4())
         {
-            tr_logAddWarn(fmt::format(
-                fmt::runtime(_("Couldn't connect socket {socket} to {address}:{port}: {error} ({error_code})")),
-                fmt::arg("socket", s),
-                fmt::arg("address", addr.display_name()),
-                fmt::arg("port", port.host()),
-                fmt::arg("error", tr_net_strerror(tmperrno)),
-                fmt::arg("error_code", tmperrno)));
+            tr_logAddWarn(
+                fmt::format(
+                    fmt::runtime(_("Couldn't connect socket {socket} to {address}:{port}: {error} ({error_code})")),
+                    fmt::arg("socket", s),
+                    fmt::arg("address", addr.display_name()),
+                    fmt::arg("port", port.host()),
+                    fmt::arg("error", tr_net_strerror(tmperrno)),
+                    fmt::arg("error_code", tmperrno)));
         }
 
         tr_net_close_socket(s);
@@ -342,15 +345,16 @@ tr_socket_t tr_netBindTCPImpl(tr_address const& addr, tr_port port, bool suppres
 
         if (!suppress_msgs)
         {
-            tr_logAddError(fmt::format(
-                fmt::runtime(
-                    err == EADDRINUSE ?
-                        _("Couldn't bind port {port} on {address}: {error} ({error_code}) -- Is another copy of Transmission already running?") :
-                        _("Couldn't bind port {port} on {address}: {error} ({error_code})")),
-                fmt::arg("address", addr.display_name()),
-                fmt::arg("port", port.host()),
-                fmt::arg("error", tr_net_strerror(err)),
-                fmt::arg("error_code", err)));
+            tr_logAddError(
+                fmt::format(
+                    fmt::runtime(
+                        err == EADDRINUSE ?
+                            _("Couldn't bind port {port} on {address}: {error} ({error_code}) -- Is another copy of Transmission already running?") :
+                            _("Couldn't bind port {port} on {address}: {error} ({error_code})")),
+                    fmt::arg("address", addr.display_name()),
+                    fmt::arg("port", port.host()),
+                    fmt::arg("error", tr_net_strerror(err)),
+                    fmt::arg("error_code", err)));
         }
 
         tr_net_close_socket(fd);

--- a/libtransmission/open-files.cc
+++ b/libtransmission/open-files.cc
@@ -166,11 +166,12 @@ std::optional<tr_sys_file_t> tr_open_files::get(
         dir.popdir();
         if (!tr_sys_dir_create(dir, TR_SYS_DIR_CREATE_PARENTS, 0777, &error))
         {
-            tr_logAddError(fmt::format(
-                fmt::runtime(_("Couldn't create '{path}': {error} ({error_code})")),
-                fmt::arg("path", dir),
-                fmt::arg("error", error.message()),
-                fmt::arg("error_code", error.code())));
+            tr_logAddError(
+                fmt::format(
+                    fmt::runtime(_("Couldn't create '{path}': {error} ({error_code})")),
+                    fmt::arg("path", dir),
+                    fmt::arg("error", error.message()),
+                    fmt::arg("error_code", error.code())));
             return {};
         }
     }
@@ -188,11 +189,12 @@ std::optional<tr_sys_file_t> tr_open_files::get(
     auto const fd = tr_sys_file_open(filename, flags, 0666, &error);
     if (!is_open(fd))
     {
-        tr_logAddError(fmt::format(
-            fmt::runtime(_("Couldn't open '{path}': {error} ({error_code})")),
-            fmt::arg("path", filename),
-            fmt::arg("error", error.message()),
-            fmt::arg("error_code", error.code())));
+        tr_logAddError(
+            fmt::format(
+                fmt::runtime(_("Couldn't open '{path}': {error} ({error_code})")),
+                fmt::arg("path", filename),
+                fmt::arg("error", error.message()),
+                fmt::arg("error_code", error.code())));
         return {};
     }
 
@@ -216,11 +218,12 @@ std::optional<tr_sys_file_t> tr_open_files::get(
 
         if (!success)
         {
-            tr_logAddError(fmt::format(
-                fmt::runtime(_("Couldn't preallocate '{path}': {error} ({error_code})")),
-                fmt::arg("path", filename),
-                fmt::arg("error", error.message()),
-                fmt::arg("error_code", error.code())));
+            tr_logAddError(
+                fmt::format(
+                    fmt::runtime(_("Couldn't preallocate '{path}': {error} ({error_code})")),
+                    fmt::arg("path", filename),
+                    fmt::arg("error", error.message()),
+                    fmt::arg("error_code", error.code())));
             tr_sys_file_close(fd);
             return {};
         }
@@ -235,11 +238,12 @@ std::optional<tr_sys_file_t> tr_open_files::get(
     // https://bugs.launchpad.net/ubuntu/+source/transmission/+bug/318249
     if (resize_needed && !tr_sys_file_truncate(fd, file_size, &error))
     {
-        tr_logAddWarn(fmt::format(
-            fmt::runtime(_("Couldn't truncate '{path}': {error} ({error_code})")),
-            fmt::arg("path", filename),
-            fmt::arg("error", error.message()),
-            fmt::arg("error_code", error.code())));
+        tr_logAddWarn(
+            fmt::format(
+                fmt::runtime(_("Couldn't truncate '{path}': {error} ({error_code})")),
+                fmt::arg("path", filename),
+                fmt::arg("error", error.message()),
+                fmt::arg("error_code", error.code())));
         tr_sys_file_close(fd);
         return {};
     }

--- a/libtransmission/port-forwarding-natpmp.cc
+++ b/libtransmission/port-forwarding-natpmp.cc
@@ -43,13 +43,14 @@ void log_val(char const* func, int ret)
     }
     else
     {
-        tr_logAddDebug(fmt::format(
-            "{} failed. Natpmp returned {} ({}); errno is {} ({})",
-            func,
-            ret,
-            strnatpmperr(ret),
-            errno,
-            tr_strerror(errno)));
+        tr_logAddDebug(
+            fmt::format(
+                "{} failed. Natpmp returned {} ({}); errno is {} ({})",
+                func,
+                ret,
+                strnatpmperr(ret),
+                errno,
+                tr_strerror(errno)));
     }
 }
 } // namespace

--- a/libtransmission/port-forwarding-upnp.cc
+++ b/libtransmission/port-forwarding-upnp.cc
@@ -269,9 +269,10 @@ tr_port_forwarding_state tr_upnpPulse(
 #endif
             == UPNP_IGD_VALID_CONNECTED)
         {
-            tr_logAddInfo(fmt::format(
-                fmt::runtime(_("Found Internet Gateway Device '{url}'")),
-                fmt::arg("url", handle->urls.controlURL)));
+            tr_logAddInfo(
+                fmt::format(
+                    fmt::runtime(_("Found Internet Gateway Device '{url}'")),
+                    fmt::arg("url", handle->urls.controlURL)));
             tr_logAddInfo(fmt::format(fmt::runtime(_("Local Address is '{address}'")), fmt::arg("address", lanaddr.data())));
             handle->state = UpnpState::Idle;
             handle->lanaddr = std::data(lanaddr);
@@ -296,10 +297,11 @@ tr_port_forwarding_state tr_upnpPulse(
         (get_specific_port_mapping_entry(handle, "TCP") != UPNPCOMMAND_SUCCESS ||
          get_specific_port_mapping_entry(handle, "UDP") != UPNPCOMMAND_SUCCESS))
     {
-        tr_logAddInfo(fmt::format(
-            fmt::runtime(_("Local port {local_port} is not forwarded to {advertised_port}")),
-            fmt::arg("local_port", handle->local_port.host()),
-            fmt::arg("advertised_port", handle->advertised_port.host())));
+        tr_logAddInfo(
+            fmt::format(
+                fmt::runtime(_("Local port {local_port} is not forwarded to {advertised_port}")),
+                fmt::arg("local_port", handle->local_port.host()),
+                fmt::arg("advertised_port", handle->advertised_port.host())));
         handle->isMapped = false;
     }
 
@@ -308,10 +310,11 @@ tr_port_forwarding_state tr_upnpPulse(
         tr_upnpDeletePortMapping(handle, "TCP", handle->advertised_port);
         tr_upnpDeletePortMapping(handle, "UDP", handle->advertised_port);
 
-        tr_logAddInfo(fmt::format(
-            fmt::runtime(_("Stopping port forwarding through '{url}', service '{type}'")),
-            fmt::arg("url", handle->urls.controlURL),
-            fmt::arg("type", handle->data.first.servicetype)));
+        tr_logAddInfo(
+            fmt::format(
+                fmt::runtime(_("Stopping port forwarding through '{url}', service '{type}'")),
+                fmt::arg("url", handle->urls.controlURL),
+                fmt::arg("type", handle->data.first.servicetype)));
 
         handle->isMapped = false;
         handle->state = UpnpState::Idle;
@@ -341,19 +344,21 @@ tr_port_forwarding_state tr_upnpPulse(
             handle->isMapped = err_tcp == 0 || err_udp == 0;
         }
 
-        tr_logAddDebug(fmt::format(
-            fmt::runtime(_("Port forwarding through '{url}', service '{type}'. (local address: {address}:{port})")),
-            fmt::arg("url", handle->urls.controlURL),
-            fmt::arg("type", handle->data.first.servicetype),
-            fmt::arg("address", handle->lanaddr),
-            fmt::arg("port", local_port.host())));
+        tr_logAddDebug(
+            fmt::format(
+                fmt::runtime(_("Port forwarding through '{url}', service '{type}'. (local address: {address}:{port})")),
+                fmt::arg("url", handle->urls.controlURL),
+                fmt::arg("type", handle->data.first.servicetype),
+                fmt::arg("address", handle->lanaddr),
+                fmt::arg("port", local_port.host())));
 
         if (handle->isMapped)
         {
-            tr_logAddInfo(fmt::format(
-                fmt::runtime(_("Forwarded local port {local_port} to {advertised_port}")),
-                fmt::arg("local_port", local_port.host()),
-                fmt::arg("advertised_port", advertised_port.host())));
+            tr_logAddInfo(
+                fmt::format(
+                    fmt::runtime(_("Forwarded local port {local_port} to {advertised_port}")),
+                    fmt::arg("local_port", local_port.host()),
+                    fmt::arg("advertised_port", advertised_port.host())));
             handle->advertised_port = advertised_port;
             handle->local_port = local_port;
         }

--- a/libtransmission/port-forwarding.cc
+++ b/libtransmission/port-forwarding.cc
@@ -197,10 +197,11 @@ private:
         if (!std::empty(result.local_port) && !std::empty(result.advertised_port))
         {
             mediator_.on_port_forwarded(result.advertised_port);
-            tr_logAddInfo(fmt::format(
-                fmt::runtime(_("Mapped private port {private_port} to public port {public_port}")),
-                fmt::arg("private_port", result.local_port.host()),
-                fmt::arg("public_port", result.advertised_port.host())));
+            tr_logAddInfo(
+                fmt::format(
+                    fmt::runtime(_("Mapped private port {private_port} to public port {public_port}")),
+                    fmt::arg("private_port", result.local_port.host()),
+                    fmt::arg("public_port", result.advertised_port.host())));
         }
 
         upnp_state_ = tr_upnpPulse(
@@ -213,10 +214,11 @@ private:
 
         if (auto const new_state = state(); new_state != old_state)
         {
-            tr_logAddInfo(fmt::format(
-                fmt::runtime(_("State changed from '{old_state}' to '{state}'")),
-                fmt::arg("old_state", getNatStateStr(old_state)),
-                fmt::arg("state", getNatStateStr(new_state))));
+            tr_logAddInfo(
+                fmt::format(
+                    fmt::runtime(_("State changed from '{old_state}' to '{state}'")),
+                    fmt::arg("old_state", getNatStateStr(old_state)),
+                    fmt::arg("state", getNatStateStr(new_state))));
         }
     }
 

--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -100,10 +100,11 @@ public:
 
         if (std::size(src) >= TrUnixAddrStrLen)
         {
-            tr_logAddError(fmt::format(
-                fmt::runtime(_("Unix socket path must be fewer than {count} characters (including '{prefix}' prefix)")),
-                fmt::arg("count", TrUnixAddrStrLen - 1),
-                fmt::arg("prefix", TrUnixSocketPrefix)));
+            tr_logAddError(
+                fmt::format(
+                    fmt::runtime(_("Unix socket path must be fewer than {count} characters (including '{prefix}' prefix)")),
+                    fmt::arg("count", TrUnixAddrStrLen - 1),
+                    fmt::arg("prefix", TrUnixSocketPrefix)));
             return false;
         }
         unix_socket_path_ = src;
@@ -338,9 +339,10 @@ void handle_web_client(struct evhttp_request* req, tr_rpc_server const* server)
             char* remote_host = nullptr;
             auto remote_port = ev_uint16_t{};
             evhttp_connection_get_peer(con, &remote_host, &remote_port);
-            tr_logAddWarn(fmt::format(
-                fmt::runtime(_("Rejected request from {host} (possible directory traversal attack)")),
-                fmt::arg("host", remote_host)));
+            tr_logAddWarn(
+                fmt::format(
+                    fmt::runtime(_("Rejected request from {host} (possible directory traversal attack)")),
+                    fmt::arg("host", remote_host)));
         }
         send_simple_response(req, HTTP_NOTFOUND);
     }
@@ -502,9 +504,10 @@ void handle_request(struct evhttp_request* req, void* arg)
 
     if (server->is_anti_brute_force_enabled() && server->login_attempts_ >= server->settings().anti_brute_force_limit)
     {
-        tr_logAddWarn(fmt::format(
-            fmt::runtime(_("Rejected request from {host} (brute force protection active)")),
-            fmt::arg("host", remote_host)));
+        tr_logAddWarn(
+            fmt::format(
+                fmt::runtime(_("Rejected request from {host} (brute force protection active)")),
+                fmt::arg("host", remote_host)));
         send_simple_response(req, HttpErrorForbidden);
         return;
     }
@@ -534,9 +537,10 @@ void handle_request(struct evhttp_request* req, void* arg)
 
     if (!is_authorized(server, evhttp_find_header(input_headers, "Authorization")))
     {
-        tr_logAddWarn(fmt::format(
-            fmt::runtime(_("Rejected request from {host} (failed authentication)")),
-            fmt::arg("host", remote_host)));
+        tr_logAddWarn(
+            fmt::format(
+                fmt::runtime(_("Rejected request from {host} (failed authentication)")),
+                fmt::arg("host", remote_host)));
         evhttp_add_header(output_headers, "WWW-Authenticate", "Basic realm=\"" MY_REALM "\"");
         if (server->is_anti_brute_force_enabled())
         {
@@ -608,10 +612,11 @@ void handle_request(struct evhttp_request* req, void* arg)
     }
     else
     {
-        tr_logAddWarn(fmt::format(
-            fmt::runtime(_("Unknown URI from {host}: '{uri}'")),
-            fmt::arg("host", remote_host),
-            fmt::arg("uri", uri_sv)));
+        tr_logAddWarn(
+            fmt::format(
+                fmt::runtime(_("Unknown URI from {host}: '{uri}'")),
+                fmt::arg("host", remote_host),
+                fmt::arg("uri", uri_sv)));
         send_simple_response(req, HTTP_NOTFOUND, uri);
     }
 }
@@ -627,9 +632,10 @@ bool bindUnixSocket(
     [[maybe_unused]] tr_mode_t socket_mode)
 {
 #ifdef _WIN32
-    tr_logAddError(fmt::format(
-        _("Unix sockets are unsupported on Windows. Please change '{key}' in your settings."),
-        fmt::arg("key", tr_quark_get_string_view(TR_KEY_rpc_bind_address))));
+    tr_logAddError(
+        fmt::format(
+            _("Unix sockets are unsupported on Windows. Please change '{key}' in your settings."),
+            fmt::arg("key", tr_quark_get_string_view(TR_KEY_rpc_bind_address))));
     return false;
 #else
     auto addr = sockaddr_un{};
@@ -654,9 +660,10 @@ bool bindUnixSocket(
 
     if (chmod(addr.sun_path, socket_mode) != 0)
     {
-        tr_logAddWarn(fmt::format(
-            fmt::runtime(_("Couldn't set RPC socket mode to {mode:#o}, defaulting to 0755")),
-            fmt::arg("mode", socket_mode)));
+        tr_logAddWarn(
+            fmt::format(
+                fmt::runtime(_("Couldn't set RPC socket mode to {mode:#o}, defaulting to 0755")),
+                fmt::arg("mode", socket_mode)));
     }
 
     return evhttp_bind_listener(httpd, lev) != nullptr;
@@ -717,22 +724,24 @@ void start_server(tr_rpc_server* server)
             return;
         }
 
-        tr_logAddError(fmt::format(
-            fmt::runtime(tr_ngettext(
-                "Couldn't bind to {address} after {count} attempt, giving up",
-                "Couldn't bind to {address} after {count} attempts, giving up",
-                ServerStartRetryCount)),
-            fmt::arg("address", addr_port_str),
-            fmt::arg("count", ServerStartRetryCount)));
+        tr_logAddError(
+            fmt::format(
+                fmt::runtime(tr_ngettext(
+                    "Couldn't bind to {address} after {count} attempt, giving up",
+                    "Couldn't bind to {address} after {count} attempts, giving up",
+                    ServerStartRetryCount)),
+                fmt::arg("address", addr_port_str),
+                fmt::arg("count", ServerStartRetryCount)));
     }
     else
     {
         evhttp_set_gencb(httpd, handle_request, server);
         server->httpd.reset(httpd);
 
-        tr_logAddInfo(fmt::format(
-            fmt::runtime(_("Listening for RPC and Web requests on '{address}'")),
-            fmt::arg("address", addr_port_str)));
+        tr_logAddInfo(
+            fmt::format(
+                fmt::runtime(_("Listening for RPC and Web requests on '{address}'")),
+                fmt::arg("address", addr_port_str)));
     }
 
     rpc_server_start_retry_cancel(server);
@@ -759,9 +768,10 @@ void stop_server(tr_rpc_server* server)
         unlink(address.c_str() + std::size(TrUnixSocketPrefix));
     }
 
-    tr_logAddInfo(fmt::format(
-        fmt::runtime(_("Stopped listening for RPC and Web requests on '{address}'")),
-        fmt::arg("address", server->bind_address_->to_string(server->port()))));
+    tr_logAddInfo(
+        fmt::format(
+            fmt::runtime(_("Stopped listening for RPC and Web requests on '{address}'")),
+            fmt::arg("address", server->bind_address_->to_string(server->port()))));
 }
 
 void restart_server(tr_rpc_server* const server)
@@ -901,11 +911,12 @@ void tr_rpc_server::load(Settings&& settings)
     if (!bind_address_->from_string(settings_.bind_address_str))
     {
         // NOTE: bind_address_ is default initialized to INADDR_ANY
-        tr_logAddWarn(fmt::format(
-            fmt::runtime(_(
-                "The '{key}' setting is '{value}' but must be an IPv4 or IPv6 address or a Unix socket path. Using default value '0.0.0.0'")),
-            fmt::arg("key", tr_quark_get_string_view(TR_KEY_rpc_bind_address)),
-            fmt::arg("value", settings_.bind_address_str)));
+        tr_logAddWarn(
+            fmt::format(
+                fmt::runtime(_(
+                    "The '{key}' setting is '{value}' but must be an IPv4 or IPv6 address or a Unix socket path. Using default value '0.0.0.0'")),
+                fmt::arg("key", tr_quark_get_string_view(TR_KEY_rpc_bind_address)),
+                fmt::arg("value", settings_.bind_address_str)));
     }
 
     if (bind_address_->is_unix_addr())

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -1321,11 +1321,12 @@ void onMetadataFetched(tr_web::FetchResponse const& web_response)
     auto const& [status, body, primary_ip, did_connect, did_timeout, user_data] = web_response;
     auto* data = static_cast<struct add_torrent_idle_data*>(user_data);
 
-    tr_logAddTrace(fmt::format(
-        "torrentAdd: HTTP response code was {} ({}); response length was {} bytes",
-        status,
-        tr_webGetResponseStr(status),
-        std::size(body)));
+    tr_logAddTrace(
+        fmt::format(
+            "torrentAdd: HTTP response code was {} ({}); response length was {} bytes",
+            status,
+            tr_webGetResponseStr(status),
+            std::size(body)));
 
     if (status == 200 || status == 221) /* http or ftp success.. */
     {

--- a/libtransmission/session-id.cc
+++ b/libtransmission/session-id.cc
@@ -64,11 +64,12 @@ tr_sys_file_t create_lockfile(std::string_view session_id)
 
     if (error)
     {
-        tr_logAddWarn(fmt::format(
-            fmt::runtime(_("Couldn't create '{path}': {error} ({error_code})")),
-            fmt::arg("path", lockfile_path),
-            fmt::arg("error", error.message()),
-            fmt::arg("error_code", error.code())));
+        tr_logAddWarn(
+            fmt::format(
+                fmt::runtime(_("Couldn't create '{path}': {error} ({error_code})")),
+                fmt::arg("path", lockfile_path),
+                fmt::arg("error", error.message()),
+                fmt::arg("error_code", error.code())));
     }
 
     return lockfile_fd;
@@ -146,11 +147,12 @@ bool tr_session_id::is_local(std::string_view session_id) noexcept
 
     if (error)
     {
-        tr_logAddWarn(fmt::format(
-            fmt::runtime(_("Couldn't open session lock file '{path}': {error} ({error_code})")),
-            fmt::arg("path", lockfile_path),
-            fmt::arg("error", error.message()),
-            fmt::arg("error_code", error.code())));
+        tr_logAddWarn(
+            fmt::format(
+                fmt::runtime(_("Couldn't open session lock file '{path}': {error} ({error_code})")),
+                fmt::arg("path", lockfile_path),
+                fmt::arg("error", error.message()),
+                fmt::arg("error_code", error.code())));
     }
 
     return is_local;

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -416,9 +416,10 @@ tr_session::BoundSocket::BoundSocket(
         return;
     }
 
-    tr_logAddInfo(fmt::format(
-        fmt::runtime(_("Listening to incoming peer connections on {hostport}")),
-        fmt::arg("hostport", tr_socket_address::display_name(addr, port))));
+    tr_logAddInfo(
+        fmt::format(
+            fmt::runtime(_("Listening to incoming peer connections on {hostport}")),
+            fmt::arg("hostport", tr_socket_address::display_name(addr, port))));
     event_add(ev_.get(), nullptr);
 }
 
@@ -1497,9 +1498,10 @@ void session_load_torrents(tr_session* session, tr_ctor* ctor, std::promise<size
 
     if (n_torrents != 0U)
     {
-        tr_logAddInfo(fmt::format(
-            fmt::runtime(tr_ngettext("Loaded {count} torrent", "Loaded {count} torrents", n_torrents)),
-            fmt::arg("count", n_torrents)));
+        tr_logAddInfo(
+            fmt::format(
+                fmt::runtime(tr_ngettext("Loaded {count} torrent", "Loaded {count} torrents", n_torrents)),
+                fmt::arg("count", n_torrents)));
     }
 
     loaded_promise->set_value(n_torrents);

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -133,12 +133,13 @@ bool tr_torrentSetMetainfoFromFile(tr_torrent* tor, tr_torrent_metainfo const* m
     tor->use_metainfo_from_file(metainfo, filename, &error);
     if (error)
     {
-        tor->error().set_local_error(fmt::format(
-            fmt::runtime(_("Couldn't use metainfo from '{path}' for '{magnet}': {error} ({error_code})")),
-            fmt::arg("path", filename),
-            fmt::arg("magnet", tor->magnet()),
-            fmt::arg("error", error.message()),
-            fmt::arg("error_code", error.code())));
+        tor->error().set_local_error(
+            fmt::format(
+                fmt::runtime(_("Couldn't use metainfo from '{path}' for '{magnet}': {error} ({error_code})")),
+                fmt::arg("path", filename),
+                fmt::arg("magnet", tor->magnet()),
+                fmt::arg("error", error.message()),
+                fmt::arg("error_code", error.code())));
         return false;
     }
 
@@ -716,10 +717,11 @@ void tr_torrentRemoveInSessionThread(
             ok = false;
             tor->is_deleting_ = false;
 
-            tor->error().set_local_error(fmt::format(
-                fmt::runtime(_("Couldn't remove all torrent files: {error} ({error_code})")),
-                fmt::arg("error", error.message()),
-                fmt::arg("error_code", error.code())));
+            tor->error().set_local_error(
+                fmt::format(
+                    fmt::runtime(_("Couldn't remove all torrent files: {error} ({error_code})")),
+                    fmt::arg("error", error.message()),
+                    fmt::arg("error_code", error.code())));
             tr_torrentStop(tor);
         }
     }
@@ -1001,11 +1003,12 @@ void tr_torrent::init(tr_ctor const& ctor)
 
         if (error)
         {
-            this->error().set_local_error(fmt::format(
-                fmt::runtime(_("Couldn't save '{path}': {error} ({error_code})")),
-                fmt::arg("path", file_path),
-                fmt::arg("error", error.message()),
-                fmt::arg("error_code", error.code())));
+            this->error().set_local_error(
+                fmt::format(
+                    fmt::runtime(_("Couldn't save '{path}': {error} ({error_code})")),
+                    fmt::arg("path", file_path),
+                    fmt::arg("error", error.message()),
+                    fmt::arg("error_code", error.code())));
         }
     }
 
@@ -1099,12 +1102,13 @@ void tr_torrent::set_location_in_session_thread(std::string_view const path, boo
         ok = files().move(current_dir(), path, name(), &error);
         if (error)
         {
-            this->error().set_local_error(fmt::format(
-                fmt::runtime(_("Couldn't move '{old_path}' to '{path}': {error} ({error_code})")),
-                fmt::arg("old_path", current_dir()),
-                fmt::arg("path", path),
-                fmt::arg("error", error.message()),
-                fmt::arg("error_code", error.code())));
+            this->error().set_local_error(
+                fmt::format(
+                    fmt::runtime(_("Couldn't move '{old_path}' to '{path}': {error} ({error_code})")),
+                    fmt::arg("old_path", current_dir()),
+                    fmt::arg("path", path),
+                    fmt::arg("error", error.message()),
+                    fmt::arg("error_code", error.code())));
             tr_torrentStop(this);
         }
     }
@@ -1990,11 +1994,12 @@ bool tr_torrent::set_announce_list(tr_announce_list announce_list)
 
     if (save_error.has_value())
     {
-        error().set_local_error(fmt::format(
-            fmt::runtime(_("Couldn't save '{path}': {error} ({error_code})")),
-            fmt::arg("path", filename),
-            fmt::arg("error", save_error.message()),
-            fmt::arg("error_code", save_error.code())));
+        error().set_local_error(
+            fmt::format(
+                fmt::runtime(_("Couldn't save '{path}': {error} ({error_code})")),
+                fmt::arg("path", filename),
+                fmt::arg("error", save_error.message()),
+                fmt::arg("error_code", save_error.code())));
         return false;
     }
 

--- a/libtransmission/tr-dht.cc
+++ b/libtransmission/tr-dht.cc
@@ -549,10 +549,11 @@ private:
 
             if (line_stream.bad() || std::empty(addrstr))
             {
-                tr_logAddWarn(fmt::format(
-                    fmt::runtime(_("Couldn't parse '{filename}' line: '{line}'")),
-                    fmt::arg("filename", filename),
-                    fmt::arg("line", line)));
+                tr_logAddWarn(
+                    fmt::format(
+                        fmt::runtime(_("Couldn't parse '{filename}' line: '{line}'")),
+                        fmt::arg("filename", filename),
+                        fmt::arg("line", line)));
             }
             else
             {
@@ -573,12 +574,13 @@ private:
         addrinfo* info = nullptr;
         if (int const rc = getaddrinfo(name, port_str.c_str(), &hints, &info); rc != 0)
         {
-            tr_logAddWarn(fmt::format(
-                fmt::runtime(_("Couldn't look up '{address}:{port}': {error} ({error_code})")),
-                fmt::arg("address", name),
-                fmt::arg("port", port_in.host()),
-                fmt::arg("error", gai_strerror(rc)),
-                fmt::arg("error_code", rc)));
+            tr_logAddWarn(
+                fmt::format(
+                    fmt::runtime(_("Couldn't look up '{address}:{port}': {error} ({error_code})")),
+                    fmt::arg("address", name),
+                    fmt::arg("port", port_in.host()),
+                    fmt::arg("error", gai_strerror(rc)),
+                    fmt::arg("error_code", rc)));
             return;
         }
 

--- a/libtransmission/tr-lpd.cc
+++ b/libtransmission/tr-lpd.cc
@@ -266,11 +266,12 @@ private:
             auto const err = sockerrno;
             tr_net_close_socket(mcast_sockets_[TR_AF_INET]);
             mcast_sockets_[TR_AF_INET] = TR_BAD_SOCKET;
-            tr_logAddWarn(fmt::format(
-                fmt::runtime(_("Couldn't initialize {ip_protocol} LPD: {error} ({error_code})")),
-                fmt::arg("ip_protocol", tr_ip_protocol_to_sv(TR_AF_INET)),
-                fmt::arg("error", tr_strerror(err)),
-                fmt::arg("error_code", err)));
+            tr_logAddWarn(
+                fmt::format(
+                    fmt::runtime(_("Couldn't initialize {ip_protocol} LPD: {error} ({error_code})")),
+                    fmt::arg("ip_protocol", tr_ip_protocol_to_sv(TR_AF_INET)),
+                    fmt::arg("error", tr_strerror(err)),
+                    fmt::arg("error_code", err)));
             --n_success;
         }
 
@@ -279,11 +280,12 @@ private:
             auto const err = sockerrno;
             tr_net_close_socket(mcast_sockets_[TR_AF_INET6]);
             mcast_sockets_[TR_AF_INET6] = TR_BAD_SOCKET;
-            tr_logAddWarn(fmt::format(
-                fmt::runtime(_("Couldn't initialize {ip_protocol} LPD: {error} ({error_code})")),
-                fmt::arg("ip_protocol", tr_ip_protocol_to_sv(TR_AF_INET6)),
-                fmt::arg("error", tr_strerror(err)),
-                fmt::arg("error_code", err)));
+            tr_logAddWarn(
+                fmt::format(
+                    fmt::runtime(_("Couldn't initialize {ip_protocol} LPD: {error} ({error_code})")),
+                    fmt::arg("ip_protocol", tr_ip_protocol_to_sv(TR_AF_INET6)),
+                    fmt::arg("error", tr_strerror(err)),
+                    fmt::arg("error_code", err)));
             --n_success;
         }
 
@@ -604,10 +606,11 @@ private:
     {
         if (messages_received_since_upkeep_ > MaxIncomingPerUpkeep)
         {
-            tr_logAddTrace(fmt::format(
-                "Dropped {} announces in the last interval (max. {} allowed)",
-                messages_received_since_upkeep_ - MaxIncomingPerUpkeep,
-                MaxIncomingPerUpkeep));
+            tr_logAddTrace(
+                fmt::format(
+                    "Dropped {} announces in the last interval (max. {} allowed)",
+                    messages_received_since_upkeep_ - MaxIncomingPerUpkeep,
+                    MaxIncomingPerUpkeep));
         }
 
         messages_received_since_upkeep_ = 0;

--- a/libtransmission/tr-udp.cc
+++ b/libtransmission/tr-udp.cc
@@ -144,11 +144,12 @@ void event_callback(evutil_socket_t s, [[maybe_unused]] short type, void* vsessi
             }
             else
             {
-                tr_logAddTrace(fmt::format(
-                    "{} Unexpected UDP packet... len {} [{}]",
-                    from_str(),
-                    n_read,
-                    tr_base64_encode({ reinterpret_cast<char const*>(std::data(buf)), static_cast<size_t>(n_read) })));
+                tr_logAddTrace(
+                    fmt::format(
+                        "{} Unexpected UDP packet... len {} [{}]",
+                        from_str(),
+                        n_read,
+                        tr_base64_encode({ reinterpret_cast<char const*>(std::data(buf)), static_cast<size_t>(n_read) })));
             }
         }
     }
@@ -176,22 +177,24 @@ tr_session::tr_udp_core::tr_udp_core(tr_session& session, tr_port udp_port)
         if (evutil_make_socket_nonblocking(sock) != 0)
         {
             auto const error_code = errno;
-            tr_logAddWarn(fmt::format(
-                fmt::runtime(_("Couldn't make IPv4 socket non-blocking {address}: {error} ({error_code})")),
-                fmt::arg("address", tr_socket_address::display_name(addr, udp_port_)),
-                fmt::arg("error", tr_strerror(error_code)),
-                fmt::arg("error_code", error_code)));
+            tr_logAddWarn(
+                fmt::format(
+                    fmt::runtime(_("Couldn't make IPv4 socket non-blocking {address}: {error} ({error_code})")),
+                    fmt::arg("address", tr_socket_address::display_name(addr, udp_port_)),
+                    fmt::arg("error", tr_strerror(error_code)),
+                    fmt::arg("error_code", error_code)));
 
             tr_net_close_socket(sock);
         }
         else if (bind(sock, reinterpret_cast<sockaddr const*>(&ss), sslen) != 0)
         {
             auto const error_code = errno;
-            tr_logAddWarn(fmt::format(
-                fmt::runtime(_("Couldn't bind IPv4 socket {address}: {error} ({error_code})")),
-                fmt::arg("address", tr_socket_address::display_name(addr, udp_port_)),
-                fmt::arg("error", tr_strerror(error_code)),
-                fmt::arg("error_code", error_code)));
+            tr_logAddWarn(
+                fmt::format(
+                    fmt::runtime(_("Couldn't bind IPv4 socket {address}: {error} ({error_code})")),
+                    fmt::arg("address", tr_socket_address::display_name(addr, udp_port_)),
+                    fmt::arg("error", tr_strerror(error_code)),
+                    fmt::arg("error_code", error_code)));
 
             tr_net_close_socket(sock);
         }
@@ -221,22 +224,24 @@ tr_session::tr_udp_core::tr_udp_core(tr_session& session, tr_port udp_port)
         if (evutil_make_socket_nonblocking(sock) != 0)
         {
             auto const error_code = errno;
-            tr_logAddWarn(fmt::format(
-                fmt::runtime(_("Couldn't make IPv6 socket non-blocking {address}: {error} ({error_code})")),
-                fmt::arg("address", tr_socket_address::display_name(addr, udp_port_)),
-                fmt::arg("error", tr_strerror(error_code)),
-                fmt::arg("error_code", error_code)));
+            tr_logAddWarn(
+                fmt::format(
+                    fmt::runtime(_("Couldn't make IPv6 socket non-blocking {address}: {error} ({error_code})")),
+                    fmt::arg("address", tr_socket_address::display_name(addr, udp_port_)),
+                    fmt::arg("error", tr_strerror(error_code)),
+                    fmt::arg("error_code", error_code)));
 
             tr_net_close_socket(sock);
         }
         else if (bind(sock, reinterpret_cast<sockaddr const*>(&ss), sslen) != 0)
         {
             auto const error_code = errno;
-            tr_logAddWarn(fmt::format(
-                fmt::runtime(_("Couldn't bind IPv6 socket {address}: {error} ({error_code})")),
-                fmt::arg("address", tr_socket_address::display_name(addr, udp_port_)),
-                fmt::arg("error", tr_strerror(error_code)),
-                fmt::arg("error_code", error_code)));
+            tr_logAddWarn(
+                fmt::format(
+                    fmt::runtime(_("Couldn't bind IPv6 socket {address}: {error} ({error_code})")),
+                    fmt::arg("address", tr_socket_address::display_name(addr, udp_port_)),
+                    fmt::arg("error", tr_strerror(error_code)),
+                    fmt::arg("error_code", error_code)));
 
             tr_net_close_socket(sock);
         }
@@ -301,9 +306,10 @@ void tr_session::tr_udp_core::sendto(void const* buf, size_t buflen, struct sock
         display_name = addrport->display_name();
     }
 
-    tr_logAddWarn(fmt::format(
-        "Couldn't send to {address}: {errno} ({error})",
-        fmt::arg("address", display_name),
-        fmt::arg("errno", errno),
-        fmt::arg("error", tr_strerror(errno))));
+    tr_logAddWarn(
+        fmt::format(
+            "Couldn't send to {address}: {errno} ({error})",
+            fmt::arg("address", display_name),
+            fmt::arg("errno", errno),
+            fmt::arg("error", tr_strerror(errno))));
 }

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -134,11 +134,12 @@ bool tr_file_read(std::string_view filename, std::vector<char>& contents, tr_err
     auto const info = tr_sys_path_get_info(szfilename, 0, error);
     if (*error)
     {
-        tr_logAddError(fmt::format(
-            fmt::runtime(_("Couldn't read '{path}': {error} ({error_code})")),
-            fmt::arg("path", filename),
-            fmt::arg("error", error->message()),
-            fmt::arg("error_code", error->code())));
+        tr_logAddError(
+            fmt::format(
+                fmt::runtime(_("Couldn't read '{path}': {error} ({error_code})")),
+                fmt::arg("path", filename),
+                fmt::arg("error", error->message()),
+                fmt::arg("error_code", error->code())));
         return false;
     }
 
@@ -153,22 +154,24 @@ bool tr_file_read(std::string_view filename, std::vector<char>& contents, tr_err
     auto const fd = tr_sys_file_open(szfilename, TR_SYS_FILE_READ | TR_SYS_FILE_SEQUENTIAL, 0, error);
     if (fd == TR_BAD_SYS_FILE)
     {
-        tr_logAddError(fmt::format(
-            fmt::runtime(_("Couldn't read '{path}': {error} ({error_code})")),
-            fmt::arg("path", filename),
-            fmt::arg("error", error->message()),
-            fmt::arg("error_code", error->code())));
+        tr_logAddError(
+            fmt::format(
+                fmt::runtime(_("Couldn't read '{path}': {error} ({error_code})")),
+                fmt::arg("path", filename),
+                fmt::arg("error", error->message()),
+                fmt::arg("error_code", error->code())));
         return false;
     }
 
     contents.resize(info->size);
     if (!tr_sys_file_read(fd, std::data(contents), info->size, nullptr, error))
     {
-        tr_logAddError(fmt::format(
-            fmt::runtime(_("Couldn't read '{path}': {error} ({error_code})")),
-            fmt::arg("path", filename),
-            fmt::arg("error", error->message()),
-            fmt::arg("error_code", error->code())));
+        tr_logAddError(
+            fmt::format(
+                fmt::runtime(_("Couldn't read '{path}': {error} ({error_code})")),
+                fmt::arg("path", filename),
+                fmt::arg("error", error->message()),
+                fmt::arg("error_code", error->code())));
         tr_sys_file_close(fd);
         return false;
     }
@@ -632,11 +635,12 @@ bool tr_file_move(std::string_view oldpath_in, std::string_view newpath_in, bool
 
     if (auto log_error = tr_error{}; !tr_sys_path_remove(oldpath, &log_error))
     {
-        tr_logAddError(fmt::format(
-            fmt::runtime(_("Couldn't remove '{path}': {error} ({error_code})")),
-            fmt::arg("path", oldpath),
-            fmt::arg("error", log_error.message()),
-            fmt::arg("error_code", log_error.code())));
+        tr_logAddError(
+            fmt::format(
+                fmt::runtime(_("Couldn't remove '{path}': {error} ({error_code})")),
+                fmt::arg("path", oldpath),
+                fmt::arg("error", log_error.message()),
+                fmt::arg("error_code", log_error.code())));
     }
 
     return true;

--- a/libtransmission/variant.cc
+++ b/libtransmission/variant.cc
@@ -872,11 +872,12 @@ bool tr_variant_serde::to_file(tr_variant const& var, std::string_view filename)
 
     if (error_)
     {
-        tr_logAddError(fmt::format(
-            fmt::runtime(_("Couldn't save '{path}': {error} ({error_code})")),
-            fmt::arg("path", filename),
-            fmt::arg("error", error_.message()),
-            fmt::arg("error_code", error_.code())));
+        tr_logAddError(
+            fmt::format(
+                fmt::runtime(_("Couldn't save '{path}': {error} ({error_code})")),
+                fmt::arg("path", filename),
+                fmt::arg("error", error_.message()),
+                fmt::arg("error_code", error_.code())));
         return false;
     }
 

--- a/libtransmission/watchdir-inotify.cc
+++ b/libtransmission/watchdir-inotify.cc
@@ -82,11 +82,12 @@ private:
         if (infd_ == -1)
         {
             auto const error_code = errno;
-            tr_logAddError(fmt::format(
-                fmt::runtime(_("Couldn't watch '{path}': {error} ({error_code})")),
-                fmt::arg("path", dirname()),
-                fmt::arg("error", tr_strerror(error_code)),
-                fmt::arg("error_code", error_code)));
+            tr_logAddError(
+                fmt::format(
+                    fmt::runtime(_("Couldn't watch '{path}': {error} ({error_code})")),
+                    fmt::arg("path", dirname()),
+                    fmt::arg("error", tr_strerror(error_code)),
+                    fmt::arg("error_code", error_code)));
             return;
         }
 
@@ -94,11 +95,12 @@ private:
         if (inwd_ == -1)
         {
             auto const error_code = errno;
-            tr_logAddError(fmt::format(
-                fmt::runtime(_("Couldn't watch '{path}': {error} ({error_code})")),
-                fmt::arg("path", dirname()),
-                fmt::arg("error", tr_strerror(error_code)),
-                fmt::arg("error_code", error_code)));
+            tr_logAddError(
+                fmt::format(
+                    fmt::runtime(_("Couldn't watch '{path}': {error} ({error_code})")),
+                    fmt::arg("path", dirname()),
+                    fmt::arg("error", tr_strerror(error_code)),
+                    fmt::arg("error_code", error_code)));
             return;
         }
 
@@ -106,11 +108,12 @@ private:
         if (event_ == nullptr)
         {
             auto const error_code = errno;
-            tr_logAddError(fmt::format(
-                fmt::runtime(_("Couldn't watch '{path}': {error} ({error_code})")),
-                fmt::arg("path", dirname()),
-                fmt::arg("error", tr_strerror(error_code)),
-                fmt::arg("error_code", error_code)));
+            tr_logAddError(
+                fmt::format(
+                    fmt::runtime(_("Couldn't watch '{path}': {error} ({error_code})")),
+                    fmt::arg("path", dirname()),
+                    fmt::arg("error", tr_strerror(error_code)),
+                    fmt::arg("error_code", error_code)));
             return;
         }
 
@@ -138,19 +141,21 @@ private:
             if (nread == (size_t)-1)
             {
                 auto const error_code = errno;
-                tr_logAddError(fmt::format(
-                    fmt::runtime(_("Couldn't read event: {error} ({error_code})")),
-                    fmt::arg("error", tr_strerror(error_code)),
-                    fmt::arg("error_code", error_code)));
+                tr_logAddError(
+                    fmt::format(
+                        fmt::runtime(_("Couldn't read event: {error} ({error_code})")),
+                        fmt::arg("error", tr_strerror(error_code)),
+                        fmt::arg("error_code", error_code)));
                 break;
             }
 
             if (nread != sizeof(ev))
             {
-                tr_logAddError(fmt::format(
-                    fmt::runtime(_("Couldn't read event: expected {expected_size}, got {actual_size}")),
-                    fmt::arg("expected_size", sizeof(ev)),
-                    fmt::arg("actual_size", nread)));
+                tr_logAddError(
+                    fmt::format(
+                        fmt::runtime(_("Couldn't read event: expected {expected_size}, got {actual_size}")),
+                        fmt::arg("expected_size", sizeof(ev)),
+                        fmt::arg("actual_size", nread)));
                 break;
             }
 
@@ -164,19 +169,21 @@ private:
             if (nread == static_cast<size_t>(-1))
             {
                 auto const error_code = errno;
-                tr_logAddError(fmt::format(
-                    fmt::runtime(_("Couldn't read filename: {error} ({error_code})")),
-                    fmt::arg("error", tr_strerror(error_code)),
-                    fmt::arg("error_code", error_code)));
+                tr_logAddError(
+                    fmt::format(
+                        fmt::runtime(_("Couldn't read filename: {error} ({error_code})")),
+                        fmt::arg("error", tr_strerror(error_code)),
+                        fmt::arg("error_code", error_code)));
                 break;
             }
 
             if (nread != ev.len)
             {
-                tr_logAddError(fmt::format(
-                    fmt::runtime(_("Couldn't read filename: expected {expected_size}, got {actual_size}")),
-                    fmt::arg("expected_size", sizeof(ev)),
-                    fmt::arg("actual_size", nread)));
+                tr_logAddError(
+                    fmt::format(
+                        fmt::runtime(_("Couldn't read filename: expected {expected_size}, got {actual_size}")),
+                        fmt::arg("expected_size", sizeof(ev)),
+                        fmt::arg("actual_size", nread)));
                 break;
             }
 

--- a/libtransmission/watchdir-kqueue.cc
+++ b/libtransmission/watchdir-kqueue.cc
@@ -71,10 +71,11 @@ private:
         if (kq_ == -1)
         {
             auto const error_code = errno;
-            tr_logAddError(fmt::format(
-                fmt::runtime(_("Couldn't watch '{path}': {error} ({error_code})")),
-                fmt::arg("error", tr_strerror(error_code)),
-                fmt::arg("error_code", error_code)));
+            tr_logAddError(
+                fmt::format(
+                    fmt::runtime(_("Couldn't watch '{path}': {error} ({error_code})")),
+                    fmt::arg("error", tr_strerror(error_code)),
+                    fmt::arg("error_code", error_code)));
             return;
         }
 
@@ -84,11 +85,12 @@ private:
         if (dirfd_ == -1)
         {
             auto const error_code = errno;
-            tr_logAddError(fmt::format(
-                fmt::runtime(_("Couldn't watch '{path}': {error} ({error_code})")),
-                fmt::arg("path", dirname()),
-                fmt::arg("error", tr_strerror(error_code)),
-                fmt::arg("error_code", error_code)));
+            tr_logAddError(
+                fmt::format(
+                    fmt::runtime(_("Couldn't watch '{path}': {error} ({error_code})")),
+                    fmt::arg("path", dirname()),
+                    fmt::arg("error", tr_strerror(error_code)),
+                    fmt::arg("error_code", error_code)));
             return;
         }
 
@@ -99,11 +101,12 @@ private:
         if (kevent(kq_, &ke, 1, nullptr, 0, nullptr) == -1)
         {
             auto const error_code = errno;
-            tr_logAddError(fmt::format(
-                fmt::runtime(_("Couldn't watch '{path}': {error} ({error_code})")),
-                fmt::arg("path", dirname()),
-                fmt::arg("error", tr_strerror(error_code)),
-                fmt::arg("error_code", error_code)));
+            tr_logAddError(
+                fmt::format(
+                    fmt::runtime(_("Couldn't watch '{path}': {error} ({error_code})")),
+                    fmt::arg("path", dirname()),
+                    fmt::arg("error", tr_strerror(error_code)),
+                    fmt::arg("error_code", error_code)));
             return;
         }
 
@@ -112,20 +115,22 @@ private:
         if (!event_)
         {
             auto const error_code = errno;
-            tr_logAddError(fmt::format(
-                fmt::runtime(_("Couldn't create event: {error} ({error_code})")),
-                fmt::arg("error", tr_strerror(error_code)),
-                fmt::arg("error_code", error_code)));
+            tr_logAddError(
+                fmt::format(
+                    fmt::runtime(_("Couldn't create event: {error} ({error_code})")),
+                    fmt::arg("error", tr_strerror(error_code)),
+                    fmt::arg("error_code", error_code)));
             return;
         }
 
         if (event_add(event_.get(), nullptr) == -1)
         {
             auto const error_code = errno;
-            tr_logAddError(fmt::format(
-                fmt::runtime(_("Couldn't add event: {error} ({error_code})")),
-                fmt::arg("error", tr_strerror(error_code)),
-                fmt::arg("error_code", error_code)));
+            tr_logAddError(
+                fmt::format(
+                    fmt::runtime(_("Couldn't add event: {error} ({error_code})")),
+                    fmt::arg("error", tr_strerror(error_code)),
+                    fmt::arg("error_code", error_code)));
             return;
         }
     }
@@ -142,10 +147,11 @@ private:
         if (kevent(kq_, nullptr, 0, &ke, 1, &ts) == -1)
         {
             auto const error_code = errno;
-            tr_logAddError(fmt::format(
-                fmt::runtime(_("Couldn't read event: {error} ({error_code})")),
-                fmt::arg("error", tr_strerror(error_code)),
-                fmt::arg("error_code", error_code)));
+            tr_logAddError(
+                fmt::format(
+                    fmt::runtime(_("Couldn't read event: {error} ({error_code})")),
+                    fmt::arg("error", tr_strerror(error_code)),
+                    fmt::arg("error_code", error_code)));
             return;
         }
 

--- a/libtransmission/watchdir-win32.cc
+++ b/libtransmission/watchdir-win32.cc
@@ -180,10 +180,11 @@ private:
         if (evutil_socketpair(AF_INET, SOCK_STREAM, 0, std::data(notify_pipe_)) == -1)
         {
             auto const error_code = errno;
-            tr_logAddError(fmt::format(
-                _("Couldn't create pipe: {error} ({error_code})"),
-                fmt::arg("error", tr_strerror(error_code)),
-                fmt::arg("error_code", error_code)));
+            tr_logAddError(
+                fmt::format(
+                    _("Couldn't create pipe: {error} ({error_code})"),
+                    fmt::arg("error", tr_strerror(error_code)),
+                    fmt::arg("error_code", error_code)));
             return;
         }
 
@@ -191,10 +192,11 @@ private:
         if (event_ == nullptr)
         {
             auto const error_code = errno;
-            tr_logAddError(fmt::format(
-                _("Couldn't create event: {error} ({error_code})"),
-                fmt::arg("error", tr_strerror(error_code)),
-                fmt::arg("error_code", error_code)));
+            tr_logAddError(
+                fmt::format(
+                    _("Couldn't create event: {error} ({error_code})"),
+                    fmt::arg("error", tr_strerror(error_code)),
+                    fmt::arg("error_code", error_code)));
             return;
         }
 
@@ -290,19 +292,21 @@ private:
             if (nread == static_cast<size_t>(-1))
             {
                 auto const error_code = errno;
-                tr_logAddError(fmt::format(
-                    _("Couldn't read event: {error} ({error_code})"),
-                    fmt::arg("error", tr_strerror(error_code)),
-                    fmt::arg("error_code", error_code)));
+                tr_logAddError(
+                    fmt::format(
+                        _("Couldn't read event: {error} ({error_code})"),
+                        fmt::arg("error", tr_strerror(error_code)),
+                        fmt::arg("error_code", error_code)));
                 break;
             }
 
             if (nread != header_size)
             {
-                tr_logAddError(fmt::format(
-                    _("Couldn't read event: expected {expected_size}, got {actual_size}"),
-                    fmt::arg("expected_size", header_size),
-                    fmt::arg("actual_size", nread)));
+                tr_logAddError(
+                    fmt::format(
+                        _("Couldn't read event: expected {expected_size}, got {actual_size}"),
+                        fmt::arg("expected_size", header_size),
+                        fmt::arg("actual_size", nread)));
                 break;
             }
 
@@ -324,19 +328,21 @@ private:
             if (nread == static_cast<size_t>(-1))
             {
                 auto const error_code = errno;
-                tr_logAddError(fmt::format(
-                    _("Couldn't read filename: {error} ({error_code})"),
-                    fmt::arg("error", tr_strerror(error_code)),
-                    fmt::arg("error_code", error_code)));
+                tr_logAddError(
+                    fmt::format(
+                        _("Couldn't read filename: {error} ({error_code})"),
+                        fmt::arg("error", tr_strerror(error_code)),
+                        fmt::arg("error_code", error_code)));
                 break;
             }
 
             if (nread != nleft)
             {
-                tr_logAddError(fmt::format(
-                    _("Couldn't read filename: expected {expected_size}, got {actual_size}"),
-                    fmt::arg("expected_size", nleft),
-                    fmt::arg("actual_size", nread)));
+                tr_logAddError(
+                    fmt::format(
+                        _("Couldn't read filename: expected {expected_size}, got {actual_size}"),
+                        fmt::arg("expected_size", nleft),
+                        fmt::arg("actual_size", nread)));
                 break;
             }
 

--- a/libtransmission/watchdir.cc
+++ b/libtransmission/watchdir.cc
@@ -48,11 +48,12 @@ namespace
     auto const info = tr_sys_path_get_info(path, 0, &error);
     if (error && !tr_error_is_enoent(error.code()))
     {
-        tr_logAddWarn(fmt::format(
-            fmt::runtime(_("Skipping '{path}': {error} ({error_code})")),
-            fmt::arg("path", path),
-            fmt::arg("error", error.message()),
-            fmt::arg("error_code", error.code())));
+        tr_logAddWarn(
+            fmt::format(
+                fmt::runtime(_("Skipping '{path}': {error} ({error_code})")),
+                fmt::arg("path", path),
+                fmt::arg("error", error.message()),
+                fmt::arg("error_code", error.code())));
     }
 
     return info && info->isFile();
@@ -114,11 +115,12 @@ void BaseWatchdir::scan()
 
     if (error)
     {
-        tr_logAddWarn(fmt::format(
-            fmt::runtime(_("Couldn't read '{path}': {error} ({error_code})")),
-            fmt::arg("path", dirname()),
-            fmt::arg("error", error.message()),
-            fmt::arg("error_code", error.code())));
+        tr_logAddWarn(
+            fmt::format(
+                fmt::runtime(_("Couldn't read '{path}': {error} ({error_code})")),
+                fmt::arg("path", dirname()),
+                fmt::arg("error", error.message()),
+                fmt::arg("error_code", error.code())));
     }
 }
 

--- a/libtransmission/web.cc
+++ b/libtransmission/web.cc
@@ -193,9 +193,10 @@ public:
         if (curl_ssl_verify)
         {
             auto const* bundle = std::empty(curl_ca_bundle) ? "none" : curl_ca_bundle.c_str();
-            tr_logAddInfo(fmt::format(
-                fmt::runtime(_("Will verify tracker certs using envvar CURL_CA_BUNDLE: {bundle}")),
-                fmt::arg("bundle", bundle)));
+            tr_logAddInfo(
+                fmt::format(
+                    fmt::runtime(_("Will verify tracker certs using envvar CURL_CA_BUNDLE: {bundle}")),
+                    fmt::arg("bundle", bundle)));
             tr_logAddInfo(_("NB: this only works if you built against libcurl with openssl or gnutls, NOT nss"));
             tr_logAddInfo(_("NB: Invalid certs will appear as 'Could not connect to tracker' like many other errors"));
         }
@@ -493,11 +494,13 @@ public:
             (void)curl_easy_getinfo(task->easy(), CURLINFO_RESPONSE_CODE, &code);
             if (code != NoResponseCode && code != PartialContentResponseCode)
             {
-                tr_logAddWarn(fmt::format(
-                    fmt::runtime(_("Couldn't fetch '{url}': expected HTTP response code {expected_code}, got {actual_code}")),
-                    fmt::arg("url", task->url()),
-                    fmt::arg("expected_code", PartialContentResponseCode),
-                    fmt::arg("actual_code", code)));
+                tr_logAddWarn(
+                    fmt::format(
+                        fmt::runtime(
+                            _("Couldn't fetch '{url}': expected HTTP response code {expected_code}, got {actual_code}")),
+                        fmt::arg("url", task->url()),
+                        fmt::arg("expected_code", PartialContentResponseCode),
+                        fmt::arg("actual_code", code)));
 
                 // Tell curl to error out. Returning anything that's not
                 // `bytes_used` signals an error and causes the transfer

--- a/qt/AboutDialog.cc
+++ b/qt/AboutDialog.cc
@@ -54,9 +54,10 @@ void AboutDialog::showCredits()
     QMessageBox::about(
         this,
         tr("Credits"),
-        QString::fromUtf8("Charles Kerr (Backend; Daemon; GTK+; Qt)\n"
-                          "Mitchell Livingston (macOS)\n"
-                          "Mike Gelfand\n"));
+        QString::fromUtf8(
+            "Charles Kerr (Backend; Daemon; GTK+; Qt)\n"
+            "Mitchell Livingston (macOS)\n"
+            "Mike Gelfand\n"));
 }
 
 void AboutDialog::showLicense()

--- a/qt/Application.cc
+++ b/qt/Application.cc
@@ -529,9 +529,10 @@ bool Application::notifyApp(QString const& title, QString const& body, QStringLi
         args.append(title); // summary
         args.append(body); // body
         args.append(actions);
-        args.append(QVariantMap{ {
-            std::make_pair(QStringLiteral("category"), QVariant{ QStringLiteral("transfer.complete") }),
-        } }); // hints
+        args.append(
+            QVariantMap{ {
+                std::make_pair(QStringLiteral("category"), QVariant{ QStringLiteral("transfer.complete") }),
+            } }); // hints
         args.append(static_cast<int32_t>(-1)); // use the default timeout period
         m.setArguments(args);
         QDBusReply<quint32> const reply_msg = bus.call(m);

--- a/tests/libtransmission/announce-list-test.cc
+++ b/tests/libtransmission/announce-list-test.cc
@@ -402,11 +402,12 @@ TEST_F(AnnounceListTest, save)
     EXPECT_EQ(original_tm.piece_count(), modified_tm.piece_count());
 
     // test that the saved version has the updated announce list
-    EXPECT_TRUE(std::equal(
-        std::begin(announce_list),
-        std::end(announce_list),
-        std::begin(modified_tm.announce_list()),
-        std::end(modified_tm.announce_list())));
+    EXPECT_TRUE(
+        std::equal(
+            std::begin(announce_list),
+            std::end(announce_list),
+            std::begin(modified_tm.announce_list()),
+            std::end(modified_tm.announce_list())));
 
     // cleanup
     (void)std::remove(test_file.c_str());

--- a/tests/libtransmission/net-test.cc
+++ b/tests/libtransmission/net-test.cc
@@ -84,10 +84,11 @@ TEST_F(NetTest, compact4)
     EXPECT_EQ(std::size(Compact4) - tr_port::CompactPortBytes, static_cast<size_t>(out - std::data(buf)));
     EXPECT_TRUE(
         std::equal(std::data(Compact4), std::data(Compact4) + std::size(Compact4) - tr_port::CompactPortBytes, std::data(buf)));
-    EXPECT_TRUE(std::all_of(
-        std::begin(buf) + std::size(Compact4) - tr_port::CompactPortBytes,
-        std::end(buf),
-        [](std::byte const& byte) { return static_cast<unsigned char>(byte) == 0U; }));
+    EXPECT_TRUE(
+        std::all_of(
+            std::begin(buf) + std::size(Compact4) - tr_port::CompactPortBytes,
+            std::end(buf),
+            [](std::byte const& byte) { return static_cast<unsigned char>(byte) == 0U; }));
 
     /// sockaddr --> compact
 
@@ -146,14 +147,16 @@ TEST_F(NetTest, compact6)
     out = std::data(compact6);
     out = addr.to_compact(out);
     EXPECT_EQ(std::size(Compact6) - tr_port::CompactPortBytes, static_cast<size_t>(out - std::data(compact6)));
-    EXPECT_TRUE(std::equal(
-        std::data(Compact6),
-        std::data(Compact6) + std::size(Compact6) - tr_port::CompactPortBytes,
-        std::data(compact6)));
-    EXPECT_TRUE(std::all_of(
-        std::begin(compact6) + std::size(Compact6) - tr_port::CompactPortBytes,
-        std::end(compact6),
-        [](std::byte const& byte) { return static_cast<unsigned char>(byte) == 0U; }));
+    EXPECT_TRUE(
+        std::equal(
+            std::data(Compact6),
+            std::data(Compact6) + std::size(Compact6) - tr_port::CompactPortBytes,
+            std::data(compact6)));
+    EXPECT_TRUE(
+        std::all_of(
+            std::begin(compact6) + std::size(Compact6) - tr_port::CompactPortBytes,
+            std::end(compact6),
+            [](std::byte const& byte) { return static_cast<unsigned char>(byte) == 0U; }));
 
     /// sockaddr --> compact
 

--- a/utils/show.cc
+++ b/utils/show.cc
@@ -341,14 +341,15 @@ void doScrape(tr_torrent_metainfo const& metainfo)
         auto response_mutex = std::mutex{};
         auto response_cv = std::condition_variable{};
         auto lock = std::unique_lock(response_mutex);
-        web->fetch({ scrape_url,
-                     [&response, &response_cv](tr_web::FetchResponse const& resp)
-                     {
-                         response = resp;
-                         response_cv.notify_one();
-                     },
-                     nullptr,
-                     TimeoutSecs });
+        web->fetch(
+            { scrape_url,
+              [&response, &response_cv](tr_web::FetchResponse const& resp)
+              {
+                  response = resp;
+                  response_cv.notify_one();
+              },
+              nullptr,
+              TimeoutSecs });
         response_cv.wait(lock);
 
         // check the response code


### PR DESCRIPTION
Currently it's not easily possible to contribute to Transmission from a Mac.
On macOS, when using brew, only clang-format 20 is supported: we can't install clang-format 17 easily.
```
✗ brew search clang-format
==> Formulae
clang-format ✔                                              clang-format@11                                             cfn-format
```
In order to be able to make commits and contribute on Transmission, we need to pass the clang-format check.
Attempting `clang-format -i`.