### PR TITLE
Fix running macos app on a VM when building with cmake

### DIFF
--- a/macosx/CMakeLists.txt
+++ b/macosx/CMakeLists.txt
@@ -418,6 +418,7 @@ target_link_libraries(${TR_NAME}-mac
         "-framework Foundation"
         "-framework Quartz"
         "-framework Security"
+        "-weak_framework Sparkle"
         "-weak_framework UserNotifications")
 
 if(NOT CMAKE_GENERATOR STREQUAL Xcode)


### PR DESCRIPTION
Experimental fix for a macos issue on a VM when building with cmake, as reported by @sweetppro in #7760.

Needs to be tested by @sweetppro.

Description of the fix: in #3050 I made Sparkle optional in the project.pbxproj file. Here I'm attempting to make it optional in CMakeLists.txt too.