### PR TITLE
refactor: don't use `evutil_ascii_strcasecmp()` in `get_quota_space()`

### DIFF
--- a/libtransmission/file-capacity.cc
+++ b/libtransmission/file-capacity.cc
@@ -11,8 +11,6 @@
 #include <string>
 #include <string_view>
 
-#include <event2/util.h> /* evutil_ascii_strcasecmp() */
-
 #ifndef _WIN32
 #include <unistd.h> /* getuid() */
 #include <sys/types.h> /* types needed by quota.h */
@@ -428,7 +426,7 @@ extern "C"
 
 #ifndef _WIN32
 
-    if (evutil_ascii_strcasecmp(info.fstype.c_str(), "xfs") == 0)
+    if (tr_strlower(info.fstype) == "xfs")
     {
 #ifdef HAVE_XQM
         ret = getxfsquota(info.device.c_str());


### PR DESCRIPTION
A minor refactor to remove a little more libevent API usage.

This removes the use of `evutil_ascii_strcasecmp()` in `file-capacity.cc`.