### PR TITLE
transmission-daemon man page: add missing long options

### DIFF
--- a/daemon/transmission-daemon.1
+++ b/daemon/transmission-daemon.1
@@ -47,14 +47,14 @@ Example: "127.0.0.*,192.168.1.*"
 .It Fl b Fl -blocklist
 Enable peer blocklists. Transmission understands the bluetack blocklist file format.
 New blocklists can be added by copying them into the config-dir's "blocklists" subdirectory.
-.It Fl c Ar directory
+.It Fl c Fl -watch-dir Ar directory
 Directory to watch for new .torrent files to be added. As they are added to this directory,
 the daemon will load them into Transmission.
 .It Fl C
 Do not watch for new .torrent files.
 .It Fl B Fl -no-blocklist
 Disable blocklists.
-.It Fl d
+.It Fl d Fl -dump-settings
 Dump transmission-daemon's settings to stderr.
 .It Fl f Fl -foreground
 Run in the foreground and print errors to stderr.


### PR DESCRIPTION
Saw that these two were missing while documenting them for `tldr`