### PR TITLE
chore: move away from fmt/core.h

### DIFF
--- a/cli/cli.cc
+++ b/cli/cli.cc
@@ -11,7 +11,7 @@
 
 #include <signal.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <libtransmission/transmission.h>
 

--- a/daemon/daemon-posix.cc
+++ b/daemon/daemon-posix.cc
@@ -17,7 +17,7 @@
 
 #include <event2/event.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <libtransmission/error.h>
 #include <libtransmission/utils.h>

--- a/daemon/daemon-win32.cc
+++ b/daemon/daemon-win32.cc
@@ -8,7 +8,7 @@
 
 #include <algorithm> /* std::max() */
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <libtransmission/error.h>
 #include <libtransmission/log.h>

--- a/daemon/daemon.cc
+++ b/daemon/daemon.cc
@@ -26,7 +26,7 @@
 
 #include <event2/event.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <libtransmission/transmission.h>
 

--- a/gtk/Application.cc
+++ b/gtk/Application.cc
@@ -63,7 +63,7 @@
 #include <gtkmm/selectiondata.h>
 #endif
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <algorithm>
 #include <csignal>

--- a/gtk/DetailsDialog.cc
+++ b/gtk/DetailsDialog.cc
@@ -47,7 +47,7 @@
 #include <gtkmm/treeview.h>
 
 #include <fmt/chrono.h>
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <fmt/ranges.h>
 
 #include <algorithm>

--- a/gtk/Dialogs.cc
+++ b/gtk/Dialogs.cc
@@ -12,7 +12,7 @@
 #include <glibmm/ustring.h>
 #include <gtkmm/messagedialog.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <memory>
 #include <vector>

--- a/gtk/FileList.cc
+++ b/gtk/FileList.cc
@@ -32,7 +32,7 @@
 #include <gtkmm/treestore.h>
 #include <gtkmm/treeview.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <algorithm>
 #include <memory>

--- a/gtk/FilterBar.cc
+++ b/gtk/FilterBar.cc
@@ -34,7 +34,7 @@
 #include <gtkmm/filterlistmodel.h>
 #endif
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <algorithm> // std::transform()
 #include <array>

--- a/gtk/FreeSpaceLabel.cc
+++ b/gtk/FreeSpaceLabel.cc
@@ -13,7 +13,7 @@
 #include <glibmm/i18n.h>
 #include <glibmm/main.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <memory>
 #include <string>

--- a/gtk/MakeDialog.cc
+++ b/gtk/MakeDialog.cc
@@ -41,7 +41,7 @@
 #include <gtkmm/selectiondata.h>
 #endif
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <chrono>
 #include <future>

--- a/gtk/MessageLogWindow.cc
+++ b/gtk/MessageLogWindow.cc
@@ -33,7 +33,7 @@
 #include <gtkmm/treemodelsort.h>
 #include <gtkmm/treeview.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <fmt/ostream.h>
 
 #include <array>

--- a/gtk/Notify.cc
+++ b/gtk/Notify.cc
@@ -20,7 +20,7 @@
 #include <glibmm/ustring.h>
 #include <glibmm/variant.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <map>
 #include <utility>

--- a/gtk/PrefsDialog.cc
+++ b/gtk/PrefsDialog.cc
@@ -40,7 +40,7 @@
 #include <gtkmm/eventcontrollerfocus.h>
 #endif
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <array>
 #include <limits>

--- a/gtk/RelocateDialog.cc
+++ b/gtk/RelocateDialog.cc
@@ -17,7 +17,7 @@
 #include <gtkmm/checkbutton.h>
 #include <gtkmm/messagedialog.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <memory>
 #include <string>

--- a/gtk/Session.cc
+++ b/gtk/Session.cc
@@ -41,7 +41,7 @@
 #include <gtkmm/treemodelsort.h>
 #endif
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <algorithm>
 #include <array>

--- a/gtk/StatsDialog.cc
+++ b/gtk/StatsDialog.cc
@@ -16,7 +16,7 @@
 #include <gtkmm/label.h>
 #include <gtkmm/messagedialog.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <memory>
 

--- a/gtk/Torrent.cc
+++ b/gtk/Torrent.cc
@@ -17,7 +17,7 @@
 #include <glibmm/i18n.h>
 #include <glibmm/value.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <array>
 #include <cmath>

