### PR TITLE
refactor: let client pass in translated string of None when calling `tr_strratio()`

### DIFF
--- a/gtk/Utils.cc
+++ b/gtk/Utils.cc
@@ -111,7 +111,7 @@ Glib::ustring gtr_get_unicode_string(GtrUnicode uni)
 
 Glib::ustring tr_strlratio(double ratio)
 {
-    return tr_strratio(ratio, gtr_get_unicode_string(GtrUnicode::Inf).c_str());
+    return tr_strratio(ratio, Q_("None"), gtr_get_unicode_string(GtrUnicode::Inf).c_str());
 }
 
 Glib::ustring tr_strlsize(libtransmission::Values::Storage const& storage)

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -561,11 +561,11 @@ std::string tr_strpercent(double x)
     return fmt::format("{:.0Lf}", x);
 }
 
-std::string tr_strratio(double ratio, std::string_view infinity)
+std::string tr_strratio(double ratio, std::string_view const none, std::string_view const infinity)
 {
     if ((int)ratio == TR_RATIO_NA)
     {
-        return _("None");
+        return std::string{ none };
     }
 
     if ((int)ratio == TR_RATIO_INF)

--- a/libtransmission/utils.h
+++ b/libtransmission/utils.h
@@ -247,7 +247,7 @@ template<typename T, std::enable_if_t<std::is_floating_point_v<T>, bool> = true>
 
 /** @param ratio    the ratio to convert to a string
     @param infinity the string representation of "infinity" */
-[[nodiscard]] std::string tr_strratio(double ratio, std::string_view infinity);
+[[nodiscard]] std::string tr_strratio(double ratio, std::string_view none, std::string_view infinity);
 
 // ---
 

--- a/qt/Formatter.cc
+++ b/qt/Formatter.cc
@@ -47,6 +47,14 @@ QString Formatter::storage_to_string(int64_t const bytes)
     return storage_to_string(static_cast<uint64_t>(bytes));
 }
 
+QString Formatter::ratio_to_string(double ratio)
+{
+    static auto constexpr Infinity = "\xE2\x88\x9E"sv;
+    static auto const none = tr("None").toStdString();
+
+    return QString::fromStdString(tr_strratio(ratio, none, Infinity));
+}
+
 QString Formatter::time_to_string(int seconds)
 {
     seconds = std::max(seconds, 0);

--- a/qt/Formatter.h
+++ b/qt/Formatter.h
@@ -29,12 +29,7 @@ public:
         return QString::fromStdString(tr_strpercent(x));
     }
 
-    [[nodiscard]] static auto ratio_to_string(double ratio)
-    {
-        static auto constexpr InfinitySymbol = "\xE2\x88\x9E";
-
-        return QString::fromStdString(tr_strratio(ratio, InfinitySymbol));
-    }
+    [[nodiscard]] static QString ratio_to_string(double ratio);
 
     [[nodiscard]] static QString storage_to_string(int64_t bytes);
     [[nodiscard]] static QString storage_to_string(uint64_t bytes);

--- a/tests/libtransmission/utils-test.cc
+++ b/tests/libtransmission/utils-test.cc
@@ -308,13 +308,13 @@ TEST_F(UtilsTest, ratioToString)
                                                                                          { TR_RATIO_INF, "inf" } } };
     char const nullchar = '\0';
 
-    ASSERT_EQ(tr_strratio(TR_RATIO_NA, "Ratio is NaN"), "None");
-    ASSERT_EQ(tr_strratio(TR_RATIO_INF, "A bit longer text for infinity"), "A bit longer text for infinity");
+    ASSERT_EQ(tr_strratio(TR_RATIO_NA, "None", "Ratio is NaN"), "None");
+    ASSERT_EQ(tr_strratio(TR_RATIO_INF, "None", "A bit longer text for infinity"), "A bit longer text for infinity");
     // Inf contains only null character
-    ASSERT_EQ(tr_strratio(TR_RATIO_INF, &nullchar), "");
+    ASSERT_EQ(tr_strratio(TR_RATIO_INF, "None", &nullchar), "");
 
     for (auto const& [input, expected] : Tests)
     {
-        ASSERT_EQ(tr_strratio(input, "inf"), expected);
+        ASSERT_EQ(tr_strratio(input, "None", "inf"), expected);
     }
 }

--- a/utils/remote.cc
+++ b/utils/remote.cc
@@ -168,7 +168,7 @@ struct RemoteConfig
 
 [[nodiscard]] auto strlratio2(double ratio)
 {
-    return tr_strratio(ratio, "Inf");
+    return tr_strratio(ratio, "None", "Inf");
 }
 
 [[nodiscard]] auto strlratio(int64_t numerator, int64_t denominator)


### PR DESCRIPTION
Should fix #3883.