### PR TITLE
fix: use correct defines when building libpsl with Xcode after roll.

### DIFF
--- a/Transmission.xcodeproj/project.pbxproj
+++ b/Transmission.xcodeproj/project.pbxproj
@@ -4935,7 +4935,7 @@
 				HEADER_SEARCH_PATHS = "third-party/libpsl/include";
 				OTHER_CFLAGS = (
 					"$(inherited)",
-					"-DFORCE_BUILTIN_LIST=1",
+					"-DENABLE_BUILTIN=1",
 				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
@@ -4950,7 +4950,7 @@
 				HEADER_SEARCH_PATHS = "third-party/libpsl/include";
 				OTHER_CFLAGS = (
 					"$(inherited)",
-					"-DFORCE_BUILTIN_LIST=1",
+					"-DENABLE_BUILTIN=1",
 				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
@@ -4965,7 +4965,7 @@
 				HEADER_SEARCH_PATHS = "third-party/libpsl/include";
 				OTHER_CFLAGS = (
 					"$(inherited)",
-					"-DFORCE_BUILTIN_LIST=1",
+					"-DENABLE_BUILTIN=1",
 				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};


### PR DESCRIPTION
Crashes on [assert here](https://github.com/transmission/transmission/blob/f7373cb6483bd624c065cdc5a3b53908ee9b1902/libtransmission/web-utils.cc#L256)

Broken after https://github.com/transmission/transmission/pull/7575

Define was [changed here](https://github.com/transmission/libpsl/compare/692c69d2415e1b20378030c08607935a54434087...f88562a8d9bf79d9fb74f59b7bc5a22ee6664fda#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20a)