--- a/gtk/TorrentCellRenderer.cc
+++ b/gtk/TorrentCellRenderer.cc
@@ -30,7 +30,7 @@
 #include <gtkmm/snapshot.h>
 #endif
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <algorithm> // std::max()
 #include <cstring> // strchr()

--- a/gtk/Utils.cc
+++ b/gtk/Utils.cc
@@ -41,7 +41,7 @@
 #include <gtkmm/clipboard.h>
 #endif
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <functional>
 #include <memory>

--- a/gtk/Utils.h
+++ b/gtk/Utils.h
@@ -26,7 +26,7 @@
 #include <gtkmm/listview.h>
 #endif
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <cstddef>
 #include <cstdint>

--- a/gtk/main.cc
+++ b/gtk/main.cc
@@ -25,7 +25,7 @@
 #include <glibmm/wrap.h>
 #include <gtkmm.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <cstdio>
 #include <string>

--- a/libtransmission/announcer-http.cc
+++ b/libtransmission/announcer-http.cc
@@ -20,7 +20,7 @@
 
 #include <event2/http.h> /* for HTTP_OK */
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #define LIBTRANSMISSION_ANNOUNCER_MODULE
 

--- a/libtransmission/announcer-udp.cc
+++ b/libtransmission/announcer-udp.cc
@@ -29,7 +29,7 @@
 #include <sys/socket.h> // sockaddr_storage, AF_INET
 #endif
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #define LIBTRANSMISSION_ANNOUNCER_MODULE
 

--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -21,7 +21,7 @@
 #include <utility>
 #include <vector>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #define LIBTRANSMISSION_ANNOUNCER_MODULE
 

--- a/libtransmission/bandwidth.cc
+++ b/libtransmission/bandwidth.cc
@@ -13,7 +13,7 @@
 #include <utility> // for std::swap()
 #include <vector>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include "libtransmission/transmission.h"
 

--- a/libtransmission/blocklist.cc
+++ b/libtransmission/blocklist.cc
@@ -24,7 +24,7 @@
 #include <netinet/in.h>
 #endif
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include "libtransmission/transmission.h"
 

--- a/libtransmission/cache.cc
+++ b/libtransmission/cache.cc
@@ -13,7 +13,7 @@
 #include <utility> // std::make_pair()
 #include <vector>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include "libtransmission/transmission.h"
 

--- a/libtransmission/clients.cc
+++ b/libtransmission/clients.cc
@@ -15,7 +15,7 @@
 #include <utility>
 #include <vector>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include "libtransmission/clients.h"
 #include "libtransmission/tr-macros.h" // tr_peer_id_t

--- a/libtransmission/crypto-utils-ccrypto.cc
+++ b/libtransmission/crypto-utils-ccrypto.cc
@@ -9,7 +9,7 @@
 #include <CommonCrypto/CommonDigest.h>
 #include <CommonCrypto/CommonRandom.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include "libtransmission/transmission.h"
 

--- a/libtransmission/crypto-utils-mbedtls.cc
+++ b/libtransmission/crypto-utils-mbedtls.cc
@@ -12,7 +12,7 @@
 #include <mbedtls/sha256.h>
 #include <mbedtls/version.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include "libtransmission/transmission.h"
 

--- a/libtransmission/crypto-utils-openssl.cc
+++ b/libtransmission/crypto-utils-openssl.cc
@@ -20,7 +20,7 @@
 #include <openssl/x509.h>
 #include <openssl/x509_vfy.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include "libtransmission/crypto-utils.h"
 #include "libtransmission/log.h"

--- a/libtransmission/crypto-utils-wolfssl.cc
+++ b/libtransmission/crypto-utils-wolfssl.cc
@@ -12,7 +12,7 @@
 #include <wolfssl/wolfcrypt/sha256.h>
 #include <wolfssl/version.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include "libtransmission/transmission.h"
 

--- a/libtransmission/crypto-utils.cc
+++ b/libtransmission/crypto-utils.cc
@@ -21,7 +21,7 @@ extern "C"
 #include <b64/cencode.h>
 }
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include "libtransmission/crypto-utils.h"
 #include "libtransmission/tr-assert.h"

--- a/libtransmission/favicon-cache.h
+++ b/libtransmission/favicon-cache.h
@@ -18,7 +18,7 @@
 #include <string_view>
 #include <vector>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <libtransmission/file.h>
 #include <libtransmission/utils.h> // for tr_file_save()

