### PR TITLE
Use native folder icon in torrent files tree

### DIFF
--- a/qt/FileTreeItem.cc
+++ b/qt/FileTreeItem.cc
@@ -9,9 +9,6 @@
 
 #include <small/set.hpp>
 
-#include <QApplication>
-#include <QStyle>
-
 #include <libtransmission/transmission.h> // priorities
 
 #include "FileTreeItem.h"
@@ -175,15 +172,9 @@ QVariant FileTreeItem::data(int column, int role) const
     case Qt::DecorationRole:
         if (column == FileTreeModel::COL_NAME)
         {
-            if (file_index_ < 0)
-            {
-                value = QApplication::style()->standardIcon(QStyle::SP_DirOpenIcon);
-            }
-            else
-            {
-                auto const& icon_cache = IconCache::get();
-                value = childCount() > 0 ? icon_cache.folderIcon() : icon_cache.guessMimeIcon(name(), icon_cache.fileIcon());
-            }
+            auto const& icon_cache = IconCache::get();
+            value = (file_index_ < 0 || childCount() > 0) ? icon_cache.folderIcon() :
+                                                            icon_cache.guessMimeIcon(name(), icon_cache.fileIcon());
         }
 
         break;


### PR DESCRIPTION
Not all Qt styles seem to provide a `DirOpenIcon` icon (Windows 11 style doesn't, which leads to no icon in the tree), and `DirIcon` is usually the same (or worse) as the one returned by our icon cache. It's also not clear why we'd want an _open_ folder icon specifically, given that the condition in the `else` branch is essentially checking the same thing.