### PR TITLE
chore: silence clang-tidy warnings

### DIFF
--- a/libtransmission/cache.cc
+++ b/libtransmission/cache.cc
@@ -29,7 +29,7 @@ Cache::Key Cache::make_key(tr_torrent const& tor, tr_block_info::Location const 
     return std::make_pair(tor.id(), loc.block);
 }
 
-Cache::CIter Cache::find_span_end(CIter span_begin, CIter end) noexcept
+Cache::CIter Cache::find_span_end(CIter const& span_begin, CIter const& end) noexcept
 {
     static constexpr auto NotAdjacent = [](CacheBlock const& block1, CacheBlock const& block2)
     {
@@ -39,7 +39,7 @@ Cache::CIter Cache::find_span_end(CIter span_begin, CIter end) noexcept
     return span_end == end ? end : std::next(span_end);
 }
 
-std::pair<Cache::CIter, Cache::CIter> Cache::find_biggest_span(CIter const begin, CIter const end) noexcept
+std::pair<Cache::CIter, Cache::CIter> Cache::find_biggest_span(CIter const& begin, CIter const& end) noexcept
 {
     auto biggest_begin = begin;
     auto biggest_end = begin;
@@ -62,7 +62,7 @@ std::pair<Cache::CIter, Cache::CIter> Cache::find_biggest_span(CIter const begin
     return { biggest_begin, biggest_end };
 }
 
-int Cache::write_contiguous(CIter const begin, CIter const end) const
+int Cache::write_contiguous(CIter const& begin, CIter const& end) const
 {
     // The most common case without an extra data copy.
     auto const* out = std::data(*begin->buf);
@@ -185,7 +185,7 @@ int Cache::read_block(tr_torrent const& tor, tr_block_info::Location const& loc,
 
 // ---
 
-int Cache::flush_span(CIter const begin, CIter const end)
+int Cache::flush_span(CIter const& begin, CIter const& end)
 {
     for (auto span_begin = begin; span_begin < end;)
     {

--- a/libtransmission/cache.h
+++ b/libtransmission/cache.h
@@ -56,15 +56,15 @@ private:
 
     [[nodiscard]] static Key make_key(tr_torrent const& tor, tr_block_info::Location loc) noexcept;
 
-    [[nodiscard]] static std::pair<CIter, CIter> find_biggest_span(CIter begin, CIter end) noexcept;
+    [[nodiscard]] static std::pair<CIter, CIter> find_biggest_span(CIter const& begin, CIter const& end) noexcept;
 
-    [[nodiscard]] static CIter find_span_end(CIter span_begin, CIter end) noexcept;
+    [[nodiscard]] static CIter find_span_end(CIter const& span_begin, CIter const& end) noexcept;
 
     // @return any error code from tr_ioWrite()
-    [[nodiscard]] int write_contiguous(CIter begin, CIter end) const;
+    [[nodiscard]] int write_contiguous(CIter const& begin, CIter const& end) const;
 
     // @return any error code from writeContiguous()
-    [[nodiscard]] int flush_span(CIter begin, CIter end);
+    [[nodiscard]] int flush_span(CIter const& begin, CIter const& end);
 
     // @return any error code from writeContiguous()
     [[nodiscard]] int flush_biggest();

--- a/libtransmission/peer-mgr-wishlist.cc
+++ b/libtransmission/peer-mgr-wishlist.cc
@@ -390,7 +390,7 @@ private:
         }
     }
 
-    TR_CONSTEXPR20 void resort_piece(CandidateVec::iterator const pos_old)
+    TR_CONSTEXPR20 void resort_piece(CandidateVec::iterator const& pos_old)
     {
         if (candidates_dirty_)
         {


### PR DESCRIPTION
https://github.com/transmission/transmission/actions/runs/14796226536/job/41543893459

```
[72/136] Building CXX object libtransmission\CMakeFiles\transmission.dir\cache.cc.obj
D:\a\transmission\transmission\src\libtransmission\cache.cc:32:59: warning: the parameter 'end' is copied for each invocation but only used as a const reference; consider making it a const reference [performance-unnecessary-value-param]
   32 | Cache::CIter Cache::find_span_end(CIter span_begin, CIter end) noexcept
      |                                                           ^
      |                                                     const  &
D:\a\transmission\transmission\src\libtransmission\cache.cc:38:46: warning: parameter 'span_begin' is passed by value and only copied once; consider moving it to avoid unnecessary copies [performance-unnecessary-value-param]
   38 |     auto const span_end = std::adjacent_find(span_begin, end, NotAdjacent);
      |                                              ^         
      |                                              std::move()
D:\a\transmission\transmission\src\libtransmission\cache.cc:42:76: warning: the const qualified parameter 'begin' is copied for each invocation; consider making it a reference [performance-unnecessary-value-param]
   42 | std::pair<Cache::CIter, Cache::CIter> Cache::find_biggest_span(CIter const begin, CIter const end) noexcept
      |                                                                            ^
      |                                                                           &
D:\a\transmission\transmission\src\libtransmission\cache.cc:42:95: warning: the const qualified parameter 'end' is copied for each invocation; consider making it a reference [performance-unnecessary-value-param]
   42 | std::pair<Cache::CIter, Cache::CIter> Cache::find_biggest_span(CIter const begin, CIter const end) noexcept
      |                                                                                               ^
      |                                                                                              &
D:\a\transmission\transmission\src\libtransmission\cache.cc:65:41: warning: the const qualified parameter 'begin' is copied for each invocation; consider making it a reference [performance-unnecessary-value-param]
   65 | int Cache::write_contiguous(CIter const begin, CIter const end) const
      |                                         ^
      |                                        &
D:\a\transmission\transmission\src\libtransmission\cache.cc:65:60: warning: the const qualified parameter 'end' is copied for each invocation; consider making it a reference [performance-unnecessary-value-param]
   65 | int Cache::write_contiguous(CIter const begin, CIter const end) const
      |                                                            ^
      |                                                           &
D:\a\transmission\transmission\src\libtransmission\cache.cc:188:35: warning: the const qualified parameter 'begin' is copied for each invocation; consider making it a reference [performance-unnecessary-value-param]
  188 | int Cache::flush_span(CIter const begin, CIter const end)
      |                                   ^
      |                                  &
D:\a\transmission\transmission\src\libtransmission\cache.cc:188:54: warning: the const qualified parameter 'end' is copied for each invocation; consider making it a reference [performance-unnecessary-value-param]
  188 | int Cache::flush_span(CIter const begin, CIter const end)
      |                                                      ^
      |                                                     &
```

```
[90/136] Building CXX object libtransmission\CMakeFiles\transmission.dir\peer-mgr-wishlist.cc.obj
D:\a\transmission\transmission\src\libtransmission\peer-mgr-wishlist.cc:393:67: warning: the const qualified parameter 'pos_old' is copied for each invocation; consider making it a reference [performance-unnecessary-value-param]
  393 |     TR_CONSTEXPR20 void resort_piece(CandidateVec::iterator const pos_old)
      |                                                                   ^
      |                                                                  &
```