### PR TITLE
feat(web): enhance search functionality to include download directory

### DIFF
--- a/web/src/torrent.js
+++ b/web/src/torrent.js
@@ -402,8 +402,7 @@ export class Torrent extends EventTarget {
       const searchLower = search.toLowerCase();
       const nameMatch = this.getCollatedName().includes(searchLower);
       const location = this.getDownloadDir()?.toLowerCase() ?? '';
-      const locationMatch = location.includes(searchLower);
-      pass = nameMatch || locationMatch;
+      pass = nameMatch || (location).includes(searchLower);
     }
 
     // maybe filter by labels...


### PR DESCRIPTION
in the filter box i added download directory as the filter (OR). i require this functionality so that i can easily filter a lot of downloads for a certain directory since i store the downloads by directory per series. perhaps someone else also want this.

Notes: Added download directory for search instead of just torrent name.