### PR TITLE
fix: include wolfssl library configurations header

### DIFF
--- a/libtransmission/crypto-utils.h
+++ b/libtransmission/crypto-utils.h
@@ -32,6 +32,7 @@ using tr_sha256_context_t = mbedtls_sha256_context;
 using tr_sha1_context_t = EVP_MD_CTX*;
 using tr_sha256_context_t = EVP_MD_CTX*;
 #elif defined(WITH_WOLFSSL)
+#include <wolfssl/options.h>
 #include <wolfssl/wolfcrypt/sha.h>
 #include <wolfssl/wolfcrypt/sha256.h>
 using tr_sha1_context_t = wc_Sha;


### PR DESCRIPTION
This fixes

```
  In file included from /home/runner/work/transmission/transmission/src/libtransmission/../libtransmission/crypto-utils.h:35:
  In file included from /usr/local/include/wolfssl/wolfcrypt/sha.h:30:
  In file included from /usr/local/include/wolfssl/wolfcrypt/types.h:34:
  /usr/local/include/wolfssl/wolfcrypt/settings.h:349:6: warning: "No configuration for wolfSSL detected, check header order" [-W#warnings]
    349 |     #warning "No configuration for wolfSSL detected, check header order"
        |      ^
  /usr/local/include/wolfssl/wolfcrypt/settings.h:3732:14: warning: "For timing resistance / side-channel attack prevention consider using harden options" [-W#warnings]
   3732 |             #warning "For timing resistance / side-channel attack prevention consider using harden options"
        |              ^
  2 warnings generated.
```

From WolfSSL's FAQ:

>The MOST common issue we see is a mis-configuration between APP and Library. If you compile the wolfSSL library independant of your application you MUST include the same configure options in the application as were used in the library.
>
>If building with “./configure” the build system will generate the file <wolf-root>/wolfssl/options.h with all the settings needed for your application.

Source: https://www.wolfssl.com/docs/frequently-asked-questions-faq/#How_do_I_manage_the_build_configuration_for_wolfSSL