### PR TITLE
fix: announce public peer port on dht

### DIFF
--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -871,7 +871,7 @@ void tr_session::setSettings(tr_session::Settings&& settings_in, bool force)
     }
     else if (force || !dht_ || port_changed || addr_changed || new_settings.dht_enabled != old_settings.dht_enabled)
     {
-        dht_ = tr_dht::create(dht_mediator_, localPeerPort(), udp_core_->socket4(), udp_core_->socket6());
+        dht_ = tr_dht::create(dht_mediator_, advertisedPeerPort(), udp_core_->socket4(), udp_core_->socket6());
     }
 
     if (auto const& val = new_settings.sleep_per_seconds_during_verify;


### PR DESCRIPTION
Notes: Announce port-forwarded peer port instead of local peer port on DHT.