--- a/libtransmission/file-win32.cc
+++ b/libtransmission/file-win32.cc
@@ -15,7 +15,7 @@
 #include <shlobj.h> /* SHCreateDirectoryEx() */
 #include <winioctl.h> /* FSCTL_SET_SPARSE */
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include "libtransmission/transmission.h"
 

--- a/libtransmission/inout.cc
+++ b/libtransmission/inout.cc
@@ -10,7 +10,7 @@
 #include <optional>
 #include <string_view>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include "libtransmission/transmission.h"
 

--- a/libtransmission/interned-string.h
+++ b/libtransmission/interned-string.h
@@ -7,7 +7,7 @@
 
 #include <string_view>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include "libtransmission/quark.h"
 

--- a/libtransmission/ip-cache.cc
+++ b/libtransmission/ip-cache.cc
@@ -19,7 +19,7 @@
 #include <sys/socket.h>
 #endif
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include "libtransmission/ip-cache.h"
 #include "libtransmission/log.h"

--- a/libtransmission/magnet-metainfo.cc
+++ b/libtransmission/magnet-metainfo.cc
@@ -12,7 +12,7 @@
 #include <string>
 #include <string_view>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include "libtransmission/crypto-utils.h"
 #include "libtransmission/error-types.h"

--- a/libtransmission/makemeta.cc
+++ b/libtransmission/makemeta.cc
@@ -14,7 +14,7 @@
 #include <utility>
 #include <vector>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include "libtransmission/transmission.h"
 

--- a/libtransmission/net.cc
+++ b/libtransmission/net.cc
@@ -27,7 +27,7 @@
 
 #include <event2/util.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include "libtransmission/log.h"
 #include "libtransmission/net.h"

--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -18,7 +18,7 @@
 
 #include <libutp/utp.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include "libtransmission/transmission.h"
 

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -23,7 +23,7 @@
 #include <small/map.hpp>
 #include <small/vector.hpp>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #define LIBTRANSMISSION_PEER_MODULE
 #include "libtransmission/transmission.h"

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -23,7 +23,7 @@
 #include <utility>
 #include <vector>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <small/vector.hpp>
 

--- a/libtransmission/peer-socket.cc
+++ b/libtransmission/peer-socket.cc
@@ -7,7 +7,7 @@
 #include <cerrno>
 #include <cstddef> // std::byte
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <libutp/utp.h>
 

--- a/libtransmission/platform.cc
+++ b/libtransmission/platform.cc
@@ -36,7 +36,7 @@
 #include <FindDirectory.h>
 #endif
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include "libtransmission/transmission.h"
 

--- a/libtransmission/port-forwarding.cc
+++ b/libtransmission/port-forwarding.cc
@@ -7,7 +7,7 @@
 #include <chrono>
 #include <memory>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #define LIBTRANSMISSION_PORT_FORWARDING_MODULE
 

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -12,7 +12,7 @@
 #include <string_view>
 #include <vector>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include "libtransmission/transmission.h"
 

--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -28,8 +28,8 @@
 #include <event2/http.h>
 #include <event2/listener.h>
 
-#include <fmt/core.h>
 #include <fmt/chrono.h>
+#include <fmt/format.h>
 
 #include <libdeflate.h>
 

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -17,7 +17,7 @@
 #include <utility>
 #include <vector>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <libdeflate.h>
 

--- a/libtransmission/session-id.cc
+++ b/libtransmission/session-id.cc
@@ -11,7 +11,7 @@
 #include <sys/stat.h>
 #endif
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include "libtransmission/crypto-utils.h" // for tr_rand_obj()
 #include "libtransmission/error-types.h"

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -26,7 +26,7 @@
 
 #include <event2/event.h>
 
-#include <fmt/core.h> // fmt::ptr
+#include <fmt/format.h> // fmt::ptr
 
 #include "libtransmission/transmission.h"
 

--- a/libtransmission/settings.cc
+++ b/libtransmission/settings.cc
@@ -12,7 +12,7 @@
 #include <string_view>
 #include <utility>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include "libtransmission/transmission.h"
 

--- a/libtransmission/subprocess-win32.cc
+++ b/libtransmission/subprocess-win32.cc
@@ -12,7 +12,7 @@
 #include <string>
 #include <string_view>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <fmt/xchar.h> // for wchar_t support
 
 #include <windows.h>

