### PR TITLE
fix: process failure response from a non-BEP-7 HTTP announcement

### DIFF
--- a/libtransmission/announcer-http.cc
+++ b/libtransmission/announcer-http.cc
@@ -166,6 +166,10 @@ void onAnnounceDone(tr_web::FetchResponse const& web_response)
             {
                 data->on_response(response.did_connect || response.did_timeout ? response : *data->previous_response);
             }
+            else if (data->requests_sent_count == 1U)
+            {
+                data->on_response(response);
+            }
         }
         else
         {


### PR DESCRIPTION
Regression from #7086

Fixed a bug where if an HTTP announce event only sent out 1 request, and the request failed, the response is not processed.
This can happen if program execution entered this branch:

https://github.com/transmission/transmission/blob/9e15394c65ecddf1b15f7225fa7a4fa29e302505/libtransmission/announcer-http.cc#L303

Fortunately, the bug is not present in any releases.
