### PR TITLE
build: don't add third-party submodules to user package registry

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.16.3 FATAL_ERROR)
 
+cmake_policy(SET CMP0090 NEW)
 cmake_policy(SET CMP0092 NEW)
 if(POLICY CMP0114)
     cmake_policy(SET CMP0114 NEW)


### PR DESCRIPTION
Don't insert our third-party submodules to CMake's user package registry.

For example, as of d6e78d11ea706b6d6bf95042756483a40baf873b, just configuring the Transmission CMake project without a system libevent installation will insert the build's libevent binary folder to the user package registry.

Other CMake projects might accidentally find these packages, which was only meant for Transmission, and produce confusing build errors. Other build configurations of Transmission will also find these packages, though they rarely cause a problem in this case.

Ref: https://cmake.org/cmake/help/latest/policy/CMP0090.html

Notes: Configuring Transmission's CMake project will no longer insert the third-party submodules to CMake's user package registry.