### PR TITLE
build: define `GDK_VERSION_MIN_REQUIRED`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -332,6 +332,7 @@ if(ENABLE_GTK)
             giomm-2.68>=${GIOMM_MINIMUM})
         set(GTK_VERSION 4)
         set(GTK_FOUND ${GTK4_FOUND})
+        set(GTKMM_MINIMUM ${GTKMM4_MINIMUM})
     endif()
 
     if(NOT GTK_FOUND AND (USE_GTK_VERSION STREQUAL "AUTO" OR USE_GTK_VERSION EQUAL 3))
@@ -341,6 +342,7 @@ if(ENABLE_GTK)
             giomm-2.4>=${GIOMM_MINIMUM})
         set(GTK_VERSION 3)
         set(GTK_FOUND ${GTK3_FOUND})
+        set(GTKMM_MINIMUM ${GTKMM3_MINIMUM})
     endif()
 
     if(GTK_IS_REQUIRED AND NOT GTK_FOUND)
@@ -378,6 +380,14 @@ if(GTK_FOUND)
     target_link_libraries(transmission::gtk_impl
         INTERFACE
             ${GTK${GTK_VERSION}_LIBRARIES})
+
+    if(GTKMM_MINIMUM MATCHES "^([0-9]+)\.([0-9]+)\.")
+        # GDK_VERSION_x_y is only defined for stable versions, i.e. even minor version numbers
+        math(EXPR GTKMM_MINIMUM_MINOR_STABLE "(${CMAKE_MATCH_2} + 1) / 2 * 2")
+        target_compile_definitions(transmission::gtk_impl
+            INTERFACE
+                GDK_VERSION_MIN_REQUIRED=GDK_VERSION_${CMAKE_MATCH_1}_${GTKMM_MINIMUM_MINOR_STABLE})
+    endif()
 endif()
 
 if(ENABLE_QT)


### PR DESCRIPTION
This suppresses deprecation warnings in newer GDK versions that weren't in the version that comes with our minimum GTKMM version. An example of such warnings with GDK 4.18:

