### PR TITLE
fix: FTBFS in C++20

### DIFF
--- a/libtransmission/variant.h
+++ b/libtransmission/variant.h
@@ -101,7 +101,7 @@ public:
 
         [[nodiscard]] TR_CONSTEXPR20 auto find(std::initializer_list<tr_quark> keys) noexcept
         {
-            static auto constexpr Predicate = [](auto const& item, tr_quark key)
+            auto constexpr Predicate = [](auto const& item, tr_quark key)
             {
                 return item.first == key;
             };


### PR DESCRIPTION
Fixes #7875.

I suppose we don't need notes because we don't officially support C++20.