### PR TITLE
feat: remove informed-consent dialogs

### DIFF
--- a/gtk/Application.cc
+++ b/gtk/Application.cc
@@ -777,36 +777,6 @@ void Application::Impl::app_setup()
         gtr_window_set_skip_taskbar_hint(*wind_, icon_ != nullptr);
         gtr_action_set_toggled("toggle-main-window", false);
     }
-
-    if (!gtr_pref_flag_get(TR_KEY_user_has_given_informed_consent))
-    {
-        auto w = std::make_shared<Gtk::MessageDialog>(
-            *wind_,
-            _("Transmission is a file sharing program. When you run a torrent, its data will be "
-              "made available to others by means of upload. Any content you share is your sole responsibility."),
-            false,
-            TR_GTK_MESSAGE_TYPE(OTHER),
-            TR_GTK_BUTTONS_TYPE(NONE),
-            true);
-        w->add_button(_("_Cancel"), TR_GTK_RESPONSE_TYPE(REJECT));
-        w->add_button(_("I _Agree"), TR_GTK_RESPONSE_TYPE(ACCEPT));
-        w->set_default_response(TR_GTK_RESPONSE_TYPE(ACCEPT));
-        w->signal_response().connect(
-            [w](int response) mutable
-            {
-                if (response == TR_GTK_RESPONSE_TYPE(ACCEPT))
-                {
-                    // only show it once
-                    gtr_pref_flag_set(TR_KEY_user_has_given_informed_consent, true);
-                    w.reset();
-                }
-                else
-                {
-                    exit(0);
-                }
-            });
-        w->show();
-    }
 }
 
 void Application::Impl::placeWindowFromPrefs()

--- a/gtk/Prefs.cc
+++ b/gtk/Prefs.cc
@@ -78,7 +78,6 @@ namespace
     map.try_emplace(TR_KEY_torrent_complete_notification_enabled, true);
     map.try_emplace(TR_KEY_torrent_complete_sound_enabled, true);
     map.try_emplace(TR_KEY_trash_can_enabled, true);
-    map.try_emplace(TR_KEY_user_has_given_informed_consent, false);
     map.try_emplace(TR_KEY_watch_dir, dir);
     map.try_emplace(TR_KEY_watch_dir_enabled, false);
     return tr_variant{ std::move(map) };

--- a/libtransmission/quark.cc
+++ b/libtransmission/quark.cc
@@ -713,8 +713,6 @@ auto constexpr MyStatic = std::array<std::string_view, TR_N_KEYS>{
     "use-speed-limit"sv, // .resume
     "use_global_speed_limit"sv, // .resume
     "use_speed_limit"sv, // .resume
-    "user-has-given-informed-consent"sv, // gtk app, qt app
-    "user_has_given_informed_consent"sv, // gtk app, qt app
     "ut_holepunch"sv, // BT protocol
     "ut_metadata"sv, // BEP0011; BT protocol
     "ut_pex"sv, // BEP0010, BEP0011; BT protocol
@@ -1109,7 +1107,6 @@ tr_quark tr_quark_convert(tr_quark const q)
     case TR_KEY_uploaded_ever_camel: return TR_KEY_uploaded_ever;
     case TR_KEY_use_global_speed_limit_kebab: return TR_KEY_use_global_speed_limit;
     case TR_KEY_use_speed_limit_kebab: return TR_KEY_use_speed_limit;
-    case TR_KEY_user_has_given_informed_consent_kebab: return TR_KEY_user_has_given_informed_consent;
     case TR_KEY_utp_enabled_kebab: return TR_KEY_utp_enabled;
     case TR_KEY_watch_dir_kebab: return TR_KEY_watch_dir;
     case TR_KEY_watch_dir_enabled_kebab: return TR_KEY_watch_dir_enabled;

--- a/libtransmission/quark.h
+++ b/libtransmission/quark.h
@@ -711,8 +711,6 @@ enum // NOLINT(performance-enum-size)
     TR_KEY_use_speed_limit_kebab,
     TR_KEY_use_global_speed_limit,
     TR_KEY_use_speed_limit,
-    TR_KEY_user_has_given_informed_consent_kebab,
-    TR_KEY_user_has_given_informed_consent,
     TR_KEY_ut_holepunch,
     TR_KEY_ut_metadata,
     TR_KEY_ut_pex,

--- a/qt/Application.cc
+++ b/qt/Application.cc
@@ -212,26 +212,6 @@ Application::Application(
         window_->openSession();
     }
 
-    if (!prefs_->getBool(Prefs::USER_HAS_GIVEN_INFORMED_CONSENT))
-    {
-        auto* dialog = new QMessageBox{ QMessageBox::Information,
-                                        QString{},
-                                        tr("<b>Transmission is a file sharing program.</b>"),
-                                        QMessageBox::Ok | QMessageBox::Cancel,
-                                        window_.get() };
-        dialog->setInformativeText(
-            tr("When you run a torrent, its data will be made available to others by means of upload. "
-               "Any content you share is your sole responsibility."));
-        dialog->button(QMessageBox::Ok)->setText(tr("I &Agree"));
-        dialog->setDefaultButton(QMessageBox::Ok);
-        dialog->setModal(true);
-
-        connect(dialog, &QDialog::finished, this, &Application::consentGiven);
-
-        dialog->setAttribute(Qt::WA_DeleteOnClose);
-        dialog->show();
-    }
-
     // torrent files passed in on the command line
     for (QString const& filename : filenames)
     {
@@ -361,21 +341,7 @@ void Application::notifyTorrentAdded(Torrent const* tor) const
     notifyApp(tr("Torrent Added"), tor->name(), actions);
 }
 
-/***
-****
-***/
-
-void Application::consentGiven(int result) const
-{
-    if (result == QMessageBox::Ok)
-    {
-        prefs_->set<bool>(Prefs::USER_HAS_GIVEN_INFORMED_CONSENT, true);
-    }
-    else
-    {
-        quit();
-    }
-}
+// ---
 
 void Application::saveGeometry() const
 {
@@ -389,9 +355,7 @@ void Application::saveGeometry() const
     }
 }
 