--- a/libtransmission/torrent-files.cc
+++ b/libtransmission/torrent-files.cc
@@ -15,7 +15,7 @@
 #include <string_view>
 #include <utility>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include "libtransmission/transmission.h"
 

--- a/libtransmission/torrent-magnet.cc
+++ b/libtransmission/torrent-magnet.cc
@@ -15,7 +15,7 @@
 #include <string_view>
 #include <utility> // std::move
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include "libtransmission/transmission.h"
 

--- a/libtransmission/torrent-metainfo.cc
+++ b/libtransmission/torrent-metainfo.cc
@@ -11,7 +11,7 @@
 #include <string_view>
 #include <vector>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include "libtransmission/transmission.h"
 

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -16,7 +16,7 @@
 #include <vector>
 
 #include <fmt/chrono.h>
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <small/map.hpp>
 

--- a/libtransmission/tr-dht.cc
+++ b/libtransmission/tr-dht.cc
@@ -30,7 +30,7 @@
 #include <netinet/in.h> /* sockaddr_in */
 #endif
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include "libtransmission/transmission.h"
 

--- a/libtransmission/tr-getopt.cc
+++ b/libtransmission/tr-getopt.cc
@@ -10,7 +10,7 @@
 #include <string>
 #include <string_view>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include "libtransmission/tr-getopt.h"
 #include "libtransmission/utils.h"

--- a/libtransmission/tr-lpd.cc
+++ b/libtransmission/tr-lpd.cc
@@ -25,7 +25,7 @@
 
 #include <event2/event.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include "libtransmission/transmission.h"
 

--- a/libtransmission/tr-strbuf.h
+++ b/libtransmission/tr-strbuf.h
@@ -9,7 +9,7 @@
 #include <string_view>
 #include <utility>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 /**
  * A memory buffer which uses a builtin array of N bytes, using heap

--- a/libtransmission/tr-udp.cc
+++ b/libtransmission/tr-udp.cc
@@ -16,7 +16,7 @@
 
 #include <event2/event.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include "libtransmission/log.h"
 #include "libtransmission/net.h"

--- a/libtransmission/tr-utp.cc
+++ b/libtransmission/tr-utp.cc
@@ -6,7 +6,6 @@
 #include <cstddef>
 #include <cstdint>
 
-#include <fmt/core.h>
 #include <fmt/format.h> // fmt::ptr
 
 #include <libutp/utp.h>

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -40,7 +40,7 @@
 
 #include <curl/curl.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <fast_float/fast_float.h>
 #include <wildmat.h>

