### PR TITLE
perf: use http range request info to preallocate response body buffer

### DIFF
--- a/libtransmission/web.h
+++ b/libtransmission/web.h
@@ -7,6 +7,7 @@
 
 #include <chrono>
 #include <cstddef> // size_t
+#include <cstdint> // uint64_t
 #include <ctime> // time_t
 #include <functional>
 #include <memory>
@@ -68,8 +69,9 @@ public:
         // option concatenated like this: "name1=content1; name2=content2;"
         std::optional<std::string> cookies;
 
+        // If set, bytes [range->first...range->second] are requested.
         // https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests
-        std::optional<std::string> range;
+        std::optional<std::pair<uint64_t, uint64_t>> range;
 
         // Tag used by tr_web::Mediator to limit some transfers' bandwidth
         std::optional<int> speed_limit_tag;

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -501,7 +501,7 @@ void tr_webseed_task::request_next_chunk()
     auto url = tr_urlbuf{};
     makeUrl(webseed_, tor.file_subpath(file_index), std::back_inserter(url));
     auto options = tr_web::FetchOptions{ url.sv(), on_partial_data_fetched, this };
-    options.range = fmt::format("{:d}-{:d}", file_offset, file_offset + this_chunk - 1);
+    options.range.emplace(file_offset, file_offset + this_chunk - 1);
     options.speed_limit_tag = tor.id();
     options.buffer = content();
     tor.session->fetch(std::move(options));


### PR DESCRIPTION
When making an HTTP range request, use that range's size to preallocate memory for the response body buffer.

This is a small side refactor that I came across while working on #7743. It's not directly related to that change though, so for clarity's sake I'm putting it in a standalone PR.

Notes: Improved libtransmission code to use less CPU.