### PR TITLE
fixup! chore: move away from fmt/core.h (#7557)

### DIFF
--- a/libtransmission/file-posix.cc
+++ b/libtransmission/file-posix.cc
@@ -52,7 +52,7 @@
 #define USE_COPY_FILE_RANGE
 #endif /* __linux__ */
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include "libtransmission/error.h"
 #include "libtransmission/file.h"

--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -12,7 +12,7 @@
 #include <tuple>
 #include <utility>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include "libtransmission/transmission.h"
 

--- a/libtransmission/log.cc
+++ b/libtransmission/log.cc
@@ -19,7 +19,7 @@
 #endif
 
 #include <fmt/chrono.h>
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <small/map.hpp>
 

--- a/libtransmission/open-files.cc
+++ b/libtransmission/open-files.cc
@@ -9,7 +9,7 @@
 #include <string_view>
 #include <utility>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include "libtransmission/transmission.h"
 

--- a/libtransmission/port-forwarding-natpmp.cc
+++ b/libtransmission/port-forwarding-natpmp.cc
@@ -14,7 +14,7 @@
 
 #include <event2/util.h> /* evutil_inet_ntop() */
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #define ENABLE_STRNATPMPERR
 #include "natpmp.h"

--- a/libtransmission/port-forwarding-upnp.cc
+++ b/libtransmission/port-forwarding-upnp.cc
@@ -13,7 +13,7 @@
 #include <thread>
 #include <utility>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <miniupnpc/miniupnpc.h>
 #include <miniupnpc/upnpcommands.h>

--- a/libtransmission/subprocess-posix.cc
+++ b/libtransmission/subprocess-posix.cc
@@ -15,7 +15,7 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include "libtransmission/error.h"
 #include "libtransmission/subprocess.h"

--- a/libtransmission/variant-json.cc
+++ b/libtransmission/variant-json.cc
@@ -16,7 +16,7 @@
 #include <utility>
 #include <variant>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <rapidjson/encodedstream.h>
 #include <rapidjson/encodings.h>

--- a/libtransmission/watchdir-win32.cc
+++ b/libtransmission/watchdir-win32.cc
@@ -17,7 +17,7 @@
 #include <event2/event.h>
 #include <event2/util.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #define LIBTRANSMISSION_WATCHDIR_MODULE
 

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -16,7 +16,7 @@
 
 #include <event2/buffer.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include "libtransmission/transmission.h"
 


### PR DESCRIPTION
Missed some in #7557.