### PR TITLE
feat: Add NAT-PMP `gateway_address` configuration option.

### DIFF
--- a/docs/Editing-Configuration-Files.md
+++ b/docs/Editing-Configuration-Files.md
@@ -113,6 +113,7 @@ Here is a sample of the three basic types: respectively Boolean, Number and Stri
  * **peer-port-random-low:** Number (default = 1024)
  * **peer-port-random-on-start:** Boolean (default = false)
  * **port-forwarding-enabled:** Boolean (default = true) Enable [UPnP](https://en.wikipedia.org/wiki/Universal_Plug_and_Play) or [NAT-PMP](https://en.wikipedia.org/wiki/NAT_Port_Mapping_Protocol).
+ * **gateway_address**: String? (default = null) Gateway to use for NAT-PMP.
 
 #### Queuing
  * **download-queue-enabled:** Boolean (default = true) When true, Transmission will only download `download-queue-size` non-stalled torrents at once.

--- a/libtransmission/port-forwarding-natpmp.cc
+++ b/libtransmission/port-forwarding-natpmp.cc
@@ -64,11 +64,19 @@ void tr_natpmp::setCommandTime()
     command_time_ = tr_time() + CommandWaitSecs;
 }
 
-tr_natpmp::PulseResult tr_natpmp::pulse(tr_port local_port, bool is_enabled)
+tr_natpmp::PulseResult tr_natpmp::pulse(tr_port local_port, bool is_enabled, std::optional<tr_address> gateway)
 {
     if (is_enabled && state_ == State::Discover)
     {
-        int val = initnatpmp(&natpmp_, 0, 0);
+        int forcegw = 0;
+        in_addr_t forcedgw = 0;
+        if (gateway && gateway->is_ipv4())
+        {
+            forcegw = 1;
+            forcedgw = gateway->addr.addr4.s_addr;
+        }
+
+        int val = initnatpmp(&natpmp_, forcegw, forcedgw);
         log_val("initnatpmp", val);
         val = sendpublicaddressrequest(&natpmp_);
         log_val("sendpublicaddressrequest", val);

--- a/libtransmission/port-forwarding-natpmp.h
+++ b/libtransmission/port-forwarding-natpmp.h
@@ -49,7 +49,7 @@ public:
         tr_port advertised_port;
     };
 
-    PulseResult pulse(tr_port local_port, bool is_enabled);
+    PulseResult pulse(tr_port local_port, bool is_enabled, std::optional<tr_address> gateway);
 
 private:
     enum class State : uint8_t

--- a/libtransmission/port-forwarding.cc
+++ b/libtransmission/port-forwarding.cc
@@ -192,7 +192,7 @@ private:
 
         auto const old_state = state();
 
-        auto const result = natpmp_->pulse(mediator_.local_peer_port(), is_enabled);
+        auto const result = natpmp_->pulse(mediator_.local_peer_port(), is_enabled, mediator_.gateway_address());
         natpmp_state_ = result.state;
         if (!std::empty(result.local_port) && !std::empty(result.advertised_port))
         {

--- a/libtransmission/port-forwarding.h
+++ b/libtransmission/port-forwarding.h
@@ -30,6 +30,7 @@ public:
 
         [[nodiscard]] virtual tr_port advertised_peer_port() const = 0;
         [[nodiscard]] virtual tr_port local_peer_port() const = 0;
+        [[nodiscard]] virtual std::optional<tr_address> gateway_address() const = 0;
         [[nodiscard]] virtual tr_address incoming_peer_address() const = 0;
         [[nodiscard]] virtual libtransmission::TimerMaker& timer_maker() = 0;
         virtual void on_port_forwarded(tr_port advertised_port) = 0;

--- a/libtransmission/quark.cc
+++ b/libtransmission/quark.cc
@@ -136,6 +136,7 @@ auto constexpr MyStatic = std::array<std::string_view, TR_N_KEYS>{
     "fromLtep"sv,
     "fromPex"sv,
     "fromTracker"sv,
+    "gateway_address"sv,
     "group"sv,
     "hasAnnounced"sv,
     "hasScraped"sv,

--- a/libtransmission/quark.h
+++ b/libtransmission/quark.h
@@ -138,6 +138,7 @@ enum // NOLINT(performance-enum-size)
     TR_KEY_fromLtep,
     TR_KEY_fromPex,
     TR_KEY_fromTracker,
+    TR_KEY_gateway_address,
     TR_KEY_group,
     TR_KEY_hasAnnounced,
     TR_KEY_hasScraped,

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -213,6 +213,11 @@ private:
             return session_.localPeerPort();
         }
 
+        [[nodiscard]] std::optional<tr_address> gateway_address() const override
+        {
+            return session_.gateway_address();
+        }
+
         [[nodiscard]] libtransmission::TimerMaker& timer_maker() override
         {
             return session_.timerMaker();
@@ -433,6 +438,7 @@ public:
         std::array<tr_preferred_transport, TR_NUM_PREFERRED_TRANSPORT> preferred_transport = { TR_PREFER_UTP, TR_PREFER_TCP };
         std::chrono::milliseconds sleep_per_seconds_during_verify = std::chrono::milliseconds{ 100 };
         std::optional<std::string> proxy_url;
+        std::optional<std::string> gateway_address;
         std::string announce_ip;
         std::string bind_address_ipv4;
         std::string bind_address_ipv6;
@@ -471,6 +477,7 @@ public:
                 { TR_KEY_download_queue_enabled, &download_queue_enabled },
                 { TR_KEY_download_queue_size, &download_queue_size },
                 { TR_KEY_encryption, &encryption_mode },
+                { TR_KEY_gateway_address, &gateway_address },
                 { TR_KEY_idle_seeding_limit, &idle_seeding_limit_minutes },
                 { TR_KEY_idle_seeding_limit_enabled, &idle_seeding_limit_enabled },
                 { TR_KEY_incomplete_dir, &incomplete_dir },
@@ -908,6 +915,16 @@ public:
     [[nodiscard]] constexpr tr_port advertisedPeerPort() const noexcept
     {
         return advertised_peer_port_;
+    }
+
+    [[nodiscard]] std::optional<tr_address> gateway_address() const noexcept
+    {
+        if (auto const addr = settings().gateway_address)
+        {
+            return tr_address::from_string(*addr);
+        }
+
+        return {};
     }
 
     [[nodiscard]] constexpr auto queueEnabled(tr_direction dir) const noexcept


### PR DESCRIPTION
My C++ skills are rusty (pun intended) and this isn't an easy code base to navigate. Nevertheless, this does the job.

With this change, you can set the gateway address used by libnatpmp in `settings.json`:
```json
"gateway-address": "192.168.1.1"
```

Fixes #6457.

---

PS: With arch linux (clang 21.1.4):
```
./code_style.sh --check 2>&1 | wc -l
1634
```
I just did `TR_SKIP_HOOKS=1 git commit`.