### PR TITLE
fix: Add torrent ID prefix to file listing heading in transmission-re…

### DIFF
--- a/utils/remote.cc
+++ b/utils/remote.cc
@@ -1349,8 +1349,8 @@ void print_file_list(tr_variant::Map const& map)
         }
 
         auto const n = std::size(*files);
-        fmt::print("{:s} ({:d} files):\n", *name, n);
-        fmt::print("{:>3s}  {:>5s} {:>8s} {:>3s} {:>9s}  {:s}\n", "#", "Done", "Priority", "Get", "Size", "Name");
+          auto const id = t->value_if<int64_t>(TR_KEY_id);
+    fmt::print("{:d}: {:s} ({:d} files):\n", id, *name, n);        fmt::print("{:>3s}  {:>5s} {:>8s} {:>3s} {:>9s}  {:s}\n", "#", "Done", "Priority", "Get", "Size", "Name");
 
         for (size_t i = 0; i < n; ++i)
         {


### PR DESCRIPTION
…mote

This change addresses issue #7791 by adding the torrent ID to the file listing heading when using transmission-remote -t -f command.

Changes made to utils/remote.cc in the print_file_list() function:
1. Added line to retrieve the torrent ID: auto const id = t->value_if<int64_t>(TR_KEY_id);
2. Modified fmt::print format string from "{:s} ({:d} files):\n" to "{:d}: {:s} ({:d} files):\n"
3. Updated the print arguments to include the ID as the first parameter

Result: File listing output now shows "<ID>: <Torrent Name> (<file count> files):" instead of just "<Torrent Name> (<file count> files):", making it clear which torrent ID each file list belongs to when displaying multiple torrents.