### PR TITLE
feat(remote): optionally specify piece to start sequentially download

### DIFF
--- a/utils/remote.cc
+++ b/utils/remote.cc
@@ -339,7 +339,12 @@ auto constexpr Options = std::array<tr_option, 106>{ {
     { 991, "no-start-paused", "Start added torrents unpaused", nullptr, Arg::None, nullptr },
     { 992, "trash-torrent", "Delete torrents after adding", nullptr, Arg::None, nullptr },
     { 993, "no-trash-torrent", "Do not delete torrents after adding", nullptr, Arg::None, nullptr },
-    { 994, "sequential-download", "Download the torrent sequentially", "seq", Arg::None, nullptr },
+    { 994,
+      "sequential-download",
+      "Download the torrent sequentially, starting from <piece> or 0",
+      "seq",
+      Arg::Optional,
+      "<piece>" },
     { 995, "no-sequential-download", "Download the torrent normally", "SEQ", Arg::None, nullptr },
     { 984, "honor-session", "Make the current torrent(s) honor the session limits", "hl", Arg::None, nullptr },
     { 985, "no-honor-session", "Make the current torrent(s) not honor the session limits", "HL", Arg::None, nullptr },
@@ -3187,6 +3192,10 @@ int process_args(char const* rpcurl, int argc, char const* const* argv, RemoteCo
             {
             case 994:
                 args.insert_or_assign(TR_KEY_sequential_download, true);
+                if (optarg != nullptr)
+                {
+                    args.insert_or_assign(TR_KEY_sequential_download_from_piece, numarg(optarg_sv));
+                }
                 break;
 
             case 995:


### PR DESCRIPTION
Allow setting "sequential download from piece" via an optional argument of the `--sequential-download` option.

Notes: Added support to download sequentially from a specific piece. This can enable apps to seek within media files for streaming use cases.