### PR TITLE
Adapt to Liquid Glass window corner metrics

### DIFF
--- a/macosx/Base.lproj/MainMenu.xib
+++ b/macosx/Base.lproj/MainMenu.xib
@@ -491,7 +491,7 @@
                                     <constraint firstAttribute="height" constant="24" id="dyn-PY-CuN"/>
                                     <constraint firstItem="2700" firstAttribute="centerX" secondItem="JCm-xb-Dpw" secondAttribute="centerX" id="hcK-0p-UnE"/>
                                     <constraint firstItem="3420" firstAttribute="centerY" secondItem="JCm-xb-Dpw" secondAttribute="centerY" id="usg-NR-gmG"/>
-                                    <constraint firstItem="3435" firstAttribute="leading" secondItem="JCm-xb-Dpw" secondAttribute="leading" constant="8" id="xFe-Hi-hSp"/>
+                                    <constraint firstItem="3435" firstAttribute="leading" secondItem="JCm-xb-Dpw" secondAttribute="leading" priority="750" constant="8" id="xFe-Hi-hSp"/>
                                 </constraints>
                             </customView>
                         </subviews>

--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -649,6 +649,14 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
     self.fTotalTorrentsField.cell.backgroundStyle = NSBackgroundStyleRaised;
 
     self.fActionButton.toolTip = NSLocalizedString(@"Shortcuts for changing global settings.", "Main window -> 1st bottom left button (action) tooltip");
+    if (@available(macOS 26.0, *))
+    {
+        NSLayoutConstraint* constraint = [self.fActionButton.leadingAnchor constraintEqualToAnchor:self.fActionButton.superview.leadingAnchor
+                                                                                          constant:16.0];
+        constraint.priority = NSLayoutPriorityRequired;
+        constraint.active = YES;
+    }
+
     self.fSpeedLimitButton.toolTip = NSLocalizedString(
         @"Speed Limit overrides the total bandwidth limits with its own limits.",
         "Main window -> 2nd bottom left button (turtle) tooltip");


### PR DESCRIPTION
<table>
<tr>
 <td>Before
 <td><img width="240" height="160" alt="CropBefore" src="https://github.com/user-attachments/assets/3e98dc6e-fbb6-40f9-ab67-0c452c56fd67" />
<tr>
 <td>After
 <td><img width="240" height="160" alt="CropAfter" src="https://github.com/user-attachments/assets/8dca3dfa-e0be-49e1-810d-67e707e47f33" />
</table>