### PR TITLE
build: tell clang-tidy to suggest uppercase literal suffixes

### DIFF
--- a/gtk/.clang-tidy
+++ b/gtk/.clang-tidy
@@ -28,3 +28,4 @@ CheckOptions:
   - { key: cppcoreguidelines-avoid-do-while.IgnoreMacros, value: true }
   - { key: misc-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic, value: true }
   - { key: modernize-pass-by-value.ValuesOnly, value: true }
+  - { key: readability-implicit-bool-conversion.UseUpperCaseLiteralSuffix, value: true }

--- a/libtransmission/.clang-tidy
+++ b/libtransmission/.clang-tidy
@@ -39,8 +39,9 @@ Checks: >
   -readability-qualified-auto,
 
 CheckOptions:
-  - { key: cppcoreguidelines-avoid-do-while.IgnoreMacros,          value: true       }
-  - { key: readability-identifier-naming.ConstexprVariableCase,    value: CamelCase  }
-  - { key: readability-identifier-naming.ParameterCase,            value: lower_case }
-  - { key: readability-identifier-naming.VariableCase,             value: lower_case }
+  - { key: cppcoreguidelines-avoid-do-while.IgnoreMacros,                   value: true       }
+  - { key: readability-identifier-naming.ConstexprVariableCase,             value: CamelCase  }
+  - { key: readability-identifier-naming.ParameterCase,                     value: lower_case }
+  - { key: readability-identifier-naming.VariableCase,                      value: lower_case }
+  - { key: readability-implicit-bool-conversion.UseUpperCaseLiteralSuffix,  value: true       }
 

--- a/qt/.clang-tidy
+++ b/qt/.clang-tidy
@@ -39,18 +39,19 @@ Checks: >
   -readability-redundant-access-specifiers, # keep: 'private' vs 'private slots'
 
 CheckOptions:
-  - { key: cppcoreguidelines-avoid-do-while.IgnoreMacros,          value: true       }
-  - { key: readability-identifier-naming.ClassCase,                value: CamelCase  }
-  - { key: readability-identifier-naming.ClassMethodCase,          value: camelBack  }
-  - { key: readability-identifier-naming.ConstexprVariableCase,    value: CamelCase  }
-  - { key: readability-identifier-naming.EnumConstantCase,         value: UPPER_CASE }
-  - { key: readability-identifier-naming.FunctionCase,             value: camelBack  }
-  - { key: readability-identifier-naming.GlobalConstantCase,       value: CamelCase  }
-  - { key: readability-identifier-naming.MemberConstantCase,       value: CamelCase  }
-  - { key: readability-identifier-naming.NamespaceCase,            value: lower_case }
-  - { key: readability-identifier-naming.PrivateMemberSuffix,      value: _          }
-  - { key: readability-identifier-naming.ProtectedMemberSuffix,    value: _          }
-  - { key: readability-identifier-naming.StaticConstantCase,       value: CamelCase  }
-  - { key: readability-identifier-naming.StructCase,               value: CamelCase  }
-  - { key: readability-identifier-naming.TemplateParameterCase,    value: CamelCase  }
-  - { key: readability-identifier-naming.VariableCase,             value: lower_case }
+  - { key: cppcoreguidelines-avoid-do-while.IgnoreMacros,                   value: true       }
+  - { key: readability-identifier-naming.ClassCase,                         value: CamelCase  }
+  - { key: readability-identifier-naming.ClassMethodCase,                   value: camelBack  }
+  - { key: readability-identifier-naming.ConstexprVariableCase,             value: CamelCase  }
+  - { key: readability-identifier-naming.EnumConstantCase,                  value: UPPER_CASE }
+  - { key: readability-identifier-naming.FunctionCase,                      value: camelBack  }
+  - { key: readability-identifier-naming.GlobalConstantCase,                value: CamelCase  }
+  - { key: readability-identifier-naming.MemberConstantCase,                value: CamelCase  }
+  - { key: readability-identifier-naming.NamespaceCase,                     value: lower_case }
+  - { key: readability-identifier-naming.PrivateMemberSuffix,               value: _          }
+  - { key: readability-identifier-naming.ProtectedMemberSuffix,             value: _          }
+  - { key: readability-identifier-naming.StaticConstantCase,                value: CamelCase  }
+  - { key: readability-identifier-naming.StructCase,                        value: CamelCase  }
+  - { key: readability-identifier-naming.TemplateParameterCase,             value: CamelCase  }
+  - { key: readability-identifier-naming.VariableCase,                      value: lower_case }
+  - { key: readability-implicit-bool-conversion.UseUpperCaseLiteralSuffix,  value: true       }

