### PR TITLE
fix: don't halt udp tracker requests if dns is pending

### DIFF
--- a/libtransmission/announcer-udp.cc
+++ b/libtransmission/announcer-udp.cc
@@ -414,16 +414,7 @@ struct tau_tracker
                     [this](tr_address_type ip_protocol) { return lookup(ip_protocol); },
                     static_cast<tr_address_type>(ipp));
             }
-        }
 
-        // are there any dns requests pending?
-        if (is_dns_pending())
-        {
-            return;
-        }
-
-        for (ipp_t ipp = 0; ipp < NUM_TR_AF_INET_TYPES; ++ipp)
-        {
             auto const ipp_enum = static_cast<tr_address_type>(ipp);
             auto& conn_at = connecting_at[ipp];
             logtrace(
@@ -477,11 +468,6 @@ private:
     [[nodiscard]] constexpr bool is_connected(tr_address_type ip_protocol, time_t now) const noexcept
     {
         return connection_id[ip_protocol] != tau_connection_t{} && now < connection_expiration_time[ip_protocol];
-    }
-
-    [[nodiscard]] TR_CONSTEXPR20 bool is_dns_pending() const noexcept
-    {
-        return std::any_of(std::begin(addr_pending_dns_), std::end(addr_pending_dns_), [](auto const& o) { return !!o; });
     }
 
     [[nodiscard]] TR_CONSTEXPR20 bool has_addr() const noexcept
@@ -589,8 +575,7 @@ private:
 
     void maybe_send_requests(time_t now)
     {
-        TR_ASSERT(!is_dns_pending());
-        if (is_dns_pending() || !has_addr())
+        if (!has_addr())
         {
             return;
         }


### PR DESCRIPTION
Fix a problem on BSD where UDP announces to IPv6-only trackers are being delayed for 10+ seconds.

This is caused by a combination of 2 factors:

1. The UDP tracker upkeep loop would exit early when it sees pending DNS queries, the code for sending BEP-15 connection requests and everything after it will not be reached. (This is what this PR changes)
2. `getaddrinfo` on BSD will block for 10+ seconds if you try to resolve an IPv6 address in IPv4. (e.g. `getaddrinfo("::1", "443", &hints, &res)` with `hints.ai_family == AF_INET`)

So `getaddrinfo` will block, and every `tau_tracker::upkeep()` invocation in the next 10+ seconds will exit early.

(1) is a relic from back when Transmission only supported IPv4 UDP trackers. Exiting early from the loop cycle when a DNS query is pending made sense, because that query was THE prerequisite for doing any UDP tracker stuff. I kept this without giving it enough thought when writing #6687 for dual-stack UDP tracker support.

With dual-stack UDP trackers, this early exit behaviour does not make sense because IPv4 and IPv6 are essentially 2 separate trackers. IPv6 can go on with their business even if the IPv4 DNS query is stuck.

This PR does not need notes because dual-stack UDP tracker support is not released.