### PR TITLE
refactor: move `tr_rpc_parse_list_str()` from libtransmission to `remote.cc`

### DIFF
--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -2217,33 +2217,3 @@ void tr_rpc_request_exec(tr_session* session, tr_variant const& request, tr_rpc_
 
     callback(session, tr_variant{ std::move(response) });
 }
-
-/**
- * Munge the URI into a usable form.
- *
- * We have very loose typing on this to make the URIs as simple as possible:
- * - anything not a 'tag' or 'method' is automatically in 'arguments'
- * - values that are all-digits are numbers
- * - values that are all-digits or commas are number lists
- * - all other values are strings
- */
-tr_variant tr_rpc_parse_list_str(std::string_view str)
-{
-    auto const values = tr_num_parse_range(str);
-    auto const n_values = std::size(values);
-
-    if (n_values == 0)
-    {
-        return { str };
-    }
-
-    if (n_values == 1)
-    {
-        return { values[0] };
-    }
-
-    auto num_vec = tr_variant::Vector{};
-    num_vec.resize(n_values);
-    std::copy_n(std::cbegin(values), n_values, std::begin(num_vec));
-    return { std::move(num_vec) };
-}

--- a/libtransmission/rpcimpl.h
+++ b/libtransmission/rpcimpl.h
@@ -6,7 +6,6 @@
 #pragma once
 
 #include <functional>
-#include <string_view>
 
 struct tr_session;
 struct tr_variant;
@@ -14,5 +13,3 @@ struct tr_variant;
 using tr_rpc_response_func = std::function<void(tr_session* session, tr_variant&& response)>;
 
 void tr_rpc_request_exec(tr_session* session, tr_variant const& request, tr_rpc_response_func&& callback = {});
-
-tr_variant tr_rpc_parse_list_str(std::string_view str);

--- a/tests/libtransmission/rpc-test.cc
+++ b/tests/libtransmission/rpc-test.cc
@@ -30,47 +30,6 @@ namespace libtransmission::test
 
 using RpcTest = SessionTest;
 
-TEST_F(RpcTest, list)
-{
-    auto top = tr_rpc_parse_list_str("12"sv);
-    auto i = top.value_if<int64_t>();
-    ASSERT_TRUE(i);
-    EXPECT_EQ(12, *i);
-
-    top = tr_rpc_parse_list_str("6,7"sv);
-    auto* v = top.get_if<tr_variant::Vector>();
-    ASSERT_NE(v, nullptr);
-    EXPECT_EQ(2U, std::size(*v));
-    i = (*v)[0].value_if<int64_t>();
-    ASSERT_TRUE(i);
-    EXPECT_EQ(6, *i);
-    i = (*v)[1].value_if<int64_t>();
-    ASSERT_TRUE(i);
-    EXPECT_EQ(7, *i);
-
-    top = tr_rpc_parse_list_str("asdf"sv);
-    auto sv = top.value_if<std::string_view>();
-    ASSERT_TRUE(sv);
-    EXPECT_EQ("asdf"sv, *sv);
-
-    top = tr_rpc_parse_list_str("1,3-5"sv);
-    v = top.get_if<tr_variant::Vector>();
-    ASSERT_NE(v, nullptr);
-    EXPECT_EQ(4U, std::size(*v));
-    i = (*v)[0].value_if<int64_t>();
-    ASSERT_TRUE(i);
-    EXPECT_EQ(1, *i);
-    i = (*v)[1].value_if<int64_t>();
-    ASSERT_TRUE(i);
-    EXPECT_EQ(3, *i);
-    i = (*v)[2].value_if<int64_t>();
-    ASSERT_TRUE(i);
-    EXPECT_EQ(4, *i);
-    i = (*v)[3].value_if<int64_t>();
-    ASSERT_TRUE(i);
-    EXPECT_EQ(5, *i);
-}
-
 TEST_F(RpcTest, tagSync)
 {
     auto request_map = tr_variant::Map{ 2U };

--- a/utils/remote.cc
+++ b/utils/remote.cc
@@ -551,6 +551,32 @@ enum
     return {};
 }
 
+/**
+ * - values that are all-digits are numbers
+ * - values that are all-digits or commas are number lists
+ * - anything else is a string
+ */
+[[nodiscard]] tr_variant rpc_parse_list_str(std::string_view str)
+{
+    auto const values = tr_num_parse_range(str);
+    auto const n_values = std::size(values);
+
+    if (n_values == 0)
+    {
+        return { str };
+    }
+
+    if (n_values == 1)
+    {
+        return { values[0] };
+    }
+
+    auto num_vec = tr_variant::Vector{};
+    num_vec.resize(n_values);
+    std::copy_n(std::cbegin(values), n_values, std::begin(num_vec));
+    return { std::move(num_vec) };
+}
+
 void add_id_arg(tr_variant::Map& args, std::string_view id_str, std::string_view fallback = "")
 {
     if (std::empty(id_str))
@@ -583,7 +609,7 @@ void add_id_arg(tr_variant::Map& args, std::string_view id_str, std::string_view
 
         if (is_num || is_list)
         {
-            args.insert_or_assign(TR_KEY_ids, tr_rpc_parse_list_str(id_str));
+            args.insert_or_assign(TR_KEY_ids, rpc_parse_list_str(id_str));
         }
         else
         {


### PR DESCRIPTION
libtransmission hasn't used this function for about three years (822fabb2 #3549), so let's move it into `remote.cc` next to its only caller.

Also update the slightly-inaccurate code comment describing how the function works.