### PR TITLE
fix libfmt version probe with libfmt < 11

### DIFF
--- a/cmake/FindFmt.cmake
+++ b/cmake/FindFmt.cmake
@@ -6,8 +6,13 @@ target_include_directories(fmt::fmt-header-only
     INTERFACE
         ${${CMAKE_FIND_PACKAGE_NAME}_INCLUDE})
 
-file(READ "${${CMAKE_FIND_PACKAGE_NAME}_INCLUDE}/fmt/base.h" _FMT_BASE_H)
-if(_FMT_BASE_H MATCHES "FMT_VERSION ([0-9]+)([0-9][0-9])([0-9][0-9])")
+set(_FMT_VERSION_H_PATH "${${CMAKE_FIND_PACKAGE_NAME}_INCLUDE}/fmt/base.h")
+if(NOT EXISTS "${_FMT_VERSION_H_PATH}")
+    # fmt < 11
+    set(_FMT_VERSION_H_PATH "${${CMAKE_FIND_PACKAGE_NAME}_INCLUDE}/fmt/core.h")
+endif()
+file(READ "${_FMT_VERSION_H_PATH}" _FMT_VERSION_H)
+if(_FMT_VERSION_H MATCHES "FMT_VERSION ([0-9]+)([0-9][0-9])([0-9][0-9])")
     # Use math to skip leading zeros if any.
     math(EXPR _FMT_VERSION_MAJOR ${CMAKE_MATCH_1})
     math(EXPR _FMT_VERSION_MINOR ${CMAKE_MATCH_2})


### PR DESCRIPTION
https://github.com/transmission/transmission/commit/fb25228f24ff0d918c6bc5f3b4acb75125af85d4 added some `cmake` code to probe for `fmt` version by searching for `FMT_VERSION` in `fmt/base.h`. But `fmt/base.h` was only introduced in `fmt` 11, and for `fmt` < 11, `FMT_VERSION` is defined in `fmt/core.h`, and compilation was broken for `fmt` < 11. This change restores `fmt` < 11 compatibility.

Implementation note: using `find_file()` to search for the header file does not work on `android` (most probably because of the cross-compilation using [`CMAKE_SYSROOT`](https://cmake.org/cmake/help/latest/variable/CMAKE_SYSROOT.html)) so the proposed implementation uses a simple `if`/`else` probing for the newer header file existing and falling back the the older header file.

Notes: Search both `fmt/base.h` (fmt 11+) and `fmt/core.h` (fmt < 11) for `FMT_VERSION`.