### PR TITLE
build: conditionally compile `utils.mm` using generator expression

### DIFF
--- a/libtransmission/CMakeLists.txt
+++ b/libtransmission/CMakeLists.txt
@@ -14,6 +14,11 @@ add_compile_options(
 
 add_library(${TR_NAME} STATIC)
 
+set(IS_APPLE_CLANG FALSE)
+if(APPLE AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    set(IS_APPLE_CLANG TRUE)
+endif()
+
 target_sources(${TR_NAME}
     PRIVATE
         announce-list.cc
@@ -156,7 +161,7 @@ target_sources(${TR_NAME}
         utils-ev.h
         utils.cc
         utils.h
-        utils.mm
+        $<$<BOOL:${IS_APPLE_CLANG}>:utils.mm>
         variant-benc.cc
         variant-json.cc
         variant.cc
@@ -201,8 +206,6 @@ tr_allow_compile_if(
         watchdir-inotify.cc
     [=[[WITH_KQUEUE]]=]
         watchdir-kqueue.cc
-    [=[[APPLE AND CMAKE_CXX_COMPILER_ID MATCHES "Clang"]]=]
-        utils.mm
     [=[[WIN32]]=]
         file-win32.cc
         subprocess-win32.cc


### PR DESCRIPTION
This PR removes `libtransmission/utils.mm` from the source list when not on Apple and not on Clang, so that CMake will not try to find an Obj-c++ compiler.

This fixes the error shown below, which can be seen when generating build files on Arch Linux running CMake 4.1.1 and gcc 15.2.1 without the obj-c frontend `cc1objplus` installed:

```
Cannot get compiler information:
	Compiler exited with error code 1: /usr/bin/c++ -xobjective-c++ -DENABLE_GETTEXT -DFMT_EXCEPTIONS=0 -DFMT_HEADER_ONLY=1 -DHAVE_COPY_FILE_RANGE -DHAVE_FALLOCATE64 -DHAVE_FLOCK -DHAVE_GETMNTENT -DHAVE_MKDTEMP -DHAVE_POSIX_FADVISE -DHAVE_POSIX_FALLOCATE -DHAVE_PREAD -DHAVE_PWRITE -DHAVE_SENDFILE64 -DHAVE_SO_REUSEPORT=1 -DHAVE_STATVFS -DHAVE_SYS_STATVFS_H -DMINIUPNP_STATICLIB -DNATPMP_STATICLIB -DPACKAGE_DATA_DIR=\"/usr/local/share\" -DPOSIX -DRAPIDJSON_HAS_STDSTRING=1 -DSMALL_DISABLE_EXCEPTIONS=1 -DWIDE_INTEGER_DISABLE_FLOAT_INTEROP -DWIDE_INTEGER_DISABLE_IOSTREAM -DWIDE_INTEGER_HAS_LIMB_TYPE_UINT64 -DWITH_INOTIFY -DWITH_OPENSSL -DWITH_UTP -D__TRANSMISSION__ -isystem/path/to/transmission/third-party/fast_float/include -isystem/path/to/transmission/cmake-build-debug/third-party/libnatpmp.bld/pfx/include -isystem/path/to/transmission/cmake-build-debug/third-party/miniupnp/miniupnpc.bld/pfx/include -isystem/path/to/transmission/cmake-build-debug/third-party/dht.bld/pfx/include -isystem/path/to/transmission/third-party/rapidjson/include -isystem/path/to/transmission/third-party/utfcpp/source -isystem/path/to/transmission/third-party/wide-integer -isystem/path/to/transmission/third-party/fmt/include -isystem/path/to/transmission/third-party/small/include -g -std=gnu++17 -W -Wall -Wextra -Wcast-align -Wduplicated-cond -Wextra-semi -Wfloat-equal -Winit-self -Wint-in-bool-context -Wlogical-op -Wmissing-format-attribute -Wnull-dereference -Wpointer-arith -Wredundant-decls -Wredundant-move -Wrestrict -Wself-move -Wshadow -Wsign-compare -Wsuggest-override -Wuninitialized -Wunreachable-code -Wunused -Wunused-const-variable -Wunused-parameter -Wunused-result -Wwrite-strings -fpch-preprocess -v -dD -E
	Using built-in specs.
	COLLECT_GCC=/usr/bin/c++
	Target: x86_64-pc-linux-gnu
	Configured with: /build/gcc/src/gcc/configure --enable-languages=ada,c,c++,d,fortran,go,lto,m2,objc,obj-c++,rust,cobol --enable-bootstrap --prefix=/usr --libdir=/usr/lib --libexecdir=/usr/lib --mandir=/usr/share/man --infodir=/usr/share/info --with-bugurl=https://gitlab.archlinux.org/archlinux/packaging/packages/gcc/-/issues --with-build-config=bootstrap-lto --with-linker-hash-style=gnu --with-system-zlib --enable-__cxa_atexit --enable-cet=auto --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-default-ssp --enable-gnu-indirect-function --enable-gnu-unique-object --enable-libstdcxx-backtrace --enable-link-serialization=1 --enable-linker-build-id --enable-lto --enable-multilib --enable-plugin --enable-shared --enable-threads=posix --disable-libssp --disable-libstdcxx-pch --disable-werror
	Thread model: posix
	Supported LTO compression algorithms: zlib zstd
	gcc version 15.2.1 20250813 (GCC) 
	COLLECT_GCC_OPTIONS='-D' 'ENABLE_GETTEXT' '-D' 'FMT_EXCEPTIONS=0' '-D' 'FMT_HEADER_ONLY=1' '-D' 'HAVE_COPY_FILE_RANGE' '-D' 'HAVE_FALLOCATE64' '-D' 'HAVE_FLOCK' '-D' 'HAVE_GETMNTENT' '-D' 'HAVE_MKDTEMP' '-D' 'HAVE_POSIX_FADVISE' '-D' 'HAVE_POSIX_FALLOCATE' '-D' 'HAVE_PREAD' '-D' 'HAVE_PWRITE' '-D' 'HAVE_SENDFILE64' '-D' 'HAVE_SO_REUSEPORT=1' '-D' 'HAVE_STATVFS' '-D' 'HAVE_SYS_STATVFS_H' '-D' 'MINIUPNP_STATICLIB' '-D' 'NATPMP_STATICLIB' '-D' 'PACKAGE_DATA_DIR="/usr/local/share"' '-D' 'POSIX' '-D' 'RAPIDJSON_HAS_STDSTRING=1' '-D' 'SMALL_DISABLE_EXCEPTIONS=1' '-D' 'WIDE_INTEGER_DISABLE_FLOAT_INTEROP' '-D' 'WIDE_INTEGER_DISABLE_IOSTREAM' '-D' 'WIDE_INTEGER_HAS_LIMB_TYPE_UINT64' '-D' 'WITH_INOTIFY' '-D' 'WITH_OPENSSL' '-D' 'WITH_UTP' '-D' '__TRANSMISSION__' '-isystem' '/path/to/transmission/third-party/fast_float/include' '-isystem' '/path/to/transmission/cmake-build-debug/third-party/libnatpmp.bld/pfx/include' '-isystem' '/path/to/transmission/cmake-build-debug/third-party/miniupnp/miniupnpc.bld/pfx/include' '-isystem' '/path/to/transmission/cmake-build-debug/third-party/dht.bld/pfx/include' '-isystem' '/path/to/transmission/third-party/rapidjson/include' '-isystem' '/path/to/transmission/third-party/utfcpp/source' '-isystem' '/path/to/transmission/third-party/wide-integer' '-isystem' '/path/to/transmission/third-party/fmt/include' '-isystem' '/path/to/transmission/third-party/small/include' '-g' '-std=gnu++17' '-Wall' '-Wextra' '-Wcast-align' '-Wduplicated-cond' '-Wextra-semi' '-Wfloat-equal' '-Winit-self' '-Wint-in-bool-context' '-Wlogical-op' '-Wsuggest-attribute=format' '-Wnull-dereference' '-Wpointer-arith' '-Wredundant-decls' '-Wredundant-move' '-Wrestrict' '-Wself-move' '-Wshadow' '-Wsign-compare' '-Wsuggest-override' '-Wuninitialized' '-Wunused' '-Wunused-const-variable=2' '-Wunused-parameter' '-Wunused-result' '-Wwrite-strings' '-fpch-preprocess' '-v' '-dD' '-E' '-D' '___CIDR_DEFINITIONS_END' '-shared-libgcc' '-mtune=generic' '-march=x86-64'
	 cc1objplus -E -quiet -v -D_GNU_SOURCE -D ENABLE_GETTEXT -D FMT_EXCEPTIONS=0 -D FMT_HEADER_ONLY=1 -D HAVE_COPY_FILE_RANGE -D HAVE_FALLOCATE64 -D HAVE_FLOCK -D HAVE_GETMNTENT -D HAVE_MKDTEMP -D HAVE_POSIX_FADVISE -D HAVE_POSIX_FALLOCATE -D HAVE_PREAD -D HAVE_PWRITE -D HAVE_SENDFILE64 -D HAVE_SO_REUSEPORT=1 -D HAVE_STATVFS -D HAVE_SYS_STATVFS_H -D MINIUPNP_STATICLIB -D NATPMP_STATICLIB -D PACKAGE_DATA_DIR="/usr/local/share" -D POSIX -D RAPIDJSON_HAS_STDSTRING=1 -D SMALL_DISABLE_EXCEPTIONS=1 -D WIDE_INTEGER_DISABLE_FLOAT_INTEROP -D WIDE_INTEGER_DISABLE_IOSTREAM -D WIDE_INTEGER_HAS_LIMB_TYPE_UINT64 -D WITH_INOTIFY -D WITH_OPENSSL -D WITH_UTP -D __TRANSMISSION__ -D ___CIDR_DEFINITIONS_END -isystem /path/to/transmission/third-party/fast_float/include -isystem /path/to/transmission/cmake-build-debug/third-party/libnatpmp.bld/pfx/include -isystem /path/to/transmission/cmake-build-debug/third-party/miniupnp/miniupnpc.bld/pfx/include -isystem /path/to/transmission/cmake-build-debug/third-party/dht.bld/pfx/include -isystem /path/to/transmission/third-party/rapidjson/include -isystem /path/to/transmission/third-party/utfcpp/source -isystem /path/to/transmission/third-party/wide-integer -isystem /path/to/transmission/third-party/fmt/include -isystem /path/to/transmission/third-party/small/include /tmp/compiler-file5213452366305224295 -mtune=generic -march=x86-64 -std=gnu++17 -Wall -Wextra -Wcast-align -Wduplicated-cond -Wextra-semi -Wfloat-equal -Winit-self -Wint-in-bool-context -Wlogical-op -Wsuggest-attribute=format -Wnull-dereference -Wpointer-arith -Wredundant-decls -Wredundant-move -Wrestrict -Wself-move -Wshadow -Wsign-compare -Wsuggest-override -Wuninitialized -Wunused -Wunused-const-variable=2 -Wunused-parameter -Wunused-result -Wwrite-strings -fpch-preprocess -g -fworking-directory -dD -dumpbase compiler-file5213452366305224295
	c++: fatal error: cannot execute 'cc1objplus': posix_spawnp: No such file or directory
	compilation terminated.
```