### PR TITLE
Print error log to stderr

### DIFF
--- a/libtransmission/log.cc
+++ b/libtransmission/log.cc
@@ -142,7 +142,7 @@ void logAddImpl(
         }
         else
         {
-            fmt::print("[{:s}] {:s}: {:s}\n", timestr, name, msg);
+            fmt::print(stderr, "[{:s}] {:s}: {:s}\n", timestr, name, msg);
         }
     }
 #endif


### PR DESCRIPTION
Several error messages are printed to `stdout` instead of `stderr`. E.g.

`[<time_stamp>] ... at <tracker>: Announce error: IPv4 connection failed (Retrying in 313 seconds) (udp://<tracker>)`
`[<time_stamp>] <tracker>: Couldn't look up '<tracker>' in IPv6: Name or service not known (-2)`
