### PR TITLE
upload_only fixes, check for partial seeds

### DIFF
--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -242,7 +242,8 @@ void tr_peer_info::merge(tr_peer_info& that) noexcept
     /* is_connected_ should already be set */
     /* keep is_seed_ as-is */
     /* preserve upload_only_ when peer is still connected */
-    if (that.is_connected()) {
+    if (that.is_connected())
+    {
         set_upload_only(that.is_upload_only());
     }
 


### PR DESCRIPTION
1) When peer info is merged from a duplicate, maintain the original upload_only status as it may have been communicated in extension message

2) Also check for partial seeds during peer management, not just full seeds.

