### PR TITLE
Update macos actions

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -323,31 +323,31 @@ jobs:
           if (Select-String -Path makelog -Pattern 'warning:') { exit 1 }
 
   macos-xcodebuild-universal:
-     runs-on: macos-26
-     needs: [ what-to-make ]
-     if: ${{ needs.what-to-make.outputs.make-cli == 'true' ||
-             needs.what-to-make.outputs.make-daemon == 'true' ||
-             needs.what-to-make.outputs.make-mac == 'true' ||
-             needs.what-to-make.outputs.make-utils == 'true' }}
-     steps:
-       - name: Show Configuration
-         run: |
-           echo '${{ toJSON(needs) }}'
-           echo '${{ toJSON(runner) }}'
-           sw_vers
-       - name: Get Dependencies
-         run: brew install --formulae xcbeautify
-       - name: Get Source
-         uses: actions/checkout@v4
-         with:
-           path: src
-           submodules: recursive
-       - name: Build
-         run: set -o pipefail && xcodebuild -project src/Transmission.xcodeproj -scheme Transmission -configuration 'Release - Debug' -derivedDataPath pfx ONLY_ACTIVE_ARCH=NO build | xcbeautify --renderer github-actions
-       - uses: actions/upload-artifact@v4
-         with:
-           name: binaries-${{ github.job }}
-           path: pfx/Build/Products/**/Transmission.app*
+    runs-on: macos-26
+    needs: [ what-to-make ]
+    if: ${{ needs.what-to-make.outputs.make-cli == 'true' ||
+            needs.what-to-make.outputs.make-daemon == 'true' ||
+            needs.what-to-make.outputs.make-mac == 'true' ||
+            needs.what-to-make.outputs.make-utils == 'true' }}
+    steps:
+      - name: Show Configuration
+        run: |
+          echo '${{ toJSON(needs) }}'
+          echo '${{ toJSON(runner) }}'
+          sw_vers
+      - name: Get Dependencies
+        run: brew install --formulae xcbeautify
+      - name: Get Source
+        uses: actions/checkout@v4
+        with:
+          path: src
+          submodules: recursive
+      - name: Build
+        run: set -o pipefail && xcodebuild -project src/Transmission.xcodeproj -scheme Transmission -configuration 'Release - Debug' -derivedDataPath pfx ONLY_ACTIVE_ARCH=NO build | xcbeautify --renderer github-actions
+      - uses: actions/upload-artifact@v4
+        with:
+          name: binaries-${{ github.job }}
+          path: pfx/Build/Products/**/Transmission.app*
 
   macos-cmake-universal:
     strategy:


### PR DESCRIPTION
- **ci: move macos-13 actions to macos-14**
- **ci: do not specify architectures in macOS CI builds**
- **ci: fold the macos-X-from-tarball jobs into a single job**
- **ci: fold macos-26 and macos-14 jobs into a single job**
- **Use macos-15-intel runners instead of macos-14 (arm64).**
- **Try out xcbeautify and fix missing artifacts**
- **Make job names more meaningful**
- **Fix indentation in macos-xcodebuild-universal**

Superseeds #7803

I want to reference my [past comment](https://github.com/transmission/transmission/pull/7803#issuecomment-3529610053) here inline for anybody who stumbles into this PR in the future for any infra-related work.

<details>
<summary>Details</summary>

I’m fine with any simplification — the current Actions setup has gradually become more and more convoluted.  
That said, we should make sure everything is properly verified in PRs.

From the top of my mind:

1. **macOS-related parts must be buildable with both `cmake` and `xcodebuild`.**

   This is just how it is right now — nothing can really be changed at the moment.  
   - The Xcode build compiles dependencies from source, with no system dependencies.  
     Xcode is the primary build system, as AFAIK releases are built using `xcodebuild`.  
   - The CMake build follows the common project setup — some dependencies can either be built from source or taken from the system, controlled by the `-DUSE_SYSTEM_*` flags.  
     CMake is also used by Homebrew to build the utilities package.  
     See [transmission-cli.rb](https://github.com/Homebrew/homebrew-core/blob/b97f568a19479554c3bd76406cc8d7737fc40632/Formula/t/transmission-cli.rb).

2. **We can use the latest arm64 macOS runners, but we should decide what CI should check:**
   - **Universal build**  
     - In a nutshell: build x64, build arm64, and stitch them together — all in one action.  
     - **Pros:** single, release-like artifact.  
     - **Cons:** doubles the build time in a single action.  
   - **Separate x64 and arm64 builds**  
     - Builds can run in parallel, one architecture per action.  
     - **Pros:** faster builds and smaller artifacts.  
     - **Cons:** resulting artifacts are less representative of a release.

So, the host can absolutely be arm64 — there’s a real shortage of x64 runners anyway.  
But we must ensure that both x64 and arm64 targets remain buildable.

</details>