### PR TITLE
feat: expose JsonRpc::Error API

### DIFF
--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -11,6 +11,7 @@
 #include <iterator>
 #include <memory>
 #include <numeric>
+#include <optional>
 #include <set>
 #include <string>
 #include <string_view>
@@ -56,44 +57,23 @@ namespace Error
 {
 namespace
 {
-[[nodiscard]] constexpr std::string_view get_message(Code code)
-{
-    switch (code)
-    {
-    case PARSE_ERROR:
-        return "Parse error"sv;
-    case INVALID_REQUEST:
-        return "Invalid Request"sv;
-    case METHOD_NOT_FOUND:
-        return "Method not found"sv;
-    case INVALID_PARAMS:
-        return "Invalid params"sv;
-    case INTERNAL_ERROR:
-        return "Internal error"sv;
-    case SUCCESS:
-        return "success"sv;
-    case SET_ANNOUNCE_LIST:
-        return "error setting announce list"sv;
-    case INVALID_TRACKER_LIST:
-        return "Invalid tracker list"sv;
-    case PATH_NOT_ABSOLUTE:
-        return "path is not absolute"sv;
-    case UNRECOGNIZED_INFO:
-        return "unrecognized info"sv;
-    case SYSTEM_ERROR:
-        return "system error"sv;
-    case FILE_IDX_OOR:
-        return "file index out of range"sv;
-    case PIECE_IDX_OOR:
-        return "piece index out of range"sv;
-    case HTTP_ERROR:
-        return "HTTP error from backend service"sv;
-    case CORRUPT_TORRENT:
-        return "invalid or corrupt torrent file"sv;
-    default:
-        return {};
-    }
-}
+auto constexpr Messages = std::array<std::pair<Code, std::string_view>, 15U>{ {
+    { PARSE_ERROR, "Parse error"sv },
+    { INVALID_REQUEST, "Invalid Request"sv },
+    { METHOD_NOT_FOUND, "Method not found"sv },
+    { INVALID_PARAMS, "Invalid params"sv },
+    { INTERNAL_ERROR, "Internal error"sv },
+    { SUCCESS, "success"sv },
+    { SET_ANNOUNCE_LIST, "error setting announce list"sv },
+    { INVALID_TRACKER_LIST, "Invalid tracker list"sv },
+    { PATH_NOT_ABSOLUTE, "path is not absolute"sv },
+    { UNRECOGNIZED_INFO, "unrecognized info"sv },
+    { SYSTEM_ERROR, "system error"sv },
+    { FILE_IDX_OOR, "file index out of range"sv },
+    { PIECE_IDX_OOR, "piece index out of range"sv },
+    { HTTP_ERROR, "HTTP error from backend service"sv },
+    { CORRUPT_TORRENT, "invalid or corrupt torrent file"sv },
+} };
 
 [[nodiscard]] tr_variant::Map build_data(std::string_view error_string, tr_variant::Map&& result)
 {
@@ -116,7 +96,7 @@ namespace
 {
     auto ret = tr_variant::Map{ 3U };
     ret.try_emplace(TR_KEY_code, code);
-    ret.try_emplace(TR_KEY_message, tr_variant::unmanaged_string(get_message(code)));
+    ret.try_emplace(TR_KEY_message, tr_variant::unmanaged_string(to_string(code)));
     if (!std::empty(data))
     {
         ret.try_emplace(TR_KEY_data, std::move(data));
@@ -125,6 +105,33 @@ namespace
     return ret;
 }
 } // namespace
+
+[[nodiscard]] std::string_view to_string(Code const code_in)
+{
+    for (auto const& [code, str] : Messages)
+    {
+        if (code_in == code)
+        {
+            return str;
+        }
+    }
+
+    return {};
+}
+
+[[nodiscard]] std::optional<Code> to_code(std::string_view const errmsg)
+{
+    for (auto const& [code, str] : Messages)
+    {
+        if (errmsg == str)
+        {
+            return code;
+        }
+    }
+
+    return {};
+}
+
 } // namespace Error
 
 namespace
@@ -205,7 +212,7 @@ void tr_rpc_idle_done_legacy(struct tr_rpc_idle_data* data, JsonRpc::Error::Code
     // build the response
     auto response_map = tr_variant::Map{ 3U };
     response_map.try_emplace(TR_KEY_arguments, std::move(data->args_out));
-    response_map.try_emplace(TR_KEY_result, std::empty(result) ? JsonRpc::Error::get_message(code) : result);
+    response_map.try_emplace(TR_KEY_result, std::empty(result) ? JsonRpc::Error::to_string(code) : result);
     if (auto& tag = data->id; tag.has_value())
     {
         response_map.try_emplace(TR_KEY_tag, std::move(tag));

--- a/libtransmission/rpcimpl.h
+++ b/libtransmission/rpcimpl.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <functional>
+#include <optional>
 
 struct tr_session;
 struct tr_variant;
@@ -34,7 +35,11 @@ enum Code : int16_t
     HTTP_ERROR,
     CORRUPT_TORRENT
 };
-}
+
+[[nodiscard]] std::string_view to_string(Code code);
+
+[[nodiscard]] std::optional<Code> to_code(std::string_view errmsg);
+} // namespace Error
 } // namespace JsonRpc
 
 using tr_rpc_response_func = std::function<void(tr_session* session, tr_variant&& response)>;

--- a/tests/libtransmission/rpc-test.cc
+++ b/tests/libtransmission/rpc-test.cc
@@ -977,4 +977,17 @@ TEST_F(RpcTest, wellFormedLegacyFreeSpace)
 }
 } // namespace free_space_test
 
+TEST_F(RpcTest, jsonRpcError)
+{
+    using namespace JsonRpc::Error;
+    for (auto const code : { PARSE_ERROR, INVALID_REQUEST, METHOD_NOT_FOUND, INVALID_PARAMS, INTERNAL_ERROR })
+    {
+        auto const str = to_string(code);
+        EXPECT_NE(""sv, str);
+        auto const actual = to_code(str);
+        ASSERT_TRUE(actual);
+        EXPECT_EQ(code, *actual);
+    }
+}
+
 } // namespace libtransmission::test


### PR DESCRIPTION
Expose this API so the [style converter](https://github.com/transmission/transmission/issues/7891#issuecomment-3635136911) can use it to convert RPC error responses  between jsonrpc and legacy formats.