### PR TITLE
feat(web): add autocompletion for destination folder input when adding new torrent

### DIFF
--- a/web/src/open-dialog.js
+++ b/web/src/open-dialog.js
@@ -192,8 +192,7 @@ export class OpenDialog extends EventTarget {
     input.addEventListener('change', () => this._updateFreeSpaceInAddDialog());
     input.value = this.controller.session_properties.download_dir;
     workarea.append(input);
-
-    const buildDatalist = () => {
+    workarea.append((() => {
       const datalist = document.createElement('datalist');
       datalist.id = 'add-dialog-folder-datalist';
       const dirs = new Set();
@@ -211,8 +210,7 @@ export class OpenDialog extends EventTarget {
         }
       }
       return datalist;
-    };
-    workarea.append(buildDatalist());
+    })());
     elements.folder_input = input;
 
     const checkarea = document.createElement('div');


### PR DESCRIPTION
sometimes i need to add multiple torrents manually via the web gui into the same folder and it really slows me down typing/copy pasting the same full path every single time. with `datalist` it will help me a lot and avoid typos.

Notes: Added autocompletion to folder path input with datalist.