### PR TITLE
fix: ensure the main window's network timer is set properly

### DIFF
--- a/qt/MainWindow.h
+++ b/qt/MainWindow.h
@@ -75,7 +75,6 @@ public slots:
     void queueMoveDown();
     void queueMoveBottom();
     void reannounceSelected();
-    void onNetworkTimer();
 
     void setToolbarVisible(bool);
     void setFilterbarVisible(bool);
@@ -122,12 +121,12 @@ private slots:
     void toggleSpeedMode();
     void toggleWindows(bool do_show);
     void trayActivated(QSystemTrayIcon::ActivationReason);
+    void updateNetworkLabel();
 
 private:
     [[nodiscard]] QIcon addEmblem(QIcon icon, QStringList const& emblem_names) const;
 
     [[nodiscard]] torrent_ids_t getSelectedTorrents(bool with_metadata_only = false) const;
-    void updateNetworkIcon();
 
     QMenu* createOptionsMenu();
     QMenu* createStatsModeMenu();


### PR DESCRIPTION
Previously, it didn't get started after switching to a local session to a remote session, which could cause an incorrect status to be displayed in the network status icon.

Marking as `notes:none` since this fix is hard to summarize clearly: things worked _most_ of the time anyway due to a side-effect of how the statusbar gets updated whenever there's a change to the torrent model. But it's still better to have this fixed properly to handle error cases, such as when switching from a local session to a remote session that initially responds but then stops responding.