### PR TITLE
fix: filter-by-tracker failed after the tracker list changed

### DIFF
--- a/web/src/torrent.js
+++ b/web/src/torrent.js
@@ -16,11 +16,18 @@ export class Torrent extends EventTarget {
     this.fieldObservers = {};
     this.fields = {};
     this.refresh(data);
+
+    this.setLazyCollatedField('name', 'collatedName');
+    this.setLazyCollatedField('trackers', 'collatedTrackers');
+  }
+
+  setLazyCollatedField(name, collated_name) {
+    this.notifyOnFieldChange(name, () => delete this.fields[collated_name]);
   }
 
   notifyOnFieldChange(field, callback) {
-    this.fieldObservers[field] = this.fieldObservers[field] || [];
-    this.fieldObservers[field].push(callback);
+    const observers = (this.fieldObservers[field] ??= []);
+    observers.push(callback);
   }
 
   setField(o, name, value) {
@@ -78,12 +85,6 @@ export class Torrent extends EventTarget {
         case 'trackers': // ...so only save 'trackers' if we don't have it already
           if (!(key in this.fields)) {
             changed |= this.setField(this.fields, key, value);
-          }
-          break;
-        case 'name':
-          if (this.setField(this.fields, key, data[key])) {
-            this.fields.collatedName = '';
-            changed = true;
           }
           break;
         default:


### PR DESCRIPTION
Fix filtering by tracker after a torrent's tracker list has been edited.

Each Torrent object has a lazy-created a collated trackerlist string for quick searching, but that string wasn't reset when the trackerlist changed.

Notes: Fixed filtering torrents by tracker after a torrent's tracker list is edited.