### PR TITLE
fix(remote): print label separators correctly

### DIFF
--- a/utils/remote.cc
+++ b/utils/remote.cc
@@ -941,7 +941,7 @@ void print_details(tr_variant::Map const& map)
             {
                 if (auto sv = it->value_if<std::string_view>(); sv)
                 {
-                    fmt::print("{:s}{:s}", it == begin ? ", " : "", *sv);
+                    fmt::print("{:s}{:s}", it != begin ? ", " : "", *sv);
                 }
             }
 


### PR DESCRIPTION
Fixes #7534
Regression from #6832