```
  [259/315] Building CXX object gtk/CMakeFiles/transmission-gtk.dir/Utils.cc.o
  FAILED: gtk/CMakeFiles/transmission-gtk.dir/Utils.cc.o 
  /usr/bin/c++ -DENABLE_GETTEXT -DFMT_EXCEPTIONS=0 -DFMT_HEADER_ONLY=1 -DGETTEXT_PACKAGE=\"transmission-gtk\" -DSMALL_DISABLE_EXCEPTIONS=1 -DTRANSMISSIONLOCALEDIR=\"/home/runner/work/transmission/transmission/pfx/share/locale\" -DWITH_OPENSSL -DWITH_UTP -I/home/runner/work/transmission/transmission/obj/gtk -I/home/runner/work/transmission/transmission/src/libtransmission/.. -I/home/runner/work/transmission/transmission/obj/libtransmission/.. -isystem /usr/local/include -isystem /home/runner/work/transmission/transmission/src/third-party/fmt/include -isystem /home/runner/work/transmission/transmission/src/third-party/small/include -isystem /home/runner/work/transmission/transmission/obj/third-party/libevent.bld/pfx/include -isystem /usr/local/include/gtkmm-4.0 -isystem /usr/local/lib/gtkmm-4.0/include -isystem /usr/local/include/pangomm-2.48 -isystem /usr/local/lib/pangomm-2.48/include -isystem /usr/local/include/cairomm-1.16 -isystem /usr/local/lib/cairomm-1.16/include -isystem /usr/local/include/gtk-4.0/unix-print -isystem /usr/local/include/gtk-4.0 -isystem /usr/local/include/pango-1.0 -isystem /usr/local/include/harfbuzz -isystem /usr/local/include/fribidi -isystem /usr/X11R6/include -isystem /usr/local/include/gdk-pixbuf-2.0 -isystem /usr/local/include/cairo -isystem /usr/local/include/libpng16 -isystem /usr/X11R6/include/freetype2 -isystem /usr/X11R6/include/pixman-1 -isystem /usr/local/include/graphene-1.0 -isystem /usr/local/lib/graphene-1.0/include -isystem /usr/local/include/giomm-2.68 -isystem /usr/local/lib/giomm-2.68/include -isystem /usr/local/include/gio-unix-2.0 -isystem /usr/local/include/glibmm-2.68 -isystem /usr/local/lib/glibmm-2.68/include -isystem /usr/local/include/glib-2.0 -isystem /usr/local/lib/glib-2.0/include -isystem /usr/local/include/sigc++-3.0 -isystem /usr/local/lib/sigc++-3.0/include -O2 -g -DNDEBUG -std=gnu++17 -W -Wall -Wextra -Wcast-align -Wextra-semi -Wextra-semi-stmt -Wextra-tokens -Wfloat-equal -Wgnu -Winit-self -Wint-in-bool-context -Wmissing-format-attribute -Wnull-dereference -Wpointer-arith -Wredundant-decls -Wredundant-move -Wreorder-ctor -Wreturn-std-move -Wself-assign -Wself-move -Wsemicolon-before-method-body -Wsentinel -Wshadow -Wsign-compare -Wsometimes-uninitialized -Wstring-conversion -Wsuggest-destructor-override -Wsuggest-override -Wuninitialized -Wunreachable-code -Wunused -Wunused-const-variable -Wunused-parameter -Wunused-result -Wwrite-strings -Wformat-security -Werror -Wno-exit-time-destructors -mfpmath=sse -msse -msse2 -pthread -MD -MT gtk/CMakeFiles/transmission-gtk.dir/Utils.cc.o -MF gtk/CMakeFiles/transmission-gtk.dir/Utils.cc.o.d -o gtk/CMakeFiles/transmission-gtk.dir/Utils.cc.o -c /home/runner/work/transmission/transmission/src/gtk/Utils.cc
  /home/runner/work/transmission/transmission/src/gtk/Utils.cc:828:9: error: 'gdk_x11_surface_set_skip_taskbar_hint' is deprecated [-Werror,-Wdeprecated-declarations]
          gdk_x11_surface_set_skip_taskbar_hint(surface, value ? TRUE : FALSE);
          ^
  /usr/local/include/gtk-4.0/gdk/x11/gdkx11surface.h:107:1: note: 'gdk_x11_surface_set_skip_taskbar_hint' has been explicitly marked deprecated here
  GDK_DEPRECATED_IN_4_18
  ^
  /usr/local/include/gtk-4.0/gdk/version/gdk-visibility.h:343:32: note: expanded from macro 'GDK_DEPRECATED_IN_4_18'
  #define GDK_DEPRECATED_IN_4_18 GDK_DEPRECATED
                                 ^
  /usr/local/include/gtk-4.0/gdk/version/gdk-visibility.h:30:24: note: expanded from macro 'GDK_DEPRECATED'
  #define GDK_DEPRECATED G_DEPRECATED _GDK_EXTERN
                         ^
  /usr/local/include/glib-2.0/glib/gmacros.h:1267:37: note: expanded from macro 'G_DEPRECATED'
  #define G_DEPRECATED __attribute__((__deprecated__))
                                      ^
  /home/runner/work/transmission/transmission/src/gtk/Utils.cc:842:9: error: 'gdk_x11_surface_set_urgency_hint' is deprecated [-Werror,-Wdeprecated-declarations]
          gdk_x11_surface_set_urgency_hint(surface, value ? TRUE : FALSE);
          ^
  /usr/local/include/gtk-4.0/gdk/x11/gdkx11surface.h:113:1: note: 'gdk_x11_surface_set_urgency_hint' has been explicitly marked deprecated here
  GDK_DEPRECATED_IN_4_18
  ^
  /usr/local/include/gtk-4.0/gdk/version/gdk-visibility.h:343:32: note: expanded from macro 'GDK_DEPRECATED_IN_4_18'
  #define GDK_DEPRECATED_IN_4_18 GDK_DEPRECATED
                                 ^
  /usr/local/include/gtk-4.0/gdk/version/gdk-visibility.h:30:24: note: expanded from macro 'GDK_DEPRECATED'
  #define GDK_DEPRECATED G_DEPRECATED _GDK_EXTERN
                         ^
  /usr/local/include/glib-2.0/glib/gmacros.h:1267:37: note: expanded from macro 'G_DEPRECATED'
  #define G_DEPRECATED __attribute__((__deprecated__))
                                      ^
  2 errors generated.
```