### PR TITLE
Simplify logic around gettext/libintl use

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -627,7 +627,7 @@ jobs:
           echo '${{ toJSON(runner) }}'
           sw_vers
       - name: Get Dependencies
-        run: brew install --formulae cmake gettext ninja node pkgconf
+        run: brew install --formulae cmake ninja node pkgconf
       - name: Get Source
         uses: actions/download-artifact@v4
         with:
@@ -643,6 +643,7 @@ jobs:
             -DCMAKE_BUILD_TYPE=RelWithDebInfo \
             -DCMAKE_INSTALL_PREFIX=pfx \
             -DCMAKE_OSX_ARCHITECTURES='x86_64;arm64' \
+            -DCMAKE_DISABLE_FIND_PACKAGE_Intl=ON \
             -DENABLE_CLI=${{ (needs.what-to-make.outputs.make-cli == 'true') && 'ON' || 'OFF' }} \
             -DENABLE_DAEMON=${{ (needs.what-to-make.outputs.make-daemon == 'true') && 'ON' || 'OFF' }} \
             -DENABLE_GTK=OFF \

--- a/libtransmission/CMakeLists.txt
+++ b/libtransmission/CMakeLists.txt
@@ -3,10 +3,7 @@ include(CheckLibraryExists)
 include(CheckSymbolExists)
 
 if(ENABLE_NLS)
-    check_library_exists(intl libintl_gettext "" HAVE_LIBINTL)
-    if(HAVE_LIBINTL)
-        set(LIBINTL_LIBRARY intl)
-    endif()
+    find_package(Intl)
 endif()
 
 check_symbol_exists(SO_REUSEPORT "sys/types.h;sys/socket.h" HAVE_SO_REUSEPORT)
@@ -230,19 +227,13 @@ target_compile_definitions(${TR_NAME}
         $<$<STREQUAL:${CRYPTO_PKG},mbedtls>:WITH_MBEDTLS>
         $<$<STREQUAL:${CRYPTO_PKG},openssl>:WITH_OPENSSL>
         $<$<STREQUAL:${CRYPTO_PKG},wolfssl>:WITH_WOLFSSL>
-        $<$<NOT:$<BOOL:${ENABLE_NLS}>>:DISABLE_GETTEXT>)
+        $<$<BOOL:${Intl_FOUND}>:ENABLE_GETTEXT>)
 
 tr_target_compile_definitions_for_headers(${TR_NAME}
     PRIVATE
         sys/statvfs.h
         xfs/xfs.h
         xlocale.h)
-
-if(ENABLE_NLS)
-    tr_target_compile_definitions_for_headers(${TR_NAME}
-        PRIVATE
-            libintl.h)
-endif()
 
 tr_target_compile_definitions_for_functions(${TR_NAME}
     PRIVATE
@@ -259,17 +250,13 @@ tr_target_compile_definitions_for_functions(${TR_NAME}
         pread
         pwrite
         sendfile64
-        statvfs
-    PUBLIC
-        gettext
-        ngettext
-    REQUIRED_LIBS
-        $<$<BOOL:${HAVE_LIBINTL}>:${LIBINTL_LIBRARY}>) # gettext, ngettext
+        statvfs)
 
 target_include_directories(${TR_NAME}
     PUBLIC
         ${CMAKE_CURRENT_SOURCE_DIR}/..
-        ${CMAKE_CURRENT_BINARY_DIR}/..)
+        ${CMAKE_CURRENT_BINARY_DIR}/..
+        ${Intl_INCLUDE_DIRS})
 
 if(ANDROID)
     find_library(log-lib log)
@@ -287,7 +274,7 @@ target_link_libraries(${TR_NAME}
         dht::dht
         libutp::libutp
         libb64::libb64
-        ${LIBINTL_LIBRARY}
+        ${Intl_LIBRARIES}
         ${LIBM_LIBRARY}
         ${LIBQUOTA_LIBRARY}
         ${TR_NETWORK_LIBRARIES}

--- a/libtransmission/utils.h
+++ b/libtransmission/utils.h
@@ -25,30 +25,11 @@ struct tr_error;
  * @{
  */
 
-#if !defined(_)
-#if defined(HAVE_GETTEXT) && !defined(__APPLE__)
+#ifdef ENABLE_GETTEXT
 #include <libintl.h>
-#define _(a) gettext(a)
-#else
-#define _(a) (a)
-#endif
-#endif
-
-#if defined(HAVE_NGETTEXT)
+#define _ gettext
 #define tr_ngettext ngettext
 #else
-#define tr_ngettext(singular, plural, count) ((count) == 1 ? (singular) : (plural))
-#endif
-
-/* #define DISABLE_GETTEXT */
-#ifndef DISABLE_GETTEXT
-#if defined(_WIN32)
-#define DISABLE_GETTEXT
-#endif
-#endif
-#ifdef DISABLE_GETTEXT
-#undef _
-#undef tr_ngettext
 #define _(a) (a)
 #define tr_ngettext(singular, plural, count) ((count) == 1 ? (singular) : (plural))
 #endif


### PR DESCRIPTION
Use CMake-provided FindIntl module to look for the library and includes. Don't check for functions existence, both `gettext()` and `ngettext()` are available for ages now. Remove Windows- and Mac-specific logic, always use the functions if found and ENABLE_NLS is set to ON; for rare cases where their use is unwanted, one could set CMAKE_DISABLE_FIND_PACKAGE_Intl to ON.

Fixes: #7579