### PR TITLE
[peer-mgr] Prevent out-of-bounds in update_canonical_priority

### DIFF
--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -258,9 +258,10 @@ void tr_peer_info::merge(tr_peer_info& that) noexcept
 
 void tr_peer_info::update_canonical_priority()
 {
-    auto const type = client_external_address_.type;
-    if (type == NUM_TR_AF_INET_TYPES)
+    if (!client_external_address_.is_valid())
+    {
         return;
+    }
 
     // https://www.bittorrent.org/beps/bep_0040.html
     // If the IP addresses are the same, the port numbers (16-bit integers) should be used instead:
@@ -276,6 +277,8 @@ void tr_peer_info::update_canonical_priority()
         canonical_priority_ = tr_crc32c(reinterpret_cast<uint8_t*>(std::data(buf)), std::size(buf) * sizeof(uint16_t));
         return;
     }
+
+    auto const type = client_external_address_.type;
 
     // https://www.bittorrent.org/beps/bep_0040.html
     // The formula to be used in prioritizing peers is this:


### PR DESCRIPTION
This prevents the app from crashing on launch.

Fix #7737

We have those three pieces of code in contradiction:

1. `tr_address_type` can go from 0 to 2 (with NUM_TR_AF_INET_TYPES).
https://github.com/transmission/transmission/blob/d31e77a494eaac4c03376680ad453365f2c8db0a/libtransmission/net.h#L148-L152

2. `CompactAddrBytes` has only 2 values.
https://github.com/transmission/transmission/blob/d31e77a494eaac4c03376680ad453365f2c8db0a/libtransmission/net.h#L267

3. When `type` is NUM_TR_AF_INET_TYPES (which is its default value!), we're out of bounds.
https://github.com/transmission/transmission/blob/d31e77a494eaac4c03376680ad453365f2c8db0a/libtransmission/peer-mgr.cc#L283

Quick solution: we guard from NUM_TR_AF_INET_TYPES