### PR TITLE
Replace invalid utf8 in peer client user-agent

### DIFF
--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -1304,7 +1304,7 @@ void tr_peerMsgsImpl::parse_ltep_handshake(MessageReader& payload)
     // peer id encoding.
     if (auto sv = std::string_view{}; tr_variantDictFindStrView(&*var, TR_KEY_v, &sv))
     {
-        set_user_agent(tr_interned_string{ sv });
+        set_user_agent(tr_interned_string{ tr_strv_replace_invalid(sv) });
     }
 
     /* get peer's listening port */


### PR DESCRIPTION
If peer's client is using non-utf8 in its User-Agent (aka client name), the Transmission (version 4.1.0~beta2+dfsg-3) crashes. This fix sanitizes the string.