### PR TITLE
ci: use clang for alpine-musl build

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -441,11 +441,11 @@ jobs:
           apk update
           apk add \
             ca-certificates \
+            clang \
             cmake \
             crc32c-dev \
             curl-dev \
             fmt-dev \
-            g++ \
             gettext-dev \
             git \
             libevent-dev \
@@ -473,6 +473,8 @@ jobs:
             -S src \
             -B obj \
             -G Ninja \
+            -DCMAKE_C_COMPILER='clang' \
+            -DCMAKE_CXX_COMPILER='clang++' \
             -DCMAKE_BUILD_TYPE=RelWithDebInfo \
             -DCMAKE_INSTALL_PREFIX=pfx \
             -DENABLE_CLI=${{ (needs.what-to-make.outputs.make-cli == 'true') && 'ON' || 'OFF' }} \


### PR DESCRIPTION
The version of g++ in the new alpine/latest is giving what appears to be a false positive compiler warning that breaks CI. Let's switch to clang for now.