### PR TITLE
perf: cache folder nodes

### DIFF
--- a/macosx/FileListNode.mm
+++ b/macosx/FileListNode.mm
@@ -44,7 +44,6 @@
 - (void)insertChild:(FileListNode*)child
 {
     NSAssert(_isFolder, @"method can only be invoked on folders");
-
     [_children addObject:child];
 }
 


### PR DESCRIPTION
On torrents with a large number of folders, creating the file list can take a lot of time since it has to go over all folders in the same parent every time it adds a new one. By using a dictionary we can cut down on that time.

Before:
<img width="1455" alt="Screenshot 2025-06-17 at 10 29 41 AM" src="https://github.com/user-attachments/assets/4321cc1f-962c-44ce-816d-e5dc7ab67c9e" />
~15 seconds before finishing AppKit initialization, ~10 seconds creating file list

After:
<img width="1183" alt="Screenshot 2025-06-17 at 10 29 20 AM" src="https://github.com/user-attachments/assets/3a3913d2-9745-4fb7-8b69-2ac8044ff2df" />
~10 seconds before finishing AppKit initialization, ~5 seconds creating file list