### PR TITLE
Apply Xcode 26.0 recommendations

### DIFF
--- a/Transmission.xcodeproj/project.pbxproj
+++ b/Transmission.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 51;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -3155,7 +3155,7 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
-				LastUpgradeCheck = 1530;
+				LastUpgradeCheck = 2610;
 				ORGANIZATIONNAME = "The Transmission Project";
 				TargetAttributes = {
 					8D1107260486CEB800E47090 = {
@@ -3180,7 +3180,7 @@
 				};
 			};
 			buildConfigurationList = 4DF0C59A089918A300DD8943 /* Build configuration list for PBXProject "Transmission" */;
-			compatibilityVersion = "Xcode 10.0";
+			compatibilityVersion = "Xcode 12.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 1;
 			knownRegions = (

--- a/code_style.sh
+++ b/code_style.sh
@@ -65,13 +65,17 @@ if ! find_cfiles -exec "${clang_format_exe}" $clang_format_args '{}' '+'; then
   exitcode=1
 fi
 
-# format Xcodeproj
-if ! grep -q 'objectVersion = 51' Transmission.xcodeproj/project.pbxproj; then
-  echo 'project.pbxproj needs objectVersion = 51 for compatibility with Xcode 11'
+# check important compatibility constraints in Xcode project
+if ! grep -q 'objectVersion = 54;' Transmission.xcodeproj/project.pbxproj; then
+  echo "project.pbxproj needs 'objectVersion = 54;' for compatibility with Xcode 12"
   exitcode=1
 fi
-if ! grep -q 'BuildIndependentTargetsInParallel = YES' Transmission.xcodeproj/project.pbxproj; then
-  echo 'please keep BuildIndependentTargetsInParallel in project.pbxproj'
+if ! grep -q 'compatibilityVersion = "Xcode 12.0";' Transmission.xcodeproj/project.pbxproj; then
+  echo "project.pbxproj needs 'compatibilityVersion = \"Xcode 12.0\";' for compatibility with Xcode 12"
+  exitcode=1
+fi
+if ! grep -q 'BuildIndependentTargetsInParallel = YES;' Transmission.xcodeproj/project.pbxproj; then
+  echo "please keep 'BuildIndependentTargetsInParallel = YES;' line in project.pbxproj for faster builds"
   exitcode=1
 fi
 


### PR DESCRIPTION
Also sets compatibilityVersion to Xcode 12.0.
Now 'natively' supports BuildIndependentTargetsInParallel option.
No more pain with this line being removed every time Xcode project
touched.
