### PR TITLE
build: support different install prefixes for daemon service file

### DIFF
--- a/daemon/CMakeLists.txt
+++ b/daemon/CMakeLists.txt
@@ -42,20 +42,20 @@ tr_win32_app_info(${TR_NAME}-daemon
     "${TR_NAME}-daemon"
     "${TR_NAME}-daemon.exe")
 
-foreach(P daemon)
+install(
+    TARGETS ${TR_NAME}-daemon
+    DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+if(INSTALL_DOC)
     install(
-        TARGETS ${TR_NAME}-${P}
-        DESTINATION ${CMAKE_INSTALL_BINDIR})
+        FILES ${TR_NAME}-daemon.1
+        DESTINATION ${CMAKE_INSTALL_MANDIR}/man1)
+endif()
 
-    if(INSTALL_DOC)
-        install(
-            FILES ${TR_NAME}-${P}.1
-            DESTINATION ${CMAKE_INSTALL_MANDIR}/man1)
-    endif()
+if (WITH_SYSTEMD)
+    configure_file("${TR_NAME}-daemon.service.in" "${TR_NAME}-daemon.service")
 
-    if (WITH_SYSTEMD)
-        install(
-            FILES ${TR_NAME}-${P}.service
-            DESTINATION lib/systemd/system)
-    endif()
-endforeach()
+    install(
+        FILES "${CMAKE_CURRENT_BINARY_DIR}/${TR_NAME}-daemon.service"
+        DESTINATION lib/systemd/system)
+endif()

--- a/daemon/CMakeLists.txt
+++ b/daemon/CMakeLists.txt
@@ -53,7 +53,7 @@ if(INSTALL_DOC)
 endif()
 
 if (WITH_SYSTEMD)
-    configure_file("${TR_NAME}-daemon.service.in" "${TR_NAME}-daemon.service")
+    configure_file("${TR_NAME}-daemon.service.in" "${TR_NAME}-daemon.service" @ONLY)
 
     install(
         FILES "${CMAKE_CURRENT_BINARY_DIR}/${TR_NAME}-daemon.service"

--- a/daemon/transmission-daemon.service.in
+++ b/daemon/transmission-daemon.service.in
@@ -2,12 +2,12 @@
 Description=Transmission BitTorrent Daemon
 Wants=network-online.target
 After=network-online.target
-Documentation=man:transmission-daemon(1)
+Documentation=man:@TR_NAME@-daemon(1)
 
 [Service]
 User=transmission
 Type=notify
-ExecStart=/usr/bin/transmission-daemon -f --log-level=error
+ExecStart=@CMAKE_INSTALL_FULL_BINDIR@/@TR_NAME@-daemon -f --log-level=error
 ExecReload=/bin/kill -s HUP $MAINPID
 
 # Hardening


### PR DESCRIPTION
Notes: The daemon systemd service file now uses the CMake install prefix.