### PR TITLE
chore: move `.gitattributes` to root of repository

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,7 @@
+# libtransmission
 libtransmission/mime-types.h linguist-generated=true
+
+# web
+web/package.json.buildonly linguist-generated=true
+web/public_html/transmission-app.* linguist-generated=true
+web/public_html/transmission-app.js -diff -merge

--- a/web/.gitattributes
+++ b/web/.gitattributes
@@ -1,2 +1,0 @@
-transmission-app.js -diff -merge
-transmission-app.js linguist-generated=true


### PR DESCRIPTION
According to https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github, `linguist-generated=true` works only inside the `.gitattributes` file located at the root of the repository.

> Unless the *.gitattributes* file already exists, create a *.gitattributes* file in the root of the repository.