### PR TITLE
Ignore outdated clang-format-17 on macOS

### DIFF
--- a/code_style.sh
+++ b/code_style.sh
@@ -40,11 +40,10 @@ find_cfiles() {
        ! \( $(get_find_path_args $(trim_comments .clang-format-ignore)) \) "$@"
 }
 
-# We're targeting clang-format version 17 and other versions give slightly
-# different results, so prefer `clang-format-17` if it's installed.
+# We're targeting clang-format version 17 and other versions give
+# different results, so only accept `clang-format-17` if it's installed.
 clang_format_exe_names=(
   'clang-format-17'
-  'clang-format'
 )
 for name in ${clang_format_exe_names[@]}; do
   clang_format_exe=$(command -v "${name}")
@@ -53,16 +52,18 @@ for name in ${clang_format_exe_names[@]}; do
     break
   fi
 done
-if [ -z "${clang_format_exe}" ]; then
-  echo "error: clang-format not found";
-  exit 1;
-fi
 
 # format C/C++
-clang_format_args="$([ -n "$fix" ] && echo '-i' || echo '--dry-run --Werror')"
-if ! find_cfiles -exec "${clang_format_exe}" $clang_format_args '{}' '+'; then
-  [ -n "$fix" ] || echo 'C/C++ code needs formatting'
-  exitcode=1
+if [ -z "${clang_format_exe}" ]; then
+  echo "error: clang-format-17 not found"
+  # We ignore that error: clang-format-17 is outdated nowadays.
+  #exitcode=1
+else
+  clang_format_args="$([ -n "$fix" ] && echo '-i' || echo '--dry-run --Werror')"
+  if ! find_cfiles -exec "${clang_format_exe}" $clang_format_args '{}' '+'; then
+    [ -n "$fix" ] || echo 'C/C++ code needs formatting'
+    exitcode=1
+  fi
 fi
 
 # format Xcodeproj


### PR DESCRIPTION
Contributing to Transmission has been mostly impossible for macOS users (or at least not straigthforward at all, since they can't commit anything without figuring out how to install an outdated version of clang-format that is no more available to them via the brew package manager).

While fixing the format was offered in #7499, it has been unreviewed there for weeks.
At this point, it's best to give up on imposing clang-format-17 for macOS users if Transmission is not keeping itself up-to-date with latest clang-format versions.

**Clang-format errors will still be detected by CI pipelines, so they will still be addressable before merging pull requests.**

The goal of this pull request is to allow to make **commits** for macOS users.