### PR TITLE
fix: don't bind udp sockets if no source address

### DIFF
--- a/libtransmission/ip-cache.cc
+++ b/libtransmission/ip-cache.cc
@@ -62,6 +62,15 @@ namespace global_source_ip_helpers
 // and check its source address.
 //
 // Since it's a UDP socket, this doesn't actually send any packets
+//
+// N.B. Successfully obtaining a source address does not imply
+// connectivity to the given destination address, since all connect()
+// does is setting the default remote address for subsequent send() and
+// recv() calls.
+//
+// Having said that, the connect() step is still needed because on Windows,
+// calling getsockname() might not return what we want before calling
+// connect() if we are binding to 0.0.0.0 or ::.
 [[nodiscard]] std::optional<tr_address> get_source_address(
     tr_address const& dst_addr,
     tr_port dst_port,
@@ -213,7 +222,7 @@ bool tr_ip_cache::set_global_addr(tr_address_type type, tr_address const& addr) 
 void tr_ip_cache::update_addr(tr_address_type type) noexcept
 {
     update_source_addr(type);
-    if (global_source_addr(type))
+    if (source_addr(type))
     {
         update_global_addr(type);
     }
@@ -266,8 +275,7 @@ void tr_ip_cache::update_source_addr(tr_address_type type) noexcept
     auto const protocol = tr_ip_protocol_to_sv(type);
 
     auto err = 0;
-    auto const& source_addr = get_global_source_address(bind_addr(type), err);
-    if (source_addr)
+    if (auto const& source_addr = get_global_source_address(bind_addr(type), err); source_addr)
     {
         set_source_addr(*source_addr);
         tr_logAddDebug(fmt::format(

--- a/libtransmission/ip-cache.h
+++ b/libtransmission/ip-cache.h
@@ -28,10 +28,10 @@
  * This class caches 3 useful info:
  * 1. Whether your machine supports the IP protocol
  * 2. Source address used for global connections
- * 3. Global address
+ * 3. Global address (IPv4 public address/IPv6 global unicast address)
  *
  * The idea is, if this class successfully cached a source address, that means
- * you have connectivity to the public internet. And if the global address is
+ * your system is capable in that IP protocol. And if the global address is
  * the same as the source address, then you are not behind a NAT.
  */
 class tr_ip_cache
@@ -70,7 +70,7 @@ public:
         return global_addr_[type];
     }
 
-    [[nodiscard]] std::optional<tr_address> global_source_addr(tr_address_type type) const noexcept
+    [[nodiscard]] std::optional<tr_address> source_addr(tr_address_type type) const noexcept
     {
         auto const lock = std::shared_lock{ source_addr_mutex_[type] };
         return source_addr_[type];

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -447,7 +447,7 @@ tr_address tr_session::bind_address(tr_address_type type) const noexcept
         // if user provided an address, use it.
         // otherwise, if we can determine which one to use via global_source_address(ipv6) magic, use it.
         // otherwise, use any_ipv6 (::).
-        auto const source_addr = global_source_address(type);
+        auto const source_addr = source_address(type);
         auto const default_addr = source_addr && source_addr->is_global_unicast_address() ? *source_addr :
                                                                                             tr_address::any(TR_AF_INET6);
         return tr_address::from_string(settings_.bind_address_ipv6).value_or(default_addr);

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -1032,10 +1032,10 @@ public:
         return ip_cache_.set_global_addr(addr.type, addr);
     }
 
-    [[nodiscard]] std::optional<tr_address> global_source_address(tr_address_type type) const noexcept
+    [[nodiscard]] std::optional<tr_address> source_address(tr_address_type type) const noexcept
     {
         TR_ASSERT(tr_address::is_valid(type));
-        return ip_cache_.global_source_addr(type);
+        return ip_cache_.source_addr(type);
     }
 
     [[nodiscard]] auto speed_limit(tr_direction const dir) const noexcept

--- a/libtransmission/tr-udp.cc
+++ b/libtransmission/tr-udp.cc
@@ -273,7 +273,6 @@ tr_session::tr_udp_core::~tr_udp_core()
 
 void tr_session::tr_udp_core::sendto(void const* buf, size_t buflen, struct sockaddr const* to, socklen_t const tolen) const
 {
-    auto const addrport = tr_socket_address::from_sockaddr(to);
     if (to->sa_family != AF_INET && to->sa_family != AF_INET6)
     {
         errno = EAFNOSUPPORT;
@@ -283,11 +282,9 @@ void tr_session::tr_udp_core::sendto(void const* buf, size_t buflen, struct sock
         // don't warn on bad sockets; the system may not support IPv6
         return;
     }
-    else if (
-        addrport && addrport->address().is_global_unicast_address() &&
-        !session_.global_source_address(tr_af_to_ip_protocol(to->sa_family)))
+    else if (!session_.source_address(tr_af_to_ip_protocol(to->sa_family)))
     {
-        // don't try to connect to a global address if we don't have connectivity to public internet
+        // don't try to send if we don't have a route in this IP protocol
         return;
     }
     else if (::sendto(sock, static_cast<char const*>(buf), buflen, 0, to, tolen) != -1)
@@ -296,7 +293,7 @@ void tr_session::tr_udp_core::sendto(void const* buf, size_t buflen, struct sock
     }
 
     auto display_name = std::string{};
-    if (addrport)
+    if (auto const addrport = tr_socket_address::from_sockaddr(to); addrport)
     {
         display_name = addrport->display_name();
     }

--- a/libtransmission/tr-udp.cc
+++ b/libtransmission/tr-udp.cc
@@ -166,7 +166,11 @@ tr_session::tr_udp_core::tr_udp_core(tr_session& session, tr_port udp_port)
         return;
     }
 
-    if (auto sock = socket(PF_INET, SOCK_DGRAM, 0); sock != TR_BAD_SOCKET)
+    if (!session.source_address(TR_AF_INET))
+    {
+        // no IPv4; do nothing
+    }
+    else if (auto sock = socket(PF_INET, SOCK_DGRAM, 0); sock != TR_BAD_SOCKET)
     {
         (void)evutil_make_listen_socket_reuseable(sock);
 
@@ -206,7 +210,7 @@ tr_session::tr_udp_core::tr_udp_core(tr_session& session, tr_port udp_port)
         }
     }
 
-    if (!session.has_ip_protocol(TR_AF_INET6))
+    if (!session.source_address(TR_AF_INET6))
     {
         // no IPv6; do nothing
     }
@@ -250,6 +254,11 @@ tr_session::tr_udp_core::tr_udp_core(tr_session& session, tr_port udp_port)
             event_add(udp6_event_.get(), nullptr);
         }
     }
+
+    if (udp4_socket_ == TR_BAD_SOCKET && udp6_socket_ == TR_BAD_SOCKET)
+    {
+        tr_logAddError(_("Couldn't create any UDP sockets."));
+    }
 }
 
 tr_session::tr_udp_core::~tr_udp_core()
@@ -280,11 +289,6 @@ void tr_session::tr_udp_core::sendto(void const* buf, size_t buflen, struct sock
     else if (auto const sock = to->sa_family == AF_INET ? udp4_socket_ : udp6_socket_; sock == TR_BAD_SOCKET)
     {
         // don't warn on bad sockets; the system may not support IPv6
-        return;
-    }
-    else if (!session_.source_address(tr_af_to_ip_protocol(to->sa_family)))
-    {
-        // don't try to send if we don't have a route in this IP protocol
         return;
     }
     else if (::sendto(sock, static_cast<char const*>(buf), buflen, 0, to, tolen) != -1)

--- a/tests/libtransmission/ip-cache-test.cc
+++ b/tests/libtransmission/ip-cache-test.cc
@@ -179,13 +179,13 @@ TEST_F(IPCacheTest, globalSourceIPv4)
     ip_cache_ = std::make_unique<tr_ip_cache>(mediator);
 
     ip_cache_->update_source_addr(TR_AF_INET);
-    auto const addr = ip_cache_->global_source_addr(TR_AF_INET);
+    auto const addr = ip_cache_->source_addr(TR_AF_INET);
     if (!addr)
     {
         GTEST_SKIP() << "globalSourceIPv4 did not return an address, either:\n"
                      << "1. globalSourceIPv4 is broken\n"
                      << "2. Your system does not support IPv4\n"
-                     << "3. You don't have IPv4 connectivity to public internet";
+                     << "3. You don't have an IPv4 address to your interface";
     }
     EXPECT_TRUE(addr->is_ipv4());
 }
@@ -203,13 +203,13 @@ TEST_F(IPCacheTest, globalSourceIPv6)
     ip_cache_ = std::make_unique<tr_ip_cache>(mediator);
 
     ip_cache_->update_source_addr(TR_AF_INET6);
-    auto const addr = ip_cache_->global_source_addr(TR_AF_INET6);
+    auto const addr = ip_cache_->source_addr(TR_AF_INET6);
     if (!addr)
     {
         GTEST_SKIP() << "globalSourceIPv6 did not return an address, either:\n"
                      << "1. globalSourceIPv6 is broken\n"
                      << "2. Your system does not support IPv6\n"
-                     << "3. You don't have IPv6 connectivity to public internet";
+                     << "3. You don't have an IPv6 address to your interface";
     }
     EXPECT_TRUE(addr->is_ipv6());
 }


### PR DESCRIPTION
Don't create a UDP socket if there's no source address, since we can't make any connections anyway.

> [!NOTE]
> This PR blocked by #7520.