### PR TITLE
chore: bump libnatpmp

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,7 +13,6 @@
 [submodule "third-party/libnatpmp"]
 	path = third-party/libnatpmp
 	url = https://github.com/transmission/libnatpmp.git
-	branch = post-20151025-transmission
 [submodule "third-party/libutp"]
 	path = third-party/libutp
 	url = https://github.com/transmission/libutp.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -507,7 +507,9 @@ tr_add_external_auto_library(EVENT2 libevent event
         -DEVENT__LIBRARY_TYPE:STRING=STATIC)
 
 tr_add_external_auto_library(NATPMP libnatpmp natpmp
-    TARGET natpmp::natpmp)
+    TARGET natpmp::natpmp
+    CMAKE_ARGS
+        -DBUILD_SHARED_LIBS=OFF)
 if(NOT USE_SYSTEM_NATPMP)
     target_compile_definitions(natpmp::natpmp
         INTERFACE


### PR DESCRIPTION
They now provide their own CMakeLists.txt.

On the side of bumping libnatpmp, their minimum CMake version is bumped to 3.5, which is deprecated, but still supported at the moment.