### PR TITLE
chore: add suffix to private and protected members

### DIFF
--- a/libtransmission/.clang-tidy
+++ b/libtransmission/.clang-tidy
@@ -45,6 +45,7 @@ CheckOptions:
   - { key: cppcoreguidelines-special-member-functions.AllowSoleDefaultDtor,  value: true       }
   - { key: readability-identifier-naming.ConstexprVariableCase,              value: CamelCase  }
   - { key: readability-identifier-naming.ParameterCase,                      value: lower_case }
+  - { key: readability-identifier-naming.PrivateMemberSuffix,                value: _          }
+  - { key: readability-identifier-naming.ProtectedMemberSuffix,              value: _          }
   - { key: readability-identifier-naming.VariableCase,                       value: lower_case }
   - { key: readability-implicit-bool-conversion.UseUpperCaseLiteralSuffix,   value: true       }
-

--- a/libtransmission/crypto-utils.h
+++ b/libtransmission/crypto-utils.h
@@ -207,22 +207,22 @@ class tr_salt_shaker // NOLINT(cppcoreguidelines-pro-type-member-init): buf does
 public:
     [[nodiscard]] auto operator()() noexcept
     {
-        if (pos == std::size(buf))
+        if (pos_ == std::size(buf_))
         {
-            pos = 0U;
+            pos_ = 0U;
         }
 
-        if (pos == 0U)
+        if (pos_ == 0U)
         {
-            tr_rand_buffer(std::data(buf), std::size(buf) * sizeof(T));
+            tr_rand_buffer(std::data(buf_), std::size(buf_) * sizeof(T));
         }
 
-        return buf[pos++];
+        return buf_[pos_++];
     }
 
 private:
-    size_t pos = 0;
-    std::array<T, N> buf;
+    size_t pos_ = 0;
+    std::array<T, N> buf_;
 };
 
 // UniformRandomBitGenerator impl that uses `tr_rand_buffer()`.