--- a/tests/libtransmission/.clang-tidy
+++ b/tests/libtransmission/.clang-tidy
@@ -35,18 +35,19 @@ Checks: >
   -readability-qualified-auto,
 
 CheckOptions:
-  - { key: cppcoreguidelines-avoid-do-while.IgnoreMacros,          value: true       }
-  - { key: readability-identifier-naming.ClassCase,                value: CamelCase  }
-  - { key: readability-identifier-naming.ClassMethodCase,          value: camelBack  }
-  - { key: readability-identifier-naming.ConstexprVariableCase,    value: CamelCase  }
-  - { key: readability-identifier-naming.EnumConstantCase,         value: UPPER_CASE }
-  - { key: readability-identifier-naming.FunctionCase,             value: camelBack  }
-  - { key: readability-identifier-naming.GlobalConstantCase,       value: CamelCase  }
-  - { key: readability-identifier-naming.MemberConstantCase,       value: CamelCase  }
-  - { key: readability-identifier-naming.NamespaceCase,            value: lower_case }
-  - { key: readability-identifier-naming.PrivateMemberSuffix,      value: _          }
-  - { key: readability-identifier-naming.ProtectedMemberSuffix,    value: _          }
-  - { key: readability-identifier-naming.StaticConstantCase,       value: CamelCase  }
-  - { key: readability-identifier-naming.StructCase,               value: CamelCase  }
-  - { key: readability-identifier-naming.TemplateParameterCase,    value: CamelCase  }
-  - { key: readability-identifier-naming.VariableCase,             value: lower_case }
+  - { key: cppcoreguidelines-avoid-do-while.IgnoreMacros,                   value: true       }
+  - { key: readability-identifier-naming.ClassCase,                         value: CamelCase  }
+  - { key: readability-identifier-naming.ClassMethodCase,                   value: camelBack  }
+  - { key: readability-identifier-naming.ConstexprVariableCase,             value: CamelCase  }
+  - { key: readability-identifier-naming.EnumConstantCase,                  value: UPPER_CASE }
+  - { key: readability-identifier-naming.FunctionCase,                      value: camelBack  }
+  - { key: readability-identifier-naming.GlobalConstantCase,                value: CamelCase  }
+  - { key: readability-identifier-naming.MemberConstantCase,                value: CamelCase  }
+  - { key: readability-identifier-naming.NamespaceCase,                     value: lower_case }
+  - { key: readability-identifier-naming.PrivateMemberSuffix,               value: _          }
+  - { key: readability-identifier-naming.ProtectedMemberSuffix,             value: _          }
+  - { key: readability-identifier-naming.StaticConstantCase,                value: CamelCase  }
+  - { key: readability-identifier-naming.StructCase,                        value: CamelCase  }
+  - { key: readability-identifier-naming.TemplateParameterCase,             value: CamelCase  }
+  - { key: readability-identifier-naming.VariableCase,                      value: lower_case }
+  - { key: readability-implicit-bool-conversion.UseUpperCaseLiteralSuffix,  value: true       }


### PR DESCRIPTION
Enabling `readability-uppercase-literal-suffix` doesn't automatically make `readability-implicit-bool-conversion` suggest uppercase literal suffixies.

We need to manually tell `clang-tidy` to do so by setting `readability-implicit-bool-conversion.UseUpperCaseLiteralSuffix` to `true`.