### PR TITLE
ci: don't use macOS runners with deprecated os versions or architectures

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -418,7 +418,7 @@ jobs:
         run: cmake --build obj --config RelWithDebInfo --target install/strip
       - uses: actions/upload-artifact@v4
         with:
-          name: binaries-${{ github.job }}
+          name: binaries-${{ matrix.os }}-from-repo
           path: pfx/**/*
 
   alpine-musl:


### PR DESCRIPTION
We have some GitHub Actions which we try to run on the oldest version of macOS available. That's currently macos-13, but GitHub is deprecating it:

> This is a scheduled macos-13 brownout.
> The macOS-13 based runner images are being deprecated. For more details,
> see https://github.com/actions/runner-images/issues/13046.

The last bump from macos-12 to macos-13 happened in 43f5ca8 #7275

CC @Coeur