### PR TITLE
ci: bump to clang-format-18

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -56,7 +56,7 @@ FixNamespaceComments: true
 IndentGotoLabels: false
 KeepEmptyLinesAtTheStartOfBlocks: false
 QualifierAlignment: Right
-SortUsingDeclarations: true # Since clang-format 16, the equivalent value is LexicographicNumeric
+SortUsingDeclarations: LexicographicNumeric
 SpaceAfterTemplateKeyword: false
 ---
 Language: ObjC

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -71,7 +71,7 @@ jobs:
           cat "$GITHUB_OUTPUT"
 
   code-style:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: [ what-to-make ]
     if: ${{ needs.what-to-make.outputs.test-style == 'true' }}
     env:
@@ -89,9 +89,7 @@ jobs:
       - name: Get Dependencies
         run: |
           set -ex
-          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          sudo add-apt-repository "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-17 main"
-          sudo apt-get install -y clang-format-17 npm
+          sudo apt-get install -y clang-format-18 npm
       - name: Check for style diffs
         id: check-for-diffs
         working-directory: .

--- a/code_style.sh
+++ b/code_style.sh
@@ -40,10 +40,10 @@ find_cfiles() {
        ! \( $(get_find_path_args $(trim_comments .clang-format-ignore)) \) "$@"
 }
 
-# We're targeting clang-format version 17 and other versions give slightly
-# different results, so prefer `clang-format-17` if it's installed.
+# We're targeting clang-format version 18 and other versions give slightly
+# different results, so prefer `clang-format-18` if it's installed.
 clang_format_exe_names=(
-  'clang-format-17'
+  'clang-format-18'
   'clang-format'
 )
 for name in ${clang_format_exe_names[@]}; do

--- a/libtransmission/favicon-cache.h
+++ b/libtransmission/favicon-cache.h
@@ -44,9 +44,7 @@ public:
         return iter != std::end(icons_) ? &iter->second : nullptr;
     }
 
-    void load( //
-        std::string_view url_in,
-        IconFunc callback = [](Icon const&) { /*default callback is a no-op */ })
+    void load(std::string_view url_in, IconFunc callback = [](Icon const&) { /*default callback is a no-op */ })
     {
         std::call_once(scan_once_flag_, &FaviconCache::scan_file_cache, this);
 

--- a/tests/libtransmission/dht-test.cc
+++ b/tests/libtransmission/dht-test.cc
@@ -65,10 +65,7 @@ namespace
 
 bool waitFor(struct event_base* event_base, std::chrono::milliseconds msec)
 {
-    return libtransmission::test::waitFor( //
-        event_base,
-        []() { return false; },
-        msec);
+    return libtransmission::test::waitFor(event_base, []() { return false; }, msec);
 }
 
 auto constexpr IdLength = size_t{ 20U };
@@ -604,10 +601,7 @@ TEST_F(DhtTest, usesBootstrapFile)
     auto const expected = tr_socket_address{ tr_address::from_string(BootstrapNodeName).value_or(tr_address{}),
                                              BootstrapNodePort };
     auto& pinged = mediator.mock_dht_.pinged_;
-    waitFor( //
-        event_base_,
-        [&pinged]() { return !std::empty(pinged); },
-        5s);
+    waitFor(event_base_, [&pinged]() { return !std::empty(pinged); }, 5s);
     ASSERT_EQ(1U, std::size(pinged));
     auto const [actual_addrport, time] = pinged.front();
     EXPECT_EQ(expected.address(), actual_addrport.address());

--- a/tests/libtransmission/timer-test.cc
+++ b/tests/libtransmission/timer-test.cc
@@ -42,10 +42,7 @@ protected:
 
     void sleepMsec(std::chrono::milliseconds msec)
     {
-        EXPECT_FALSE(waitFor( //
-            evbase_.get(),
-            []() { return false; },
-            msec));
+        EXPECT_FALSE(waitFor(evbase_.get(), []() { return false; }, msec));
     }
 
     static void expectTime(


### PR DESCRIPTION
Our `clang-tidy` is already on 18, it makes sense to do the same for `clang-format`.