--- a/libtransmission/observable.h
+++ b/libtransmission/observable.h
@@ -81,7 +81,7 @@ public:
 
     [[nodiscard]] auto observe(Observer observer)
     {
-        auto const key = next_key_++;
+        auto const key = next_key++;
         observers_.emplace(key, std::move(observer));
         return ObserverTag{ [this, key]()
                             {
@@ -104,9 +104,7 @@ private:
         TR_ASSERT(n_removed == 1U);
     }
 
-    // TODO: Re-enable after setting readability-identifier-naming.PrivateMemberSuffix to _
-    // NOLINTNEXTLINE(readability-identifier-naming)
-    static auto inline next_key_ = Key{ 1U };
+    static auto inline next_key = Key{ 1U };
     small::map<Key, Observer, 4U> observers_;
 };
 

--- a/libtransmission/peer-socket.cc
+++ b/libtransmission/peer-socket.cc
@@ -30,7 +30,7 @@ tr_peer_socket::tr_peer_socket(tr_session const* session, tr_socket_address cons
 {
     TR_ASSERT(sock != TR_BAD_SOCKET);
 
-    ++n_open_sockets_;
+    ++n_open_sockets;
     session->setSocketTOS(sock, address().type);
 
     if (auto const& algo = session->peerCongestionAlgorithm(); !std::empty(algo))
@@ -47,7 +47,7 @@ tr_peer_socket::tr_peer_socket(tr_socket_address const& socket_address, struct U
 {
     TR_ASSERT(sock != nullptr);
 
-    ++n_open_sockets_;
+    ++n_open_sockets;
     handle.utp = sock;
 
     tr_logAddTraceIo(this, fmt::format("socket (µTP) is {}", fmt::ptr(handle.utp)));
@@ -57,13 +57,13 @@ void tr_peer_socket::close()
 {
     if (is_tcp() && (handle.tcp != TR_BAD_SOCKET))
     {
-        --n_open_sockets_;
+        --n_open_sockets;
         tr_net_close_socket(handle.tcp);
     }
 #ifdef WITH_UTP
     else if (is_utp())
     {
-        --n_open_sockets_;
+        --n_open_sockets;
         utp_set_userdata(handle.utp, nullptr);
         utp_close(handle.utp);
     }
@@ -131,5 +131,5 @@ size_t tr_peer_socket::try_read(InBuf& buf, size_t max, [[maybe_unused]] bool bu
 
 bool tr_peer_socket::limit_reached(tr_session const* const session) noexcept
 {
-    return n_open_sockets_.load() >= session->peerLimit();
+    return n_open_sockets.load() >= session->peerLimit();
 }

--- a/libtransmission/peer-socket.h
+++ b/libtransmission/peer-socket.h
@@ -114,7 +114,5 @@ private:
 
     enum Type type_ = Type::None;
 
-    // TODO: Re-enable after setting readability-identifier-naming.PrivateMemberSuffix to _
-    // NOLINTNEXTLINE(readability-identifier-naming)
-    static inline std::atomic<size_t> n_open_sockets_ = {};
+    static inline std::atomic<size_t> n_open_sockets = {};
 };

--- a/libtransmission/variant.cc
+++ b/libtransmission/variant.cc
@@ -618,7 +618,7 @@ protected:
         var_ = v_in;
         is_visited_ = false;
         child_index_ = 0;
-        sorted.clear();
+        sorted_.clear();
     }
 
     struct ByKey
@@ -649,10 +649,10 @@ protected:
 
         //  keep the sorted indices
 
-        sorted.resize(n);
+        sorted_.resize(n);
         for (size_t i = 0; i < n; ++i)
         {
-            sorted[i] = sortbuf[i].idx;
+            sorted_[i] = sortbuf[i].idx;
         }
     }
 
@@ -662,15 +662,15 @@ private:
 
     // When `v` is a dict, this is its children's indices sorted by key.
     // Bencoded dicts must be sorted, so this is useful when writing benc.
-    small::vector<size_t, 128U> sorted;
+    small::vector<size_t, 128U> sorted_;
 
     [[nodiscard]] size_t next_index()
     {
         auto idx = child_index_++;
 
-        if (idx < std::size(sorted))
+        if (idx < std::size(sorted_))
         {
-            idx = sorted[idx];
+            idx = sorted_[idx];
         }
 
         return idx;

--- a/libtransmission/watchdir.h
+++ b/libtransmission/watchdir.h
@@ -60,7 +60,6 @@ public:
         std::chrono::milliseconds rescan_interval = generic_rescan_interval_);
 
 private:
-    // TODO: Re-enable after setting readability-identifier-naming.PrivateMemberSuffix to _
     // NOLINTNEXTLINE(readability-identifier-naming)
     static inline auto generic_rescan_interval_ = std::chrono::milliseconds{ 1000 };
 };

--- a/libtransmission/web.cc
+++ b/libtransmission/web.cc
@@ -258,12 +258,12 @@ public:
     public:
         Task(tr_web::Impl& impl_in, tr_web::FetchOptions&& options_in)
             : impl{ impl_in }
-            , options{ std::move(options_in) }
+            , options_{ std::move(options_in) }
         {
-            auto const parsed = tr_urlParse(options.url);
+            auto const parsed = tr_urlParse(options_.url);
             easy_ = parsed ? impl.get_easy(parsed->host) : nullptr;
 
-            response.user_data = options.done_func_user_data;
+            response.user_data = options_.done_func_user_data;
         }
 
         // Some of the curl_easy_setopt() args took a pointer to this task.
@@ -285,47 +285,47 @@ public:
 
         [[nodiscard]] auto* body() const
         {
-            return options.buffer != nullptr ? options.buffer : privbuf.get();
+            return options_.buffer != nullptr ? options_.buffer : privbuf_.get();
         }
 
         [[nodiscard]] constexpr auto const& speedLimitTag() const
         {
-            return options.speed_limit_tag;
+            return options_.speed_limit_tag;
         }
 
         [[nodiscard]] constexpr auto const& url() const
         {
-            return options.url;
+            return options_.url;
         }
 
         [[nodiscard]] constexpr auto const& range() const
         {
-            return options.range;
+            return options_.range;
         }
 
         [[nodiscard]] constexpr auto const& cookies() const
         {
-            return options.cookies;
+            return options_.cookies;
         }
 
         [[nodiscard]] constexpr auto const& sndbuf() const
         {
-            return options.sndbuf;
+            return options_.sndbuf;
         }
 
         [[nodiscard]] constexpr auto const& rcvbuf() const
         {
-            return options.rcvbuf;
+            return options_.rcvbuf;
         }
 
         [[nodiscard]] constexpr auto const& timeoutSecs() const
         {
-            return options.timeout_secs;
+            return options_.timeout_secs;
         }
 
         [[nodiscard]] constexpr auto ipProtocol() const
         {
-            switch (options.ip_proto)
+            switch (options_.ip_proto)
             {
             case FetchOptions::IPProtocol::V4:
                 return CURL_IPRESOLVE_V4;
@@ -338,7 +338,7 @@ public:
 
         [[nodiscard]] auto bind_address() const
         {
-            switch (options.ip_proto)
+            switch (options_.ip_proto)
             {
             case FetchOptions::IPProtocol::V4:
                 return impl.mediator.bind_address_V4();
@@ -357,14 +357,14 @@ public:
 
         void done()
         {
-            if (!options.done_func)
+            if (!options_.done_func)
             {
                 return;
             }
 
             response.body.assign(reinterpret_cast<char const*>(evbuffer_pullup(body(), -1)), evbuffer_get_length(body()));
-            impl.mediator.run(std::move(options.done_func), std::move(this->response));
-            options.done_func = {};
+            impl.mediator.run(std::move(options_.done_func), std::move(this->response));
+            options_.done_func = {};
         }
 
         [[nodiscard]] bool operator==(Task const& that) const noexcept
@@ -385,7 +385,7 @@ public:
 
             impl.paused_easy_handles.erase(easy_);
 
-            if (auto const url = tr_urlParse(options.url); url)
+            if (auto const url = tr_urlParse(options_.url); url)
             {
                 curl_easy_reset(easy);
                 impl.easy_pool_[std::string{ url->host }].emplace(easy);
@@ -396,9 +396,9 @@ public:
             }
         }
 
-        libtransmission::evhelpers::evbuffer_unique_ptr privbuf{ evbuffer_new() };
+        libtransmission::evhelpers::evbuffer_unique_ptr privbuf_{ evbuffer_new() };
 
-        tr_web::FetchOptions options;
+        tr_web::FetchOptions options_;
 
         CURL* easy_;
     };

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -100,7 +100,7 @@ class ConnectionLimiter
 public:
     constexpr void task_started() noexcept
     {
-        ++n_tasks;
+        ++n_tasks_;
     }
 
     void task_finished(bool success)
@@ -110,15 +110,15 @@ public:
             task_failed();
         }
 
-        TR_ASSERT(n_tasks > 0);
-        --n_tasks;
+        TR_ASSERT(n_tasks_ > 0);
+        --n_tasks_;
     }
 
     constexpr void got_data() noexcept
     {
-        TR_ASSERT(n_tasks > 0);
-        n_consecutive_failures = 0;
-        paused_until = 0;
+        TR_ASSERT(n_tasks_ > 0);
+        n_consecutive_failures_ = 0;
+        paused_until_ = 0;
     }
 
     [[nodiscard]] size_t slots_available() const noexcept
@@ -129,32 +129,32 @@ public:
         }
 
         auto const max = max_connections();
-        if (n_tasks >= max)
+        if (n_tasks_ >= max)
         {
             return 0;
         }
 
-        return max - n_tasks;
+        return max - n_tasks_;
     }
 
 private:
     [[nodiscard]] bool is_paused() const noexcept
     {
-        return paused_until > tr_time();
+        return paused_until_ > tr_time();
     }
 
     [[nodiscard]] constexpr size_t max_connections() const noexcept
     {
-        return n_consecutive_failures > 0 ? 1 : MaxConnections;
+        return n_consecutive_failures_ > 0 ? 1 : MaxConnections;
     }
 
     void task_failed()
     {
-        TR_ASSERT(n_tasks > 0);
+        TR_ASSERT(n_tasks_ > 0);
 
-        if (++n_consecutive_failures >= MaxConsecutiveFailures)
+        if (++n_consecutive_failures_ >= MaxConsecutiveFailures)
         {
-            paused_until = tr_time() + TimeoutIntervalSecs;
+            paused_until_ = tr_time() + TimeoutIntervalSecs;
         }
     }
 
@@ -162,9 +162,9 @@ private:
     static auto constexpr MaxConnections = size_t{ 4 };
     static auto constexpr MaxConsecutiveFailures = MaxConnections;
 
-    size_t n_tasks = 0;
-    size_t n_consecutive_failures = 0;
-    time_t paused_until = 0;
+    size_t n_tasks_ = 0;
+    size_t n_consecutive_failures_ = 0;
+    time_t paused_until_ = 0;
 };
 
 class tr_webseed_impl final : public tr_webseed


### PR DESCRIPTION
First of a series of PRs to tighten clang-tidy rules in libtransmission to match qt and gtk.