### PR TITLE
Fix. Mac GUI. Incorrect filter selected when hiding the Filter Bar and then showing it again

### DIFF
--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -2522,7 +2522,7 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
         {
             //not found - must be filtering
             NSAssert([self.fDefaults boolForKey:@"FilterBar"], @"expected the filter to be enabled");
-            [self.fFilterBar reset:YES];
+            [self.fFilterBar reset];
 
             row = [self.fTableView rowForItem:torrent];
 
@@ -4039,7 +4039,7 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
     //disable filtering when hiding (have to do before updateMainWindow:)
     if (!show)
     {
-        [self.fFilterBar reset:YES];
+        [self.fFilterBar reset];
     }
 
     [self.fDefaults setBool:show forKey:@"FilterBar"];

--- a/macosx/FilterBarController.h
+++ b/macosx/FilterBarController.h
@@ -31,7 +31,7 @@ extern NSInteger const kGroupFilterAllTag;
 - (IBAction)setSearchText:(id)sender;
 - (IBAction)setSearchType:(id)sender;
 - (IBAction)setGroupFilter:(id)sender;
-- (void)reset:(BOOL)updateUI;
+- (void)reset;
 - (void)focusSearchField;
 - (BOOL)isFocused;
 

--- a/macosx/FilterBarController.mm
+++ b/macosx/FilterBarController.mm
@@ -319,24 +319,16 @@ typedef NS_ENUM(NSInteger, FilterTypeTag) {
     [NSNotificationCenter.defaultCenter postNotificationName:@"ApplyFilter" object:nil];
 }
 
-- (void)reset:(BOOL)updateUI
+- (void)reset
 {
     [NSUserDefaults.standardUserDefaults setInteger:kGroupFilterAllTag forKey:@"FilterGroup"];
 
-    if (updateUI)
-    {
-        [self updateGroupsButton];
+    [self updateGroupsButton];
 
-        [self setFilter:self.fNoFilterButton];
+    [self setFilter:self.fNoFilterButton];
 
-        self.fSearchField.stringValue = @"";
-        [self setSearchText:self.fSearchField];
-    }
-    else
-    {
-        [NSUserDefaults.standardUserDefaults setObject:FilterTypeNone forKey:@"Filter"];
-        [NSUserDefaults.standardUserDefaults removeObjectForKey:@"FilterSearchString"];
-    }
+    self.fSearchField.stringValue = @"";
+    [self setSearchText:self.fSearchField];
 }
 
 - (NSArray<NSString*>*)searchStrings


### PR DESCRIPTION
How to reproduce the issue:
1. Show the Filter Bar (⌘+F)
2. Select any filter that is not “All”, for example “Active”
3. Hide the Filter Bar. This will switch the app to showing all downloads again
4. Show the Filter Bar. The app will keep showing all downloads but the previous filter (“Active”) will be highlighted. After that if you click on another filter, say “All” two filters in the Filter Bar will be highlighted. You need to click the third time (on some other filter), so that the filter is properly activated and highlighted in the Filter Bar.

A screenshot showing an inconsistent state of the UI after hiding and showing the filter bar again:

<img width="428" height="101" alt="Screenshot" src="https://github.com/user-attachments/assets/fc98febc-b2b7-4c19-814a-39b68413fabe" />

* * *

The fix consists of explicitly setting the filter to “All” before hiding the Filter Bar. Also as the `updateUI` parameter ends up being `YES` in all cases now, it has been removed in a separate commit.

FYI. The `updateUI` parameter was added to `FilterBarController#reset` here: https://github.com/transmission/transmission/commit/347994608410a1b96ba8b90094a0de9b0282475e

Notes: Fixed button highlighting when hiding the Filter Bar and then showing it again.

⚠️ This is an AI-assisted work. 🤖 