### PR TITLE
fix: performance-for-range-copy warning in tr-peer-info-test.cc

### DIFF
--- a/tests/libtransmission/tr-peer-info-test.cc
+++ b/tests/libtransmission/tr-peer-info-test.cc
@@ -139,7 +139,7 @@ TEST_F(PeerInfoTest, updateCanonicalPriority)
                     uint32_t{ 0x67F8FE57 } },
     };
 
-    for (auto [client_sockaddr_str, peer_sockaddr_str, expected] : Tests)
+    for (auto const& [client_sockaddr_str, peer_sockaddr_str, expected] : Tests)
     {
         auto client_sockaddr = tr_socket_address::from_string(client_sockaddr_str);
         auto peer_sockaddr = tr_socket_address::from_string(peer_sockaddr_str);


### PR DESCRIPTION
this warning broke the clang-tidy-libtransmission-win32 CI, e.g. [here](https://github.com/transmission/transmission/actions/runs/18825589711/job/53707670683).

> 2025-10-27T00:34:29.6117101Z D:\a\transmission\transmission\src\tests\libtransmission\tr-peer-info-test.cc:142:15: warning: loop variable is copied but only used as const reference; consider making it a const reference [performance-for-range-copy]
2025-10-27T00:34:29.7263121Z   142 |     for (auto [client_sockaddr_str, peer_sockaddr_str, expected] : Tests)
2025-10-27T00:34:29.8757360Z       |               ^
2025-10-27T00:34:30.1018735Z       |          const  &