### PR TITLE
Draw custom colored progress bars (Qt client)

### DIFF
--- a/qt/FileTreeDelegate.cc
+++ b/qt/FileTreeDelegate.cc
@@ -59,7 +59,7 @@ void FileTreeDelegate::paint(QPainter* painter, QStyleOptionViewItem const& opti
         p.textVisible = true;
         p.progress = static_cast<int>(100.0 * index.data().toDouble());
         p.text = QStringLiteral("%1%").arg(p.progress);
-        StyleHelper::drawProgressBar(*style, *painter, p);
+        StyleHelper::drawProgressBar(*painter, p);
     }
     else if (column == FileTreeModel::COL_WANTED)
     {

--- a/qt/StyleHelper.cc
+++ b/qt/StyleHelper.cc
@@ -3,7 +3,10 @@
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.
 
+#include <algorithm>
+
 #include <QPainter>
+#include <QStaticText>
 #include <QStyleOptionProgressBar>
 
 #include "StyleHelper.h"
@@ -23,19 +26,79 @@ QIcon::Mode StyleHelper::getIconMode(QStyle::State const& state)
     return QIcon::Normal;
 }
 
-void StyleHelper::drawProgressBar(QStyle const& style, QPainter& painter, QStyleOptionProgressBar const& option)
+void StyleHelper::drawProgressBar(QPainter& painter, QStyleOptionProgressBar const& option)
 {
-    // Workaround for https://bugreports.qt.io/browse/QTBUG-67830
-
-#ifdef Q_OS_DARWIN
-    auto my_option = option;
-    my_option.rect.translate(-option.rect.topLeft());
-
     painter.save();
-    painter.translate(option.rect.topLeft());
-    style.drawControl(QStyle::CE_ProgressBar, &my_option, &painter);
+
+    auto rect = option.rect.adjusted(0, 0, -1, -1);
+
+    painter.setPen(option.palette.color(QPalette::Base));
+    painter.drawRect(rect);
+
+    rect.adjust(1, 1, 0, 0);
+
+    auto const max_pos = std::max(option.maximum - option.minimum, 1);
+    auto const pos = std::min(std::max(option.progress - option.minimum, 0), max_pos);
+    auto const bar_width = pos * rect.width() / max_pos;
+    auto const is_inverted = option.invertedAppearance != (option.direction == Qt::RightToLeft);
+
+    if (pos < max_pos)
+    {
+        auto back_rect = rect;
+        if (pos > 0)
+        {
+            back_rect.setWidth(back_rect.width() - bar_width);
+            if (!is_inverted)
+            {
+                back_rect.moveRight(rect.right());
+            }
+        }
+
+        painter.fillRect(back_rect, option.palette.brush(QPalette::Window));
+    }
+
+    if (pos > 0)
+    {
+        auto bar_rect = rect;
+        if (pos < max_pos)
+        {
+            bar_rect.setWidth(bar_width);
+            if (is_inverted)
+            {
+                bar_rect.moveRight(rect.right());
+            }
+        }
+
+        painter.fillRect(bar_rect, option.palette.brush(QPalette::Highlight));
+    }
+
+    if (option.textVisible)
+    {
+        rect.adjust(1, 0, -1, 0);
+
+        auto text = QStaticText(option.text);
+        text.setTextFormat(Qt::PlainText);
+        text.prepare({}, painter.font());
+        auto const text_pos = QStyle::alignedRect(option.direction, option.textAlignment, text.size().toSize(), rect).topLeft();
+
+        auto const text_color = option.palette.color(QPalette::WindowText);
+        auto const shadow_color = text_color.value() <= 128 ? QColor(255, 255, 255, 160) : QColor(0, 0, 0, 160);
+
+        painter.setPen(shadow_color);
+        for (int i = -1; i <= 1; ++i)
+        {
+            for (int j = -1; j <= 1; ++j)
+            {
+                if (i != 0 && j != 0)
+                {
+                    painter.drawStaticText(text_pos.x() + i, text_pos.y() + j, text);
+                }
+            }
+        }
+
+        painter.setPen(text_color);
+        painter.drawStaticText(text_pos, text);
+    }
+
     painter.restore();
-#else
-    style.drawControl(QStyle::CE_ProgressBar, &option, &painter);
-#endif
 }

--- a/qt/StyleHelper.h
+++ b/qt/StyleHelper.h
@@ -16,5 +16,5 @@ class StyleHelper
 public:
     static QIcon::Mode getIconMode(QStyle::State const& state);
 
-    static void drawProgressBar(QStyle const& style, QPainter& painter, QStyleOptionProgressBar const& option);
+    static void drawProgressBar(QPainter& painter, QStyleOptionProgressBar const& option);
 };

--- a/qt/TorrentDelegate.cc
+++ b/qt/TorrentDelegate.cc
@@ -595,7 +595,7 @@ void TorrentDelegate::drawTorrent(QPainter* painter, QStyleOptionViewItem const&
     progress_bar_style_.state = progress_bar_state;
     setProgressBarPercentDone(option, tor);
 
-    StyleHelper::drawProgressBar(*style, *painter, progress_bar_style_);
+    StyleHelper::drawProgressBar(*painter, progress_bar_style_);
 
     painter->restore();
 }

--- a/qt/TorrentDelegateMin.cc
+++ b/qt/TorrentDelegateMin.cc
@@ -270,7 +270,7 @@ void TorrentDelegateMin::drawTorrent(QPainter* painter, QStyleOptionViewItem con
     progress_bar_style_.textVisible = true;
     progress_bar_style_.textAlignment = Qt::AlignCenter;
     setProgressBarPercentDone(option, tor);
-    StyleHelper::drawProgressBar(*style, *painter, progress_bar_style_);
+    StyleHelper::drawProgressBar(*painter, progress_bar_style_);
 
     painter->restore();
 }


### PR DESCRIPTION
Fixes #343.
Conflicts with #6517 but doesn't draw pieces, only colors to the progress bars.

Notes: Use custom colored progress bars in Qt client for torrent states differentiation.

On a side note, this also helps with progress bars on Windows 11 where Qt draws them so thin it's even worse than on Mac. It also draws the text (percents) below the bar, which makes both clipped and the text hardly readable. Not to mention bar color matching the selection background color… In other words, it's a huge mess.