### PR TITLE
perf: use small::vector<> when sorting map keys

### DIFF
--- a/libtransmission/variant-benc.cc
+++ b/libtransmission/variant-benc.cc
@@ -18,6 +18,8 @@
 #include <fmt/compile.h>
 #include <fmt/format.h>
 
+#include <small/vector.hpp>
+
 #define LIBTRANSMISSION_VARIANT_MODULE
 
 #include "libtransmission/benc.h"
@@ -279,7 +281,8 @@ using OutBuf = fmt::memory_buffer;
 
 [[nodiscard]] auto sorted_entries(tr_variant::Map const& map)
 {
-    auto entries = std::vector<std::pair<std::string_view, tr_variant const*>>{};
+    static auto constexpr N = 32U;
+    auto entries = small::vector<std::pair<std::string_view, tr_variant const*>, N>{};
     entries.reserve(map.size());
     for (auto const& [key, child] : map)
     {

--- a/libtransmission/variant-json.cc
+++ b/libtransmission/variant-json.cc
@@ -19,6 +19,8 @@
 
 #include <fmt/format.h>
 
+#include <small/vector.hpp>
+
 #include <rapidjson/encodedstream.h>
 #include <rapidjson/encodings.h>
 #include <rapidjson/error/en.h>
@@ -294,7 +296,8 @@ private:
 
 [[nodiscard]] auto sorted_entries(tr_variant::Map const& map)
 {
-    auto entries = std::vector<std::pair<std::string_view, tr_variant const*>>{};
+    static auto constexpr N = 32U;
+    auto entries = small::vector<std::pair<std::string_view, tr_variant const*>, N>{};
     entries.reserve(map.size());
     for (auto const& [key, child] : map)
     {


### PR DESCRIPTION
Small perf followup to #7923 that avoids std::vector heap allocations when sorting an object's property keys.

I ran Transmission for a day with some code hacked into measure how many properties we see per object. Prealllocating a stack size for 32 is enough for 99% of the cases I saw.

This is unlikely to put stress on our stack memory: Since we limit how deeply data can be nested in both JSON and benc data, the worst case would be to max out at about 64 * 32 * `sizeof(std::pair<std::string_view, void*>)`, about 48KB.