--- a/libtransmission/values.h
+++ b/libtransmission/values.h
@@ -12,7 +12,7 @@
 #include <string>
 #include <string_view>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 namespace libtransmission::Values
 {

--- a/libtransmission/variant-benc.cc
+++ b/libtransmission/variant-benc.cc
@@ -14,8 +14,8 @@
 #include <string_view>
 #include <utility>
 
-#include <fmt/core.h>
 #include <fmt/compile.h>
+#include <fmt/format.h>
 
 #define LIBTRANSMISSION_VARIANT_MODULE
 

--- a/libtransmission/variant.cc
+++ b/libtransmission/variant.cc
@@ -18,7 +18,7 @@
 #include <share.h>
 #endif
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <small/vector.hpp>
 

--- a/libtransmission/watchdir-inotify.cc
+++ b/libtransmission/watchdir-inotify.cc
@@ -18,7 +18,7 @@
 #include <event2/bufferevent.h>
 #include <event2/event.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #define LIBTRANSMISSION_WATCHDIR_MODULE
 

--- a/libtransmission/watchdir-kqueue.cc
+++ b/libtransmission/watchdir-kqueue.cc
@@ -19,7 +19,7 @@
 
 #include <event2/event.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #define LIBTRANSMISSION_WATCHDIR_MODULE
 #include "libtransmission/transmission.h"

--- a/libtransmission/watchdir.cc
+++ b/libtransmission/watchdir.cc
@@ -7,7 +7,7 @@
 #include <string>
 #include <string_view>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #define LIBTRANSMISSION_WATCHDIR_MODULE
 

--- a/libtransmission/web-utils.cc
+++ b/libtransmission/web-utils.cc
@@ -14,7 +14,7 @@
 #include <string_view>
 #include <utility>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #define PSL_STATIC
 #include <libpsl.h>

--- a/libtransmission/web-utils.h
+++ b/libtransmission/web-utils.h
@@ -11,7 +11,7 @@
 #include <string_view>
 #include <utility>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include "libtransmission/tr-macros.h" // tr_sha1_digest_t
 

--- a/libtransmission/web.cc
+++ b/libtransmission/web.cc
@@ -35,7 +35,7 @@
 
 #include <event2/buffer.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #ifdef _WIN32
 #include "libtransmission/crypto-utils.h"

--- a/qt/RpcClient.cc
+++ b/qt/RpcClient.cc
@@ -5,7 +5,7 @@
 
 #include <string_view>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include "RpcClient.h"
 

--- a/qt/main.cc
+++ b/qt/main.cc
@@ -7,7 +7,7 @@
 #include <memory>
 #include <string_view>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <libtransmission/transmission.h>
 

--- a/tests/libtransmission/announce-list-test.cc
+++ b/tests/libtransmission/announce-list-test.cc
@@ -11,7 +11,7 @@
 #include <string_view>
 #include <vector>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <libtransmission/transmission.h>
 

--- a/tests/libtransmission/benc-test.cc
+++ b/tests/libtransmission/benc-test.cc
@@ -6,7 +6,7 @@
 #include <cstdint> // int64_t
 #include <string_view>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <libtransmission/benc.h>
 #include <libtransmission/error.h>

--- a/tests/libtransmission/dht-test.cc
+++ b/tests/libtransmission/dht-test.cc
@@ -30,7 +30,7 @@
 
 #include <event2/event.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <libtransmission/transmission.h>
 

--- a/tests/libtransmission/file-test.cc
+++ b/tests/libtransmission/file-test.cc
@@ -23,7 +23,7 @@
 #include <windows.h>
 #endif
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <libtransmission/error.h>
 #include <libtransmission/file.h>

--- a/tests/libtransmission/open-files-test.cc
+++ b/tests/libtransmission/open-files-test.cc
@@ -10,7 +10,7 @@
 #include <cstdint> // uint64_t
 #include <string_view>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <libtransmission/transmission.h>
 

--- a/tests/libtransmission/platform-test.cc
+++ b/tests/libtransmission/platform-test.cc
@@ -6,7 +6,7 @@
 #include <cstdlib>
 #include <string_view>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <libtransmission/transmission.h>
 

--- a/tests/libtransmission/subprocess-test-program.cc
+++ b/tests/libtransmission/subprocess-test-program.cc
@@ -6,7 +6,7 @@
 #include <libtransmission/file.h> // tr_sys_dir_get_current()
 #include <libtransmission/utils.h> // tr_env_get_string()
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <fmt/ostream.h>
 
 #include <fstream>

--- a/tests/libtransmission/utils-test.cc
+++ b/tests/libtransmission/utils-test.cc
@@ -19,7 +19,7 @@
 #define unsetenv(key) SetEnvironmentVariableA(key, nullptr)
 #endif
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <libtransmission/transmission.h>
 

--- a/utils/create.cc
+++ b/utils/create.cc
@@ -15,7 +15,7 @@
 #include <utility>
 #include <vector>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <libtransmission/transmission.h>
 

--- a/utils/edit.cc
+++ b/utils/edit.cc
@@ -10,7 +10,7 @@
 #include <string_view>
 #include <vector>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <libtransmission/error.h>
 #include <libtransmission/log.h>

--- a/utils/remote.cc
+++ b/utils/remote.cc
@@ -24,7 +24,7 @@
 #include <event2/buffer.h>
 
 #include <fmt/chrono.h>
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <libtransmission/transmission.h>
 

--- a/utils/show.cc
+++ b/utils/show.cc
@@ -19,7 +19,7 @@
 #include <vector>
 
 #include <fmt/chrono.h>
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <libtransmission/transmission.h>
 


### PR DESCRIPTION
`fmt/core.h` is a deprecated header in {fmt} v11, all it does now is `#include "fmt/format.h"`, and it's not in the docs anymore.

`fmt/base.h` now takes `fmt/core.h`'s place, but we have no reason to use it, since we are using the header-only variant of {fmt}.

Related: #5404