### PR TITLE
Use transmission/libevent.git

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,7 @@
 	branch = post-1.2.1-transmission
 [submodule "third-party/libevent"]
 	path = third-party/libevent
-	# Windows/Android build fixes (libevent/libevent#1813 and libevent/libevent#1817)
-	url = https://github.com/coeur/libevent.git
+	url = https://github.com/transmission/libevent.git
 	branch = master
 [submodule "third-party/libnatpmp"]
 	path = third-party/libnatpmp


### PR DESCRIPTION
Thank you for merging #7765, but that was using my own fork until the following PR would be approved/merged:
- https://github.com/transmission/libevent/pull/5
- https://github.com/transmission/libevent/pull/6

So ideally:
1. a `post-2.2.0-transmission` branch is created on  https://github.com/transmission/libevent based on `master` branch
2. the above 2 PRs get retargeted to that branch
3. We merge above PRs
4. We update this PR with the new commit
5. We set the gitmodule back to https://github.com/transmission/libevent.git

Alternatively, skipping the pull requests merges:
1. a `post-2.2.0-transmission` branch is created on  https://github.com/transmission/libevent based on my `coeur/Transmission` branch
2. We set the gitmodule back to https://github.com/transmission/libevent.git
