### PR TITLE
docs: add quark citation code comments

### DIFF
--- a/libtransmission/quark.cc
+++ b/libtransmission/quark.cc
@@ -20,718 +20,719 @@ namespace
 
 auto constexpr MyStatic = std::array<std::string_view, TR_N_KEYS>{
     ""sv,
-    "activeTorrentCount"sv,
-    "active_torrent_count"sv,
-    "activity-date"sv,
-    "activityDate"sv,
-    "activity_date"sv,
-    "added"sv,
-    "added-date"sv,
-    "added.f"sv,
-    "added6"sv,
-    "added6.f"sv,
-    "addedDate"sv,
-    "added_date"sv,
-    "address"sv,
-    "alt-speed-down"sv,
-    "alt-speed-enabled"sv,
-    "alt-speed-time-begin"sv,
-    "alt-speed-time-day"sv,
-    "alt-speed-time-enabled"sv,
-    "alt-speed-time-end"sv,
-    "alt-speed-up"sv,
-    "alt_speed_down"sv,
-    "alt_speed_enabled"sv,
-    "alt_speed_time_begin"sv,
-    "alt_speed_time_day"sv,
-    "alt_speed_time_enabled"sv,
-    "alt_speed_time_end"sv,
-    "alt_speed_up"sv,
-    "announce"sv,
-    "announce-ip"sv,
-    "announce-ip-enabled"sv,
-    "announce-list"sv,
-    "announceState"sv,
-    "announce_ip"sv,
-    "announce_ip_enabled"sv,
-    "announce_state"sv,
-    "anti-brute-force-enabled"sv,
-    "anti-brute-force-threshold"sv,
-    "anti_brute_force_enabled"sv,
-    "anti_brute_force_threshold"sv,
-    "arguments"sv,
-    "availability"sv,
-    "bandwidth-priority"sv,
-    "bandwidthPriority"sv,
-    "bandwidth_priority"sv,
-    "begin_piece"sv,
-    "bind-address-ipv4"sv,
-    "bind-address-ipv6"sv,
-    "bind_address_ipv4"sv,
-    "bind_address_ipv6"sv,
-    "bitfield"sv,
-    "blocklist-date"sv,
-    "blocklist-enabled"sv,
-    "blocklist-size"sv,
-    "blocklist-update"sv,
-    "blocklist-updates-enabled"sv,
-    "blocklist-url"sv,
-    "blocklist_date"sv,
-    "blocklist_enabled"sv,
-    "blocklist_size"sv,
-    "blocklist_update"sv,
-    "blocklist_updates_enabled"sv,
-    "blocklist_url"sv,
-    "blocks"sv,
-    "bytesCompleted"sv,
-    "bytes_completed"sv,
-    "bytes_to_client"sv,
-    "bytes_to_peer"sv,
-    "cache-size-mb"sv,
-    "cache_size_mb"sv,
-    "clientIsChoked"sv,
-    "clientIsInterested"sv,
-    "clientName"sv,
-    "client_is_choked"sv,
-    "client_is_interested"sv,
-    "client_name"sv,
-    "code"sv,
-    "comment"sv,
-    "compact-view"sv,
-    "compact_view"sv,
-    "complete"sv,
-    "config-dir"sv,
-    "config_dir"sv,
-    "cookies"sv,
-    "corrupt"sv,
-    "corruptEver"sv,
-    "corrupt_ever"sv,
-    "created by"sv,
-    "creation date"sv,
-    "creator"sv,
-    "cumulative-stats"sv,
-    "cumulative_stats"sv,
-    "current-stats"sv,
-    "current_stats"sv,
-    "data"sv,
-    "dateCreated"sv,
-    "date_created"sv,
-    "default-trackers"sv,
-    "default_trackers"sv,
-    "delete-local-data"sv,
-    "delete_local_data"sv,
-    "desiredAvailable"sv,
-    "desired_available"sv,
-    "destination"sv,
-    "details-window-height"sv,
-    "details-window-width"sv,
-    "details_window_height"sv,
-    "details_window_width"sv,
-    "dht-enabled"sv,
-    "dht_enabled"sv,
-    "dnd"sv,
-    "done-date"sv,
-    "doneDate"sv,
-    "done_date"sv,
-    "download-dir"sv,
-    "download-dir-free-space"sv,
-    "download-queue-enabled"sv,
-    "download-queue-size"sv,
-    "downloadCount"sv,
-    "downloadDir"sv,
-    "downloadLimit"sv,
-    "downloadLimited"sv,
-    "downloadSpeed"sv,
-    "download_count"sv,
-    "download_dir"sv,
-    "download_dir_free_space"sv,
-    "download_limit"sv,
-    "download_limited"sv,
-    "download_queue_enabled"sv,
-    "download_queue_size"sv,
-    "download_speed"sv,
-    "downloaded"sv,
-    "downloaded-bytes"sv,
-    "downloadedBytes"sv,
-    "downloadedEver"sv,
-    "downloaded_bytes"sv,
-    "downloaded_ever"sv,
-    "downloader_count"sv,
-    "downloading-time-seconds"sv,
-    "downloading_time_seconds"sv,
-    "dropped"sv,
-    "dropped6"sv,
-    "e"sv,
-    "editDate"sv,
-    "edit_date"sv,
-    "encoding"sv,
-    "encryption"sv,
-    "end_piece"sv,
-    "error"sv,
-    "errorString"sv,
-    "error_string"sv,
-    "eta"sv,
-    "etaIdle"sv,
-    "eta_idle"sv,
-    "fields"sv,
-    "file-count"sv,
-    "fileStats"sv,
-    "file_count"sv,
-    "file_stats"sv,
-    "filename"sv,
-    "files"sv,
-    "files-added"sv,
-    "files-unwanted"sv,
-    "files-wanted"sv,
-    "filesAdded"sv,
-    "files_added"sv,
-    "files_unwanted"sv,
-    "files_wanted"sv,
-    "filter-mode"sv,
-    "filter-text"sv,
-    "filter-trackers"sv,
-    "filter_mode"sv,
-    "filter_text"sv,
-    "filter_trackers"sv,
-    "flagStr"sv,
-    "flag_str"sv,
-    "flags"sv,
-    "format"sv,
-    "free-space"sv,
-    "free_space"sv,
-    "fromCache"sv,
-    "fromDht"sv,
-    "fromIncoming"sv,
-    "fromLpd"sv,
-    "fromLtep"sv,
-    "fromPex"sv,
-    "fromTracker"sv,
-    "from_cache"sv,
-    "from_dht"sv,
-    "from_incoming"sv,
-    "from_lpd"sv,
-    "from_ltep"sv,
-    "from_pex"sv,
-    "from_tracker"sv,
-    "group"sv,
-    "group-get"sv,
-    "group-set"sv,
-    "group_get"sv,
-    "group_set"sv,
-    "hasAnnounced"sv,
-    "hasScraped"sv,
-    "has_announced"sv,
-    "has_scraped"sv,
-    "hashString"sv,
-    "hash_string"sv,
-    "haveUnchecked"sv,
-    "haveValid"sv,
-    "have_unchecked"sv,
-    "have_valid"sv,
-    "honorsSessionLimits"sv,
-    "honors_session_limits"sv,
-    "host"sv,
-    "id"sv,
-    "id_timestamp"sv,
-    "idle-limit"sv,
-    "idle-mode"sv,
-    "idle-seeding-limit"sv,
-    "idle-seeding-limit-enabled"sv,
-    "idle_limit"sv,
-    "idle_mode"sv,
-    "idle_seeding_limit"sv,
-    "idle_seeding_limit_enabled"sv,
-    "ids"sv,
-    "incomplete"sv,
-    "incomplete-dir"sv,
-    "incomplete-dir-enabled"sv,
-    "incomplete_dir"sv,
-    "incomplete_dir_enabled"sv,
-    "info"sv,
-    "inhibit-desktop-hibernation"sv,
-    "inhibit_desktop_hibernation"sv,
-    "ip_protocol"sv,
-    "ipv4"sv,
-    "ipv6"sv,
-    "isBackup"sv,
-    "isDownloadingFrom"sv,
-    "isEncrypted"sv,
-    "isFinished"sv,
-    "isIncoming"sv,
-    "isPrivate"sv,
-    "isStalled"sv,
-    "isUTP"sv,
-    "isUploadingTo"sv,
-    "is_backup"sv,
-    "is_downloading_from"sv,
-    "is_encrypted"sv,
-    "is_finished"sv,
-    "is_incoming"sv,
-    "is_private"sv,
-    "is_stalled"sv,
-    "is_uploading_to"sv,
-    "is_utp"sv,
-    "jsonrpc"sv,
-    "labels"sv,
-    "lastAnnouncePeerCount"sv,
-    "lastAnnounceResult"sv,
-    "lastAnnounceStartTime"sv,
-    "lastAnnounceSucceeded"sv,
-    "lastAnnounceTime"sv,
-    "lastAnnounceTimedOut"sv,
-    "lastScrapeResult"sv,
-    "lastScrapeStartTime"sv,
-    "lastScrapeSucceeded"sv,
-    "lastScrapeTime"sv,
-    "lastScrapeTimedOut"sv,
-    "last_announce_peer_count"sv,
-    "last_announce_result"sv,
-    "last_announce_start_time"sv,
-    "last_announce_succeeded"sv,
-    "last_announce_time"sv,
-    "last_announce_timed_out"sv,
-    "last_scrape_result"sv,
-    "last_scrape_start_time"sv,
-    "last_scrape_succeeded"sv,
-    "last_scrape_time"sv,
-    "last_scrape_timed_out"sv,
-    "leecherCount"sv,
-    "leecher_count"sv,
-    "leftUntilDone"sv,
-    "left_until_done"sv,
-    "length"sv,
-    "location"sv,
-    "lpd-enabled"sv,
-    "lpd_enabled"sv,
-    "m"sv,
-    "magnetLink"sv,
-    "magnet_link"sv,
-    "main-window-height"sv,
-    "main-window-is-maximized"sv,
-    "main-window-layout-order"sv,
-    "main-window-width"sv,
-    "main-window-x"sv,
-    "main-window-y"sv,
-    "main_window_height"sv,
-    "main_window_is_maximized"sv,
-    "main_window_layout_order"sv,
-    "main_window_width"sv,
-    "main_window_x"sv,
-    "main_window_y"sv,
-    "manualAnnounceTime"sv,
-    "manual_announce_time"sv,
-    "max-peers"sv,
-    "maxConnectedPeers"sv,
-    "max_connected_peers"sv,
-    "max_peers"sv,
-    "memory-bytes"sv,
-    "memory-units"sv,
-    "memory_bytes"sv,
-    "memory_units"sv,
-    "message"sv,
-    "message-level"sv,
-    "message_level"sv,
-    "metadataPercentComplete"sv,
-    "metadata_percent_complete"sv,
-    "metadata_size"sv,
-    "metainfo"sv,
-    "method"sv,
-    "move"sv,
-    "msg_type"sv,
-    "mtimes"sv,
-    "name"sv,
-    "nextAnnounceTime"sv,
-    "nextScrapeTime"sv,
-    "next_announce_time"sv,
-    "next_scrape_time"sv,
-    "nodes"sv,
-    "nodes6"sv,
-    "open-dialog-dir"sv,
-    "open_dialog_dir"sv,
-    "p"sv,
-    "params"sv,
-    "path"sv,
-    "paused"sv,
-    "pausedTorrentCount"sv,
-    "paused_torrent_count"sv,
-    "peer-congestion-algorithm"sv,
-    "peer-limit"sv,
-    "peer-limit-global"sv,
-    "peer-limit-per-torrent"sv,
-    "peer-port"sv,
-    "peer-port-random-high"sv,
-    "peer-port-random-low"sv,
-    "peer-port-random-on-start"sv,
-    "peer-socket-tos"sv,
-    "peerIsChoked"sv,
-    "peerIsInterested"sv,
-    "peer_congestion_algorithm"sv,
-    "peer_id"sv,
-    "peer_is_choked"sv,
-    "peer_is_interested"sv,
-    "peer_limit"sv,
-    "peer_limit_global"sv,
-    "peer_limit_per_torrent"sv,
-    "peer_port"sv,
-    "peer_port_random_high"sv,
-    "peer_port_random_low"sv,
-    "peer_port_random_on_start"sv,
-    "peer_socket_tos"sv,
-    "peers"sv,
-    "peers2"sv,
-    "peers2-6"sv,
-    "peers2_6"sv,
-    "peersConnected"sv,
-    "peersFrom"sv,
-    "peersGettingFromUs"sv,
-    "peersSendingToUs"sv,
-    "peers_connected"sv,
-    "peers_from"sv,
-    "peers_getting_from_us"sv,
-    "peers_sending_to_us"sv,
-    "percentComplete"sv,
-    "percentDone"sv,
-    "percent_complete"sv,
-    "percent_done"sv,
-    "pex-enabled"sv,
-    "pex_enabled"sv,
-    "pidfile"sv,
-    "piece"sv,
-    "piece length"sv,
-    "pieceCount"sv,
-    "pieceSize"sv,
-    "piece_count"sv,
-    "piece_size"sv,
-    "pieces"sv,
-    "port"sv,
-    "port-forwarding-enabled"sv,
-    "port-is-open"sv,
-    "port-test"sv,
-    "port_forwarding_enabled"sv,
-    "port_is_open"sv,
-    "port_test"sv,
-    "preallocation"sv,
-    "preferred_transports"sv,
-    "primary-mime-type"sv,
-    "primary_mime_type"sv,
-    "priorities"sv,
-    "priority"sv,
-    "priority-high"sv,
-    "priority-low"sv,
-    "priority-normal"sv,
-    "priority_high"sv,
-    "priority_low"sv,
-    "priority_normal"sv,
-    "private"sv,
-    "progress"sv,
-    "prompt-before-exit"sv,
-    "prompt_before_exit"sv,
-    "proxy_url"sv,
-    "queue-move-bottom"sv,
-    "queue-move-down"sv,
-    "queue-move-top"sv,
-    "queue-move-up"sv,
-    "queue-stalled-enabled"sv,
-    "queue-stalled-minutes"sv,
-    "queuePosition"sv,
-    "queue_move_bottom"sv,
-    "queue_move_down"sv,
-    "queue_move_top"sv,
-    "queue_move_up"sv,
-    "queue_position"sv,
-    "queue_stalled_enabled"sv,
-    "queue_stalled_minutes"sv,
-    "rateDownload"sv,
-    "rateToClient"sv,
-    "rateToPeer"sv,
-    "rateUpload"sv,
-    "rate_download"sv,
-    "rate_to_client"sv,
-    "rate_to_peer"sv,
-    "rate_upload"sv,
-    "ratio-limit"sv,
-    "ratio-limit-enabled"sv,
-    "ratio-mode"sv,
-    "ratio_limit"sv,
-    "ratio_limit_enabled"sv,
-    "ratio_mode"sv,
-    "read-clipboard"sv,
-    "read_clipboard"sv,
-    "recently-active"sv,
-    "recently_active"sv,
-    "recheckProgress"sv,
-    "recheck_progress"sv,
-    "remote-session-enabled"sv,
-    "remote-session-host"sv,
-    "remote-session-https"sv,
-    "remote-session-password"sv,
-    "remote-session-port"sv,
-    "remote-session-requres-authentication"sv,
-    "remote-session-username"sv,
-    "remote_session_enabled"sv,
-    "remote_session_host"sv,
-    "remote_session_https"sv,
-    "remote_session_password"sv,
-    "remote_session_port"sv,
-    "remote_session_requires_authentication"sv,
-    "remote_session_rpc_url_path"sv,
-    "remote_session_username"sv,
-    "removed"sv,
-    "rename-partial-files"sv,
-    "rename_partial_files"sv,
-    "reqq"sv,
-    "result"sv,
-    "rpc-authentication-required"sv,
-    "rpc-bind-address"sv,
-    "rpc-enabled"sv,
-    "rpc-host-whitelist"sv,
-    "rpc-host-whitelist-enabled"sv,
-    "rpc-password"sv,
-    "rpc-port"sv,
-    "rpc-socket-mode"sv,
-    "rpc-url"sv,
-    "rpc-username"sv,
-    "rpc-version"sv,
-    "rpc-version-minimum"sv,
-    "rpc-version-semver"sv,
-    "rpc-whitelist"sv,
-    "rpc-whitelist-enabled"sv,
-    "rpc_authentication_required"sv,
-    "rpc_bind_address"sv,
-    "rpc_enabled"sv,
-    "rpc_host_whitelist"sv,
-    "rpc_host_whitelist_enabled"sv,
-    "rpc_password"sv,
-    "rpc_port"sv,
-    "rpc_socket_mode"sv,
-    "rpc_url"sv,
-    "rpc_username"sv,
-    "rpc_version"sv,
-    "rpc_version_minimum"sv,
-    "rpc_version_semver"sv,
-    "rpc_whitelist"sv,
-    "rpc_whitelist_enabled"sv,
-    "scrape"sv,
-    "scrape-paused-torrents-enabled"sv,
-    "scrapeState"sv,
-    "scrape_paused_torrents_enabled"sv,
-    "scrape_state"sv,
-    "script-torrent-added-enabled"sv,
-    "script-torrent-added-filename"sv,
-    "script-torrent-done-enabled"sv,
-    "script-torrent-done-filename"sv,
-    "script-torrent-done-seeding-enabled"sv,
-    "script-torrent-done-seeding-filename"sv,
-    "script_torrent_added_enabled"sv,
-    "script_torrent_added_filename"sv,
-    "script_torrent_done_enabled"sv,
-    "script_torrent_done_filename"sv,
-    "script_torrent_done_seeding_enabled"sv,
-    "script_torrent_done_seeding_filename"sv,
-    "seconds-active"sv,
-    "secondsActive"sv,
-    "secondsDownloading"sv,
-    "secondsSeeding"sv,
-    "seconds_active"sv,
-    "seconds_downloading"sv,
-    "seconds_seeding"sv,
-    "seed-queue-enabled"sv,
-    "seed-queue-size"sv,
-    "seedIdleLimit"sv,
-    "seedIdleMode"sv,
-    "seedRatioLimit"sv,
-    "seedRatioLimited"sv,
-    "seedRatioMode"sv,
-    "seed_idle_limit"sv,
-    "seed_idle_mode"sv,
-    "seed_queue_enabled"sv,
-    "seed_queue_size"sv,
-    "seed_ratio_limit"sv,
-    "seed_ratio_limited"sv,
-    "seed_ratio_mode"sv,
-    "seederCount"sv,
-    "seeder_count"sv,
-    "seeding-time-seconds"sv,
-    "seeding_time_seconds"sv,
-    "sequential_download"sv,
-    "sequential_download_from_piece"sv,
-    "session-close"sv,
-    "session-count"sv,
-    "session-get"sv,
-    "session-id"sv,
-    "session-set"sv,
-    "session-stats"sv,
-    "sessionCount"sv,
-    "session_close"sv,
-    "session_count"sv,
-    "session_get"sv,
-    "session_id"sv,
-    "session_set"sv,
-    "session_stats"sv,
-    "show-backup-trackers"sv,
-    "show-extra-peer-details"sv,
-    "show-filterbar"sv,
-    "show-notification-area-icon"sv,
-    "show-options-window"sv,
-    "show-statusbar"sv,
-    "show-toolbar"sv,
-    "show-tracker-scrapes"sv,
-    "show_backup_trackers"sv,
-    "show_extra_peer_details"sv,
-    "show_filterbar"sv,
-    "show_notification_area_icon"sv,
-    "show_options_window"sv,
-    "show_statusbar"sv,
-    "show_toolbar"sv,
-    "show_tracker_scrapes"sv,
-    "sitename"sv,
-    "size-bytes"sv,
-    "size-units"sv,
-    "sizeWhenDone"sv,
-    "size_bytes"sv,
-    "size_units"sv,
-    "size_when_done"sv,
-    "sleep-per-seconds-during-verify"sv,
-    "sleep_per_seconds_during_verify"sv,
-    "socket_address"sv,
-    "sort-mode"sv,
-    "sort-reversed"sv,
-    "sort_mode"sv,
-    "sort_reversed"sv,
-    "source"sv,
-    "speed"sv,
-    "speed-Bps"sv,
-    "speed-bytes"sv,
-    "speed-limit-down"sv,
-    "speed-limit-down-enabled"sv,
-    "speed-limit-up"sv,
-    "speed-limit-up-enabled"sv,
-    "speed-units"sv,
-    "speed_Bps"sv,
-    "speed_bytes"sv,
-    "speed_limit_down"sv,
-    "speed_limit_down_enabled"sv,
-    "speed_limit_up"sv,
-    "speed_limit_up_enabled"sv,
-    "speed_units"sv,
-    "start-added-torrents"sv,
-    "start-minimized"sv,
-    "startDate"sv,
-    "start_added_torrents"sv,
-    "start_date"sv,
-    "start_minimized"sv,
-    "start_paused"sv,
-    "status"sv,
-    "statusbar-stats"sv,
-    "statusbar_stats"sv,
-    "tag"sv,
-    "tcp-enabled"sv,
-    "tcp_enabled"sv,
-    "tier"sv,
-    "time-checked"sv,
-    "torrent-add"sv,
-    "torrent-added"sv,
-    "torrent-added-notification-enabled"sv,
-    "torrent-added-verify-mode"sv,
-    "torrent-complete-notification-enabled"sv,
-    "torrent-complete-sound-command"sv,
-    "torrent-complete-sound-enabled"sv,
-    "torrent-duplicate"sv,
-    "torrent-get"sv,
-    "torrent-reannounce"sv,
-    "torrent-remove"sv,
-    "torrent-rename-path"sv,
-    "torrent-set"sv,
-    "torrent-set-location"sv,
-    "torrent-start"sv,
-    "torrent-start-now"sv,
-    "torrent-stop"sv,
-    "torrent-verify"sv,
-    "torrentCount"sv,
-    "torrentFile"sv,
-    "torrent_add"sv,
-    "torrent_added"sv,
-    "torrent_added_notification_enabled"sv,
-    "torrent_added_verify_mode"sv,
-    "torrent_complete_notification_enabled"sv,
-    "torrent_complete_sound_command"sv,
-    "torrent_complete_sound_enabled"sv,
-    "torrent_complete_verify_enabled"sv,
-    "torrent_count"sv,
-    "torrent_duplicate"sv,
-    "torrent_file"sv,
-    "torrent_get"sv,
-    "torrent_reannounce"sv,
-    "torrent_remove"sv,
-    "torrent_rename_path"sv,
-    "torrent_set"sv,
-    "torrent_set_location"sv,
-    "torrent_start"sv,
-    "torrent_start_now"sv,
-    "torrent_stop"sv,
-    "torrent_verify"sv,
-    "torrents"sv,
-    "totalSize"sv,
-    "total_size"sv,
-    "trackerAdd"sv,
-    "trackerList"sv,
-    "trackerRemove"sv,
-    "trackerReplace"sv,
-    "trackerStats"sv,
-    "tracker_add"sv,
-    "tracker_list"sv,
-    "tracker_remove"sv,
-    "tracker_replace"sv,
-    "tracker_stats"sv,
-    "trackers"sv,
-    "trash-can-enabled"sv,
-    "trash-original-torrent-files"sv,
-    "trash_can_enabled"sv,
-    "trash_original_torrent_files"sv,
-    "umask"sv,
-    "units"sv,
-    "upload-slots-per-torrent"sv,
-    "uploadLimit"sv,
-    "uploadLimited"sv,
-    "uploadRatio"sv,
-    "uploadSpeed"sv,
-    "upload_limit"sv,
-    "upload_limited"sv,
-    "upload_only"sv,
-    "upload_ratio"sv,
-    "upload_slots_per_torrent"sv,
-    "upload_speed"sv,
-    "uploaded"sv,
-    "uploaded-bytes"sv,
-    "uploadedBytes"sv,
-    "uploadedEver"sv,
-    "uploaded_bytes"sv,
-    "uploaded_ever"sv,
-    "url-list"sv,
-    "use-global-speed-limit"sv,
-    "use-speed-limit"sv,
-    "use_global_speed_limit"sv,
-    "use_speed_limit"sv,
-    "user-has-given-informed-consent"sv,
-    "user_has_given_informed_consent"sv,
-    "ut_holepunch"sv,
-    "ut_metadata"sv,
-    "ut_pex"sv,
-    "utp-enabled"sv,
-    "utp_enabled"sv,
-    "v"sv,
-    "version"sv,
-    "wanted"sv,
-    "watch-dir"sv,
-    "watch-dir-enabled"sv,
-    "watch-dir-force-generic"sv,
-    "watch_dir"sv,
-    "watch_dir_enabled"sv,
-    "watch_dir_force_generic"sv,
-    "webseeds"sv,
-    "webseedsSendingToUs"sv,
-    "webseeds_sending_to_us"sv,
-    "yourip"sv,
+    "activeTorrentCount"sv, // rpc
+    "active_torrent_count"sv, // rpc
+    "activity-date"sv, // .resume
+    "activityDate"sv, // rpc
+    "activity_date"sv, // .resume, rpc
+    "added"sv, // BEP0011; BT protocol, rpc
+    "added-date"sv, // .resume
+    "added.f"sv, // BEP0011; BT protocol
+    "added6"sv, // BEP0011; BT protocol
+    "added6.f"sv, // BEP0011; BT protocol
+    "addedDate"sv, // rpc
+    "added_date"sv, // .resume, rpc
+    "address"sv, // rpc
+    "alt-speed-down"sv, // gtk app, rpc, speed settings
+    "alt-speed-enabled"sv, // gtk app, rpc, speed settings
+    "alt-speed-time-begin"sv, // rpc, speed settings
+    "alt-speed-time-day"sv, // rpc, speed settings
+    "alt-speed-time-enabled"sv, // rpc, speed settings
+    "alt-speed-time-end"sv, // rpc, speed settings
+    "alt-speed-up"sv, // gtk app, rpc, speed settings
+    "alt_speed_down"sv, // gtk app, rpc, speed settings
+    "alt_speed_enabled"sv, // gtk app, rpc, speed settings
+    "alt_speed_time_begin"sv, // rpc, speed settings
+    "alt_speed_time_day"sv, // rpc, speed settings
+    "alt_speed_time_enabled"sv, // rpc, speed settings
+    "alt_speed_time_end"sv, // rpc, speed settings
+    "alt_speed_up"sv, // gtk app, rpc, speed settings
+    "announce"sv, // BEP0003; BT protocol
+    "announce-ip"sv, // tr_session::Settings
+    "announce-ip-enabled"sv, // tr_session::Settings
+    "announce-list"sv, // BEP0012; BT protocol
+    "announceState"sv, // rpc
+    "announce_ip"sv, // tr_session::Settings
+    "announce_ip_enabled"sv, // tr_session::Settings
+    "announce_state"sv, // rpc
+    "anti-brute-force-enabled"sv, // rpc, rpc server settings
+    "anti-brute-force-threshold"sv, // rpc server settings
+    "anti_brute_force_enabled"sv, // rpc, rpc server settings
+    "anti_brute_force_threshold"sv, // rpc server settings
+    "arguments"sv, // json-rpc
+    "availability"sv, // rpc
+    "bandwidth-priority"sv, // .resume
+    "bandwidthPriority"sv, // rpc
+    "bandwidth_priority"sv, // .resume, rpc
+    "begin_piece"sv, // rpc
+    "bind-address-ipv4"sv, // daemon, tr_session::Settings
+    "bind-address-ipv6"sv, // daemon, tr_session::Settings
+    "bind_address_ipv4"sv, // daemon, tr_session::Settings
+    "bind_address_ipv6"sv, // daemon, tr_session::Settings
+    "bitfield"sv, // .resume
+    "blocklist-date"sv, // gtk app, qt app
+    "blocklist-enabled"sv, // daemon, gtk app, rpc, tr_session::Settings
+    "blocklist-size"sv, // rpc
+    "blocklist-update"sv, // rpc
+    "blocklist-updates-enabled"sv, // gtk app, qt app
+    "blocklist-url"sv, // rpc, tr_session::Settings
+    "blocklist_date"sv, // gtk app, qt app
+    "blocklist_enabled"sv, // daemon, gtk app, rpc, tr_session::Settings
+    "blocklist_size"sv, // rpc
+    "blocklist_update"sv, // rpc
+    "blocklist_updates_enabled"sv, // gtk app, qt app
+    "blocklist_url"sv, // rpc, tr_session::Settings
+    "blocks"sv, // .resume
+    "bytesCompleted"sv, // rpc
+    "bytes_completed"sv, // rpc
+    "bytes_to_client"sv, // rpc
+    "bytes_to_peer"sv, // rpc
+    "cache-size-mb"sv, // rpc, tr_session::Settings
+    "cache_size_mb"sv, // rpc, tr_session::Settings
+    "clientIsChoked"sv, // rpc
+    "clientIsInterested"sv, // rpc
+    "clientName"sv, // rpc
+    "client_is_choked"sv, // rpc
+    "client_is_interested"sv, // rpc
+    "client_name"sv, // rpc
+    "code"sv, // json-rpc
+    "comment"sv, // .torrent, rpc
+    "compact-view"sv, // gtk app, qt app
+    "compact_view"sv, // gtk app, qt app
+    "complete"sv, // BEP0048; BT protocol
+    "config-dir"sv, // rpc
+    "config_dir"sv, // rpc
+    "cookies"sv, // rpc
+    "corrupt"sv, // .resume
+    "corruptEver"sv, // rpc
+    "corrupt_ever"sv, // rpc
+    "created by"sv, // .torrent
+    "creation date"sv, // .torrent
+    "creator"sv, // rpc
+    "cumulative-stats"sv, // rpc
+    "cumulative_stats"sv, // rpc
+    "current-stats"sv, // rpc
+    "current_stats"sv, // rpc
+    "data"sv, // json-rpc, rpc
+    "dateCreated"sv, // rpc
+    "date_created"sv, // rpc
+    "default-trackers"sv, // daemon, rpc, tr_session::Settings
+    "default_trackers"sv, // daemon, rpc, tr_session::Settings
+    "delete-local-data"sv, // rpc
+    "delete_local_data"sv, // rpc
+    "desiredAvailable"sv, // rpc
+    "desired_available"sv, // rpc
+    "destination"sv, // .resume
+    "details-window-height"sv, // gtk app
+    "details-window-width"sv, // gtk app
+    "details_window_height"sv, // gtk app
+    "details_window_width"sv, // gtk app
+    "dht-enabled"sv, // daemon, rpc, tr_session::Settings
+    "dht_enabled"sv, // daemon, rpc, tr_session::Settings
+    "dnd"sv, // .resume
+    "done-date"sv, // .resume
+    "doneDate"sv, // rpc
+    "done_date"sv, // .resume, rpc
+    "download-dir"sv, // daemon, gtk app, tr_session::Settings
+    "download-dir-free-space"sv, // rpc
+    "download-queue-enabled"sv, // rpc, tr_session::Settings
+    "download-queue-size"sv, // rpc, tr_session::Settings
+    "downloadCount"sv, // rpc
+    "downloadDir"sv, // rpc
+    "downloadLimit"sv, // rpc
+    "downloadLimited"sv, // rpc
+    "downloadSpeed"sv, // rpc
+    "download_count"sv, // rpc
+    "download_dir"sv, // daemon, gtk app, rpc, tr_session::Settings
+    "download_dir_free_space"sv, // rpc
+    "download_limit"sv, // rpc
+    "download_limited"sv, // rpc
+    "download_queue_enabled"sv, // rpc, tr_session::Settings
+    "download_queue_size"sv, // rpc, tr_session::Settings
+    "download_speed"sv, // rpc
+    "downloaded"sv, // BEP0048; .resume, BT protocol
+    "downloaded-bytes"sv, // stats.json
+    "downloadedBytes"sv, // rpc
+    "downloadedEver"sv, // rpc
+    "downloaded_bytes"sv, // rpc, stats.json
+    "downloaded_ever"sv, // rpc
+    "downloader_count"sv, // rpc
+    "downloading-time-seconds"sv, // .resume
+    "downloading_time_seconds"sv, // .resume
+    "dropped"sv, // BEP0011; BT protocol
+    "dropped6"sv, // BEP0011; BT protocol
+    "e"sv, // BT protocol
+    "editDate"sv, // rpc
+    "edit_date"sv, // rpc
+    "encoding"sv, // .torrent
+    "encryption"sv, // daemon, rpc, tr_session::Settings
+    "end_piece"sv, // rpc
+    "error"sv, // rpc
+    "errorString"sv, // rpc
+    "error_string"sv, // rpc
+    "eta"sv, // rpc
+    "etaIdle"sv, // rpc
+    "eta_idle"sv, // rpc
+    "fields"sv, // rpc
+    "file-count"sv, // rpc
+    "fileStats"sv, // rpc
+    "file_count"sv, // rpc
+    "file_stats"sv, // rpc
+    "filename"sv, // rpc
+    "files"sv, // .resume, .torrent, rpc
+    "files-added"sv, // stats.json
+    "files-unwanted"sv, // rpc
+    "files-wanted"sv, // rpc
+    "filesAdded"sv, // rpc
+    "files_added"sv, // rpc, stats.json
+    "files_unwanted"sv, // rpc
+    "files_wanted"sv, // rpc
+    "filter-mode"sv, // qt app
+    "filter-text"sv, // qt app
+    "filter-trackers"sv, // qt app
+    "filter_mode"sv, // qt app
+    "filter_text"sv, // qt app
+    "filter_trackers"sv, // qt app
+    "flagStr"sv, // rpc
+    "flag_str"sv, // rpc
+    "flags"sv, // .resume
+    "format"sv, // rpc
+    "free-space"sv, // rpc
+    "free_space"sv, // rpc
+    "fromCache"sv, // rpc
+    "fromDht"sv, // rpc
+    "fromIncoming"sv, // rpc
+    "fromLpd"sv, // rpc
+    "fromLtep"sv, // rpc
+    "fromPex"sv, // rpc
+    "fromTracker"sv, // rpc
+    "from_cache"sv, // rpc
+    "from_dht"sv, // rpc
+    "from_incoming"sv, // rpc
+    "from_lpd"sv, // rpc
+    "from_ltep"sv, // rpc
+    "from_pex"sv, // rpc
+    "from_tracker"sv, // rpc
+    "group"sv, // .resume, rpc
+    "group-get"sv, // rpc
+    "group-set"sv, // rpc
+    "group_get"sv, // rpc
+    "group_set"sv, // rpc
+    "hasAnnounced"sv, // rpc
+    "hasScraped"sv, // rpc
+    "has_announced"sv, // rpc
+    "has_scraped"sv, // rpc
+    "hashString"sv, // rpc
+    "hash_string"sv, // rpc
+    "haveUnchecked"sv, // rpc
+    "haveValid"sv, // rpc
+    "have_unchecked"sv, // rpc
+    "have_valid"sv, // rpc
+    "honorsSessionLimits"sv, // rpc
+    "honors_session_limits"sv, // rpc
+    "host"sv, // rpc
+    "id"sv, // dht.dat, rpc
+    "id_timestamp"sv, // dht.dat
+    "idle-limit"sv, // .resume
+    "idle-mode"sv, // .resume
+    "idle-seeding-limit"sv, // rpc, tr_session::Settings
+    "idle-seeding-limit-enabled"sv, // rpc, tr_session::Settings
+    "idle_limit"sv, // .resume
+    "idle_mode"sv, // .resume
+    "idle_seeding_limit"sv, // rpc, tr_session::Settings
+    "idle_seeding_limit_enabled"sv, // rpc, tr_session::Settings
+    "ids"sv, // rpc
+    "incomplete"sv, // BEP0048; BT protocol
+    "incomplete-dir"sv, // .resume, daemon, gtk app, rpc, tr_session::Settings
+    "incomplete-dir-enabled"sv, // daemon, rpc, tr_session::Settings
+    "incomplete_dir"sv, // .resume, daemon, gtk app, rpc, tr_session::Settings
+    "incomplete_dir_enabled"sv, // daemon, rpc, tr_session::Settings
+    "info"sv, // .torrent
+    "inhibit-desktop-hibernation"sv, // gtk app, qt app
+    "inhibit_desktop_hibernation"sv, // gtk app, qt app
+    "ip_protocol"sv, // rpc
+    "ipv4"sv, // BEP0010; BT protocol, rpc
+    "ipv6"sv, // BEP0010; BT protocol, rpc
+    "isBackup"sv, // rpc
+    "isDownloadingFrom"sv, // rpc
+    "isEncrypted"sv, // rpc
+    "isFinished"sv, // rpc
+    "isIncoming"sv, // rpc
+    "isPrivate"sv, // rpc
+    "isStalled"sv, // rpc
+    "isUTP"sv, // rpc
+    "isUploadingTo"sv, // rpc
+    "is_backup"sv, // rpc
+    "is_downloading_from"sv, // rpc
+    "is_encrypted"sv, // rpc
+    "is_finished"sv, // rpc
+    "is_incoming"sv, // rpc
+    "is_private"sv, // rpc
+    "is_stalled"sv, // rpc
+    "is_uploading_to"sv, // rpc
+    "is_utp"sv, // rpc
+    "jsonrpc"sv, // json-rpc
+    "labels"sv, // .resume, rpc
+    "lastAnnouncePeerCount"sv, // rpc
+    "lastAnnounceResult"sv, // rpc
+    "lastAnnounceStartTime"sv, // rpc
+    "lastAnnounceSucceeded"sv, // rpc
+    "lastAnnounceTime"sv, // rpc
+    "lastAnnounceTimedOut"sv, // rpc
+    "lastScrapeResult"sv, // rpc
+    "lastScrapeStartTime"sv, // rpc
+    "lastScrapeSucceeded"sv, // rpc
+    "lastScrapeTime"sv, // rpc
+    "lastScrapeTimedOut"sv, // rpc
+    "last_announce_peer_count"sv, // rpc
+    "last_announce_result"sv, // rpc
+    "last_announce_start_time"sv, // rpc
+    "last_announce_succeeded"sv, // rpc
+    "last_announce_time"sv, // rpc
+    "last_announce_timed_out"sv, // rpc
+    "last_scrape_result"sv, // rpc
+    "last_scrape_start_time"sv, // rpc
+    "last_scrape_succeeded"sv, // rpc
+    "last_scrape_time"sv, // rpc
+    "last_scrape_timed_out"sv, // rpc
+    "leecherCount"sv, // rpc
+    "leecher_count"sv, // rpc
+    "leftUntilDone"sv, // rpc
+    "left_until_done"sv, // rpc
+    "length"sv, // .torrent, rpc
+    "location"sv, // rpc
+    "lpd-enabled"sv, // daemon, rpc, tr_session::Settings
+    "lpd_enabled"sv, // daemon, rpc, tr_session::Settings
+    "m"sv, // BEP0010, BEP0011; BT protocol
+    "magnetLink"sv, // rpc
+    "magnet_link"sv, // rpc
+    "main-window-height"sv, // gtk app, qt app
+    "main-window-is-maximized"sv, // gtk app
+    "main-window-layout-order"sv, // qt app
+    "main-window-width"sv, // gtk app, qt app
+    "main-window-x"sv, // gtk app, qt app
+    "main-window-y"sv, // gtk app, qt app
+    "main_window_height"sv, // gtk app, qt app
+    "main_window_is_maximized"sv, // gtk app
+    "main_window_layout_order"sv, // qt app
+    "main_window_width"sv, // gtk app, qt app
+    "main_window_x"sv, // gtk app, qt app
+    "main_window_y"sv, // gtk app, qt app
+    "manualAnnounceTime"sv, // rpc
+    "manual_announce_time"sv, // rpc
+    "max-peers"sv, // .resume
+    "maxConnectedPeers"sv, // rpc
+    "max_connected_peers"sv, // rpc
+    "max_peers"sv, // .resume
+    "memory-bytes"sv, // rpc
+    "memory-units"sv, // rpc
+    "memory_bytes"sv, // rpc
+    "memory_units"sv, // rpc
+    "message"sv, // json-rpc, rpc
+    "message-level"sv, // daemon, gtk app, tr_session::Settings
+    "message_level"sv, // daemon, gtk app, tr_session::Settings
+    "metadataPercentComplete"sv, // rpc
+    "metadata_percent_complete"sv, // rpc
+    "metadata_size"sv, // BEP0009; BT protocol
+    "metainfo"sv, // rpc
+    "method"sv, // json-rpc
+    "move"sv, // rpc
+    "msg_type"sv, // BT protocol
+    "mtimes"sv, // .resume
+    "name"sv, // .resume, .torrent, rpc
+    "nextAnnounceTime"sv, // rpc
+    "nextScrapeTime"sv, // rpc
+    "next_announce_time"sv, // rpc
+    "next_scrape_time"sv, // rpc
+    "nodes"sv, // dht.dat
+    "nodes6"sv, // dht.dat
+    "open-dialog-dir"sv, // gtk app, qt app
+    "open_dialog_dir"sv, // gtk app, qt app
+    "p"sv, // BEP0010; BT protocol
+    "params"sv, // json-rpc
+    "path"sv, // .torrent, rpc
+    "paused"sv, // .resume, rpc
+    "pausedTorrentCount"sv, // rpc
+    "paused_torrent_count"sv, // rpc
+    "peer-congestion-algorithm"sv, // tr_session::Settings
+    "peer-limit"sv, // rpc
+    "peer-limit-global"sv, // daemon, rpc, tr_session::Settings
+    "peer-limit-per-torrent"sv, // daemon, gtk app, rpc, tr_session::Settings
+    "peer-port"sv, // daemon, gtk app, rpc, tr_session::Settings
+    "peer-port-random-high"sv, // tr_session::Settings
+    "peer-port-random-low"sv, // tr_session::Settings
+    "peer-port-random-on-start"sv, // rpc, tr_session::Settings
+    "peer-socket-tos"sv, // tr_session::Settings
+    "peerIsChoked"sv, // rpc
+    "peerIsInterested"sv, // rpc
+    "peer_congestion_algorithm"sv, // tr_session::Settings
+    "peer_id"sv, // rpc
+    "peer_is_choked"sv, // rpc
+    "peer_is_interested"sv, // rpc
+    "peer_limit"sv, // rpc
+    "peer_limit_global"sv, // daemon, rpc, tr_session::Settings
+    "peer_limit_per_torrent"sv, // daemon, gtk app, rpc, tr_session::Settings
+    "peer_port"sv, // daemon, gtk app, rpc, tr_session::Settings
+    "peer_port_random_high"sv, // tr_session::Settings
+    "peer_port_random_low"sv, // tr_session::Settings
+    "peer_port_random_on_start"sv, // rpc, tr_session::Settings
+    "peer_socket_tos"sv, // tr_session::Settings
+    "peers"sv, // rpc
+    "peers2"sv, // .resume
+    "peers2-6"sv, // .resume
+    "peers2_6"sv, // .resume
+    "peersConnected"sv, // rpc
+    "peersFrom"sv, // rpc
+    "peersGettingFromUs"sv, // rpc
+    "peersSendingToUs"sv, // rpc
+    "peers_connected"sv, // rpc
+    "peers_from"sv, // rpc
+    "peers_getting_from_us"sv, // rpc
+    "peers_sending_to_us"sv, // rpc
+    "percentComplete"sv, // rpc
+    "percentDone"sv, // rpc
+    "percent_complete"sv, // rpc
+    "percent_done"sv, // rpc
+    "pex-enabled"sv, // rpc, tr_session::Settings
+    "pex_enabled"sv, // rpc, tr_session::Settings
+    "pidfile"sv, // daemon
+    "piece"sv, // BT protocol
+    "piece length"sv, // .torrent
+    "pieceCount"sv, // rpc
+    "pieceSize"sv, // rpc
+    "piece_count"sv, // rpc
+    "piece_size"sv, // rpc
+    "pieces"sv, // .resume, .torrent, rpc
+    "port"sv, // rpc
+    "port-forwarding-enabled"sv, // daemon, rpc, tr_session::Settings
+    "port-is-open"sv, // rpc
+    "port-test"sv, // rpc
+    "port_forwarding_enabled"sv, // daemon, rpc, tr_session::Settings
+    "port_is_open"sv, // rpc
+    "port_test"sv, // rpc
+    "preallocation"sv, // tr_session::Settings
+    "preferred_transports"sv, // rpc, tr_session::Settings
+    "primary-mime-type"sv, // rpc
+    "primary_mime_type"sv, // rpc
+    "priorities"sv, // rpc
+    "priority"sv, // .resume, rpc
+    "priority-high"sv, // rpc
+    "priority-low"sv, // rpc
+    "priority-normal"sv, // rpc
+    "priority_high"sv, // rpc
+    "priority_low"sv, // rpc
+    "priority_normal"sv, // rpc
+    "private"sv, // .torrent
+    "progress"sv, // .resume, rpc
+    "prompt-before-exit"sv, // qt app
+    "prompt_before_exit"sv, // qt app
+    "proxy_url"sv, // tr_session::Settings
+    "queue-move-bottom"sv, // rpc
+    "queue-move-down"sv, // rpc
+    "queue-move-top"sv, // rpc
+    "queue-move-up"sv, // rpc
+    "queue-stalled-enabled"sv, // rpc, tr_session::Settings
+    "queue-stalled-minutes"sv, // rpc, tr_session::Settings
+    "queuePosition"sv, // rpc
+    "queue_move_bottom"sv, // rpc
+    "queue_move_down"sv, // rpc
+    "queue_move_top"sv, // rpc
+    "queue_move_up"sv, // rpc
+    "queue_position"sv, // rpc
+    "queue_stalled_enabled"sv, // rpc, tr_session::Settings
+    "queue_stalled_minutes"sv, // rpc, tr_session::Settings
+    "rateDownload"sv, // rpc
+    "rateToClient"sv, // rpc
+    "rateToPeer"sv, // rpc
+    "rateUpload"sv, // rpc
+    "rate_download"sv, // rpc
+    "rate_to_client"sv, // rpc
+    "rate_to_peer"sv, // rpc
+    "rate_upload"sv, // rpc
+    "ratio-limit"sv, // .resume, daemon, gtk app, tr_session::Settings
+    "ratio-limit-enabled"sv, // daemon, tr_session::Settings
+    "ratio-mode"sv, // .resume
+    "ratio_limit"sv, // .resume, daemon, gtk app, tr_session::Settings
+    "ratio_limit_enabled"sv, // daemon, tr_session::Settings
+    "ratio_mode"sv, // .resume
+    "read-clipboard"sv, // qt app
+    "read_clipboard"sv, // qt app
+    "recently-active"sv, // rpc
+    "recently_active"sv, // rpc
+    "recheckProgress"sv, // rpc
+    "recheck_progress"sv, // rpc
+    "remote-session-enabled"sv, // qt app
+    "remote-session-host"sv, // qt app
+    "remote-session-https"sv, // qt app
+    "remote-session-password"sv, // qt app
+    "remote-session-port"sv, // qt app
+    "remote-session-requres-authentication"sv, // SIC: misspelled prior to 4.1.0-beta.4; qt app
+    "remote-session-username"sv, // qt app
+    "remote_session_enabled"sv, // qt app
+    "remote_session_host"sv, // qt app
+    "remote_session_https"sv, // qt app
+    "remote_session_password"sv, // qt app
+    "remote_session_port"sv, // qt app
+    "remote_session_requires_authentication"sv, // qt app
+    "remote_session_rpc_url_path"sv, // qt app
+    "remote_session_username"sv, // qt app
+    "removed"sv, // rpc
+    "rename-partial-files"sv, // rpc, tr_session::Settings
+    "rename_partial_files"sv, // rpc, tr_session::Settings
+    "reqq"sv, // BEP0010; BT protocol, rpc, tr_session::Settings
+    "result"sv, // rpc
+    "rpc-authentication-required"sv, // daemon, rpc server settings
+    "rpc-bind-address"sv, // daemon, rpc server settings
+    "rpc-enabled"sv, // daemon, rpc server settings
+    "rpc-host-whitelist"sv, // rpc, rpc server settings
+    "rpc-host-whitelist-enabled"sv, // rpc, rpc server settings
+    "rpc-password"sv, // daemon, rpc server settings
+    "rpc-port"sv, // daemon, gtk app, rpc server settings
+    "rpc-socket-mode"sv, // rpc server settings
+    "rpc-url"sv, // rpc server settings
+    "rpc-username"sv, // daemon, rpc server settings
+    "rpc-version"sv, // rpc
+    "rpc-version-minimum"sv, // rpc
+    "rpc-version-semver"sv, // rpc
+    "rpc-whitelist"sv, // daemon, gtk app, rpc server settings
+    "rpc-whitelist-enabled"sv, // daemon, rpc server settings
+    "rpc_authentication_required"sv, // daemon, rpc server settings
+    "rpc_bind_address"sv, // daemon, rpc server settings
+    "rpc_enabled"sv, // daemon, rpc server settings
+    "rpc_host_whitelist"sv, // rpc, rpc server settings
+    "rpc_host_whitelist_enabled"sv, // rpc, rpc server settings
+    "rpc_password"sv, // daemon, rpc server settings
+    "rpc_port"sv, // daemon, gtk app, rpc server settings
+    "rpc_socket_mode"sv, // rpc server settings
+    "rpc_url"sv, // rpc server settings
+    "rpc_username"sv, // daemon, rpc server settings
+    "rpc_version"sv, // rpc
+    "rpc_version_minimum"sv, // rpc
+    "rpc_version_semver"sv, // rpc
+    "rpc_whitelist"sv, // daemon, gtk app, rpc server settings
+    "rpc_whitelist_enabled"sv, // daemon, rpc server settings
+    "scrape"sv, // rpc
+    "scrape-paused-torrents-enabled"sv, // tr_session::Settings
+    "scrapeState"sv, // rpc
+    "scrape_paused_torrents_enabled"sv, // tr_session::Settings
+    "scrape_state"sv, // rpc
+    "script-torrent-added-enabled"sv, // rpc, tr_session::Settings
+    "script-torrent-added-filename"sv, // rpc, tr_session::Settings
+    "script-torrent-done-enabled"sv, // rpc, tr_session::Settings
+    "script-torrent-done-filename"sv, // rpc, tr_session::Settings
+    "script-torrent-done-seeding-enabled"sv, // rpc, tr_session::Settings
+    "script-torrent-done-seeding-filename"sv, // rpc, tr_session::Settings
+    "script_torrent_added_enabled"sv, // rpc, tr_session::Settings
+    "script_torrent_added_filename"sv, // rpc, tr_session::Settings
+    "script_torrent_done_enabled"sv, // rpc, tr_session::Settings
+    "script_torrent_done_filename"sv, // rpc, tr_session::Settings
+    "script_torrent_done_seeding_enabled"sv, // rpc, tr_session::Settings
+    "script_torrent_done_seeding_filename"sv, // rpc, tr_session::Settings
+    "seconds-active"sv, // stats.json
+    "secondsActive"sv, // rpc
+    "secondsDownloading"sv, // rpc
+    "secondsSeeding"sv, // rpc
+    "seconds_active"sv, // rpc, stats.json
+    "seconds_downloading"sv, // rpc
+    "seconds_seeding"sv, // rpc
+    "seed-queue-enabled"sv, // rpc, tr_session::Settings
+    "seed-queue-size"sv, // rpc, tr_session::Settings
+    "seedIdleLimit"sv, // rpc
+    "seedIdleMode"sv, // rpc
+    "seedRatioLimit"sv, // rpc
+    "seedRatioLimited"sv, // rpc
+    "seedRatioMode"sv, // rpc
+    "seed_idle_limit"sv, // rpc
+    "seed_idle_mode"sv, // rpc
+    "seed_queue_enabled"sv, // rpc, tr_session::Settings
+    "seed_queue_size"sv, // rpc, tr_session::Settings
+    "seed_ratio_limit"sv, // rpc
+    "seed_ratio_limited"sv, // rpc
+    "seed_ratio_mode"sv, // rpc
+    "seederCount"sv, // rpc
+    "seeder_count"sv, // rpc
+    "seeding-time-seconds"sv, // .resume
+    "seeding_time_seconds"sv, // .resume
+    "sequential_download"sv, // .resume, daemon, rpc, tr_session::Settings
+    "sequential_download_from_piece"sv, // .resume, rpc
+    "session-close"sv, // rpc
+    "session-count"sv, // stats.json
+    "session-get"sv, // rpc
+    "session-id"sv, // rpc
+    "session-set"sv, // rpc
+    "session-stats"sv, // rpc
+    "sessionCount"sv, // rpc
+    "session_close"sv, // rpc
+    "session_count"sv, // rpc, stats.json
+    "session_get"sv, // rpc
+    "session_id"sv, // rpc
+    "session_set"sv, // rpc
+    "session_stats"sv, // rpc
+    "show-backup-trackers"sv, // gtk app, qt app
+    "show-extra-peer-details"sv, // gtk app
+    "show-filterbar"sv, // gtk app, qt app
+    "show-notification-area-icon"sv, // gtk app, qt app
+    "show-options-window"sv, // gtk app, qt app
+    "show-statusbar"sv, // gtk app, qt app
+    "show-toolbar"sv, // gtk app, qt app
+    "show-tracker-scrapes"sv, // gtk app, qt app
+    "show_backup_trackers"sv, // gtk app, qt app
+    "show_extra_peer_details"sv, // gtk app
+    "show_filterbar"sv, // gtk app, qt app
+    "show_notification_area_icon"sv, // gtk app, qt app
+    "show_options_window"sv, // gtk app, qt app
+    "show_statusbar"sv, // gtk app, qt app
+    "show_toolbar"sv, // gtk app, qt app
+    "show_tracker_scrapes"sv, // gtk app, qt app
+    "sitename"sv, // rpc
+    "size-bytes"sv, // rpc
+    "size-units"sv, // rpc
+    "sizeWhenDone"sv, // rpc
+    "size_bytes"sv, // rpc
+    "size_units"sv, // rpc
+    "size_when_done"sv, // rpc
+    "sleep-per-seconds-during-verify"sv, // tr_session::Settings
+    "sleep_per_seconds_during_verify"sv, // tr_session::Settings
+    "socket_address"sv, // .resume
+    "sort-mode"sv, // gtk app, qt app
+    "sort-reversed"sv, // gtk app, qt app
+    "sort_mode"sv, // gtk app, qt app
+    "sort_reversed"sv, // gtk app, qt app
+    "source"sv, // .torrent
+    "speed"sv, // .resume
+    "speed-Bps"sv, // .resume
+    "speed-bytes"sv, // rpc
+    "speed-limit-down"sv, // .resume, gtk app, rpc, tr_session::Settings
+    "speed-limit-down-enabled"sv, // rpc, tr_session::Settings
+    "speed-limit-up"sv, // .resume, gtk app, rpc, tr_session::Settings
+    "speed-limit-up-enabled"sv, // rpc, tr_session::Settings
+    "speed-units"sv, // rpc
+    "speed_Bps"sv, // .resume
+    "speed_bytes"sv, // rpc
+    "speed_limit_down"sv, // .resume, gtk app, rpc, tr_session::Settings
+    "speed_limit_down_enabled"sv, // rpc, tr_session::Settings
+    "speed_limit_up"sv, // .resume, gtk app, rpc, tr_session::Settings
+    "speed_limit_up_enabled"sv, // rpc, tr_session::Settings
+    "speed_units"sv, // rpc
+    "start-added-torrents"sv, // gtk app, rpc, tr_session::Settings
+    "start-minimized"sv, // qt app
+    "startDate"sv, // rpc
+    "start_added_torrents"sv, // gtk app, rpc, tr_session::Settings
+    "start_date"sv, // rpc
+    "start_minimized"sv, // qt app
+    "start_paused"sv, // daemon
+    "status"sv, // rpc
+    "statusbar-stats"sv, // gtk app, qt app
+    "statusbar_stats"sv, // gtk app, qt app
+    "tag"sv, // rpc
+    "tcp-enabled"sv, // rpc, tr_session::Settings
+    "tcp_enabled"sv, // rpc, tr_session::Settings
+    "tier"sv, // rpc
+    "time-checked"sv, // .resume
+    "time_checked"sv, // .resume
+    "torrent-add"sv, // rpc
+    "torrent-added"sv, // rpc
+    "torrent-added-notification-enabled"sv, // gtk app, qt app
+    "torrent-added-verify-mode"sv, // tr_session::Settings
+    "torrent-complete-notification-enabled"sv, // gtk app, qt app
+    "torrent-complete-sound-command"sv, // gtk app, qt app
+    "torrent-complete-sound-enabled"sv, // gtk app, qt app
+    "torrent-duplicate"sv, // rpc
+    "torrent-get"sv, // rpc
+    "torrent-reannounce"sv, // rpc
+    "torrent-remove"sv, // rpc
+    "torrent-rename-path"sv, // rpc
+    "torrent-set"sv, // rpc
+    "torrent-set-location"sv, // rpc
+    "torrent-start"sv, // rpc
+    "torrent-start-now"sv, // rpc
+    "torrent-stop"sv, // rpc
+    "torrent-verify"sv, // rpc
+    "torrentCount"sv, // rpc
+    "torrentFile"sv, // rpc
+    "torrent_add"sv, // rpc
+    "torrent_added"sv, // rpc
+    "torrent_added_notification_enabled"sv, // gtk app, qt app
+    "torrent_added_verify_mode"sv, // tr_session::Settings
+    "torrent_complete_notification_enabled"sv, // gtk app, qt app
+    "torrent_complete_sound_command"sv, // gtk app, qt app
+    "torrent_complete_sound_enabled"sv, // gtk app, qt app
+    "torrent_complete_verify_enabled"sv, // tr_session::Settings
+    "torrent_count"sv, // rpc
+    "torrent_duplicate"sv, // rpc
+    "torrent_file"sv, // rpc
+    "torrent_get"sv, // rpc
+    "torrent_reannounce"sv, // rpc
+    "torrent_remove"sv, // rpc
+    "torrent_rename_path"sv, // rpc
+    "torrent_set"sv, // rpc
+    "torrent_set_location"sv, // rpc
+    "torrent_start"sv, // rpc
+    "torrent_start_now"sv, // rpc
+    "torrent_stop"sv, // rpc
+    "torrent_verify"sv, // rpc
+    "torrents"sv, // rpc
+    "totalSize"sv, // rpc
+    "total_size"sv, // BT protocol, rpc
+    "trackerAdd"sv, // rpc
+    "trackerList"sv, // rpc
+    "trackerRemove"sv, // rpc
+    "trackerReplace"sv, // rpc
+    "trackerStats"sv, // rpc
+    "tracker_add"sv, // rpc
+    "tracker_list"sv, // rpc
+    "tracker_remove"sv, // rpc
+    "tracker_replace"sv, // rpc
+    "tracker_stats"sv, // rpc
+    "trackers"sv, // rpc
+    "trash-can-enabled"sv, // gtk app
+    "trash-original-torrent-files"sv, // gtk app, rpc, tr_session::Settings
+    "trash_can_enabled"sv, // gtk app
+    "trash_original_torrent_files"sv, // gtk app, rpc, tr_session::Settings
+    "umask"sv, // tr_session::Settings
+    "units"sv, // rpc
+    "upload-slots-per-torrent"sv, // tr_session::Settings
+    "uploadLimit"sv, // rpc
+    "uploadLimited"sv, // rpc
+    "uploadRatio"sv, // rpc
+    "uploadSpeed"sv, // rpc
+    "upload_limit"sv, // rpc
+    "upload_limited"sv, // rpc
+    "upload_only"sv, // BEP0021; BT protocol
+    "upload_ratio"sv, // rpc
+    "upload_slots_per_torrent"sv, // tr_session::Settings
+    "upload_speed"sv, // rpc
+    "uploaded"sv, // .resume
+    "uploaded-bytes"sv, // stats.json
+    "uploadedBytes"sv, // rpc
+    "uploadedEver"sv, // rpc
+    "uploaded_bytes"sv, // rpc, stats.json
+    "uploaded_ever"sv, // rpc
+    "url-list"sv, // .torrent
+    "use-global-speed-limit"sv, // .resume
+    "use-speed-limit"sv, // .resume
+    "use_global_speed_limit"sv, // .resume
+    "use_speed_limit"sv, // .resume
+    "user-has-given-informed-consent"sv, // gtk app, qt app
+    "user_has_given_informed_consent"sv, // gtk app, qt app
+    "ut_holepunch"sv, // BT protocol
+    "ut_metadata"sv, // BEP0011; BT protocol
+    "ut_pex"sv, // BEP0010, BEP0011; BT protocol
+    "utp-enabled"sv, // daemon, rpc, tr_session::Settings
+    "utp_enabled"sv, // daemon, rpc, tr_session::Settings
+    "v"sv, // BEP0010; BT protocol
+    "version"sv, // rpc
+    "wanted"sv, // rpc
+    "watch-dir"sv, // daemon, gtk app, qt app
+    "watch-dir-enabled"sv, // daemon, gtk app, qt app
+    "watch-dir-force-generic"sv, // daemon
+    "watch_dir"sv, // daemon, gtk app, qt app
+    "watch_dir_enabled"sv, // daemon, gtk app, qt app
+    "watch_dir_force_generic"sv, // daemon
+    "webseeds"sv, // rpc
+    "webseedsSendingToUs"sv, // rpc
+    "webseeds_sending_to_us"sv, // rpc
+    "yourip"sv, // BEP0010; BT protocol
 };
 
 bool constexpr quarks_are_sorted()
@@ -797,7 +798,7 @@ std::string_view tr_quark_get_string_view(tr_quark q)
     return q < TR_N_KEYS ? MyStatic[q] : my_runtime[q - TR_N_KEYS];
 }
 
-tr_quark tr_quark_convert(tr_quark q)
+tr_quark tr_quark_convert(tr_quark const q)
 {
     // clang-format off
     switch (q)

--- a/libtransmission/quark.h
+++ b/libtransmission/quark.h
@@ -626,6 +626,7 @@ enum // NOLINT(performance-enum-size)
     TR_KEY_tcp_enabled_kebab,
     TR_KEY_tcp_enabled,
     TR_KEY_tier,
+    TR_KEY_time_checked_kebab,
     TR_KEY_time_checked,
     TR_KEY_torrent_add_kebab,
     TR_KEY_torrent_added_kebab,


### PR DESCRIPTION
This is another single-topic PR spinoff from working on 7891's [style converter](https://github.com/transmission/transmission/issues/7891#issuecomment-3635136911).

As part of that work, I walked through all the interned strings to map out which code uses each string. This PR annotates the strings with this info.

*edit:* Also, intern `"time-checked"`
