### PR TITLE
[RFC] feat: hotswap slow block requests in sequential mode

### DIFF
--- a/libtransmission/peer-mgr-wishlist.h
+++ b/libtransmission/peer-mgr-wishlist.h
@@ -39,6 +39,7 @@ public:
         [[nodiscard]] virtual tr_block_span_t block_span(tr_piece_index_t piece) const = 0;
         [[nodiscard]] virtual tr_piece_index_t piece_count() const = 0;
         [[nodiscard]] virtual tr_priority_t priority(tr_piece_index_t piece) const = 0;
+        [[nodiscard]] virtual bool try_hotswap(tr_block_index_t block, tr_peer const* peer) const = 0;
 
         [[nodiscard]] virtual libtransmission::ObserverTag observe_files_wanted_changed(
             libtransmission::SimpleObservable<tr_torrent*, tr_file_index_t const*, tr_file_index_t, bool>::Observer) = 0;
@@ -78,6 +79,7 @@ public:
 
     // the next blocks that we should request from a peer
     [[nodiscard]] std::vector<tr_block_span_t> next(
+        tr_peer const* peer,
         size_t n_wanted_blocks,
         std::function<bool(tr_piece_index_t)> const& peer_has_piece);
 


### PR DESCRIPTION
Initial attempt to fix https://github.com/transmission/transmission/issues/7454

This would allow a proper streaming experience, where pieces should come in order and fast, even if it means losing bandwidth efficiency (Blocks data could be received multiple times).

These changes try to implement a **hotswap** algorithm similar to [webtorrent](https://github.com/webtorrent/webtorrent):

- If a block request is assigned to a slow peer, and the current peer requesting new blocks is faster, hotswap the request to the faster peer.
- The evaluated speeds should be between `slow_speed_threshold` and `fast_speed_threshold`, to avoid too many unnecessary hotswaps.
- The faster peer should be at least **twice** as fast

  Initial results seems promising by analyzing the logs, but a few blocks can be hotswapped multiple times, effectively preventing the streaming use case. From my observations, it seems a fast peer's speed can quickly drops to zero. I guess it might be due to bandwidth management, but you might have a better idea of what can happen :pray: 