-/***
-****
-***/
+// ---
 
 void Application::refreshPref(int key) const
 {

--- a/qt/Application.h
+++ b/qt/Application.h
@@ -87,7 +87,6 @@ public slots:
     void addWatchdirTorrent(QString const& filename) const;
 
 private slots:
-    void consentGiven(int result) const;
     void onSessionSourceChanged() const;
     void onTorrentsAdded(torrent_ids_t const& torrent_ids) const;
     void onTorrentsCompleted(torrent_ids_t const& torrent_ids) const;

--- a/qt/Prefs.cc
+++ b/qt/Prefs.cc
@@ -99,7 +99,6 @@ std::array<Prefs::PrefItem, Prefs::PREFS_COUNT> const Prefs::Items{
     { SESSION_REMOTE_RPC_URL_PATH, TR_KEY_remote_session_rpc_url_path, QMetaType::QString },
     { COMPLETE_SOUND_COMMAND, TR_KEY_torrent_complete_sound_command_kebab, QMetaType::QStringList },
     { COMPLETE_SOUND_ENABLED, TR_KEY_torrent_complete_sound_enabled_kebab, QMetaType::Bool },
-    { USER_HAS_GIVEN_INFORMED_CONSENT, TR_KEY_user_has_given_informed_consent_kebab, QMetaType::Bool },
     { READ_CLIPBOARD, TR_KEY_read_clipboard_kebab, QMetaType::Bool },
 
     /* libtransmission settings */
@@ -456,7 +455,6 @@ tr_variant Prefs::get_default_app_settings()
     settings.try_emplace(TR_KEY_torrent_added_notification_enabled, true);
     settings.try_emplace(TR_KEY_torrent_complete_notification_enabled, true);
     settings.try_emplace(TR_KEY_torrent_complete_sound_enabled, true);
-    settings.try_emplace(TR_KEY_user_has_given_informed_consent, false);
     settings.try_emplace(TR_KEY_watch_dir_enabled, false);
     settings.try_emplace(TR_KEY_blocklist_date, 0);
     settings.try_emplace(TR_KEY_main_window_height, 500);

--- a/qt/Prefs.h
+++ b/qt/Prefs.h
@@ -67,7 +67,6 @@ public:
         SESSION_REMOTE_RPC_URL_PATH,
         COMPLETE_SOUND_COMMAND,
         COMPLETE_SOUND_ENABLED,
-        USER_HAS_GIVEN_INFORMED_CONSENT,
         READ_CLIPBOARD,
         /* core prefs */
         FIRST_CORE_PREF,


### PR DESCRIPTION
These dialogs were added a loooong time ago in response to a [bill](https://www.govinfo.gov/content/pkg/CRPT-111hrpt361/html/CRPT-111hrpt361.htm) proposed in the US House of Representatives, the "Informed P2P User Act."

That bill never became law, and this popup is not something used by other BitTorrent apps, so let's remove it.