### PR TITLE
feat(web): add paste and drag-and-drop of .torrents to web ui

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,7 @@ node_modules/
 /tests/**/*.out
 /third-party/miniupnp/miniupnpcstrings.h
 /third-party/suffixes_dafsa.h
-/web/public_html/transmission-app.js.map
+/web/public_html/transmission-app.*
 /android/.cxx
 /android/.gradle
 /android/build

--- a/web/assets/css/transmission-app.scss
+++ b/web/assets/css/transmission-app.scss
@@ -1698,6 +1698,12 @@ dialog {
   #auto-start-label {
     margin-left: 5px;
   }
+
+  &.drag-over {
+    border: 2px dashed var(--blue-300);
+    background: rgb(44 127 234 / 5%);
+    transition: all 0.2s ease;
+  }
 }
 
 /// HOTKEYS DIALOG

--- a/web/assets/css/transmission-app.scss
+++ b/web/assets/css/transmission-app.scss
@@ -1699,6 +1699,12 @@ dialog {
   #auto-start-label {
     margin-left: 5px;
   }
+
+  &.drag-over {
+    border: 2px dashed var(--blue-300);
+    background: rgb(44 127 234 / 5%);
+    transition: all 0.2s ease;
+  }
 }
 
 /// HOTKEYS DIALOG

--- a/web/src/open-dialog.js
+++ b/web/src/open-dialog.js
@@ -166,21 +166,21 @@ export class OpenDialog extends EventTarget {
       return; // Allow default text paste behavior
     }
 
-    const files = [...event.clipboardData.files];
+    if (this._addFilesToInput(event.clipboardData.files)) {
+      event.preventDefault();
+    }
+  }
 
-    // Check for .torrent files
-    const torrentFiles = files.filter(
+  _addFilesToInput(files) {
+    const torrentFiles = [...files].filter(
       (f) =>
         f.name.endsWith('.torrent') || f.type === 'application/x-bittorrent',
     );
 
-    if (torrentFiles.length > 0) {
-      event.preventDefault();
-      this._addFilesToInput(torrentFiles);
+    if (torrentFiles.length === 0) {
+      return false;
     }
-  }
 
-  _addFilesToInput(filesArray) {
     const dt = new DataTransfer();
 
     // Add existing files first (preserve them)
@@ -189,11 +189,12 @@ export class OpenDialog extends EventTarget {
     }
 
     // Add new files
-    for (const file of filesArray) {
+    for (const file of torrentFiles) {
       dt.items.add(file);
     }
 
     this.elements.file_input.files = dt.files;
+    return true;
   }
 
   _onDragOver(event) {
@@ -215,16 +216,7 @@ export class OpenDialog extends EventTarget {
     event.preventDefault();
     event.stopPropagation();
     this.elements.root.classList.remove('drag-over');
-
-    const files = [...event.dataTransfer.files];
-    const torrentFiles = files.filter(
-      (f) =>
-        f.name.endsWith('.torrent') || f.type === 'application/x-bittorrent',
-    );
-
-    if (torrentFiles.length > 0) {
-      this._addFilesToInput(torrentFiles);
-    }
+    this._addFilesToInput(event.dataTransfer.files);
   }
 
   _create(url) {

--- a/web/src/open-dialog.js
+++ b/web/src/open-dialog.js
@@ -161,12 +161,12 @@ export class OpenDialog extends EventTarget {
   }
 
   _onPaste(event) {
-    const files = [...event.clipboardData.files];
-
     // Allow text paste in url_input
-    if (event.target === this.elements.url_input && files.length === 0) {
+    if (event.target === this.elements.url_input && event.clipboardData.files.length === 0) {
       return; // Allow default text paste behavior
     }
+
+    const files = [...event.clipboardData.files];
 
     // Check for .torrent files
     const torrentFiles = files.filter(


### PR DESCRIPTION
Notes: Added paste and drag-and-drop of .torrent files in the web client.

# Preview

## Drag and Drop

https://github.com/user-attachments/assets/4377fa41-c11b-4a2a-af0b-93eac7dceede

## Copy and Paste

https://github.com/user-attachments/assets/4375a328-01a8-4ac1-be3d-539bddbd48a6

# Changes

- Add paste handler for .torrent files in open dialog
- Add drag-and-drop support with visual feedback
- Context-aware paste: allows text paste in URL field, intercepts files elsewhere
- Files accumulate in input without replacing existing selections
- Event listener cleanup on dialog close