### PR TITLE
refactor: replace all `evutil_make_listen_socket_ipv6only` usages

### DIFF
--- a/libtransmission/net.h
+++ b/libtransmission/net.h
@@ -556,3 +556,5 @@ void tr_netSetTOS(tr_socket_t sock, int tos, tr_address_type type);
  * @param err an errno on Unix/Linux and an WSAError on win32)
  */
 [[nodiscard]] std::string tr_net_strerror(int err);
+
+[[nodiscard]] int tr_make_listen_socket_ipv6only(tr_socket_t sock);

--- a/libtransmission/tr-lpd.cc
+++ b/libtransmission/tr-lpd.cc
@@ -335,7 +335,7 @@ private:
         if constexpr (ip_protocol == TR_AF_INET6)
         {
             // must be done before binding on Linux
-            if (evutil_make_listen_socket_ipv6only(sock) == -1)
+            if (tr_make_listen_socket_ipv6only(sock) == -1)
             {
                 return false;
             }

--- a/libtransmission/tr-udp.cc
+++ b/libtransmission/tr-udp.cc
@@ -213,7 +213,7 @@ tr_session::tr_udp_core::tr_udp_core(tr_session& session, tr_port udp_port)
     else if (auto sock = socket(PF_INET6, SOCK_DGRAM, 0); sock != TR_BAD_SOCKET)
     {
         (void)evutil_make_listen_socket_reuseable(sock);
-        (void)evutil_make_listen_socket_ipv6only(sock);
+        (void)tr_make_listen_socket_ipv6only(sock);
 
         auto const addr = session_.bind_address(TR_AF_INET6);
         auto const [ss, sslen] = tr_socket_address::to_sockaddr(addr, udp_port_);


### PR DESCRIPTION
Fixes #7776