### PR TITLE
fix: api-compat fixes and test cases

### DIFF
--- a/tests/libtransmission/api-compat-test.cc
+++ b/tests/libtransmission/api-compat-test.cc
@@ -652,7 +652,7 @@ TEST(ApiCompatTest, canConvertRpc)
     using TestCase = std::tuple<std::string_view, std::string_view, Style, std::string_view>;
 
     // clang-format off
-    static auto constexpr TestCases = std::array<TestCase, 38U>{ {
+    static auto constexpr TestCases = std::array<TestCase, 40U>{ {
         { "free_space tr5 -> tr5", BadFreeSpaceRequest, Style::Tr5, BadFreeSpaceRequest },
         { "free_space tr5 -> tr4", BadFreeSpaceRequest, Style::Tr4, BadFreeSpaceRequestLegacy },
         { "free_space tr4 -> tr5", BadFreeSpaceRequestLegacy, Style::Tr5, BadFreeSpaceRequest },
@@ -691,6 +691,8 @@ TEST(ApiCompatTest, canConvertRpc)
         { "bad method name tr4 -> tr4", BadMethodNameLegacyResponse, Style::Tr4, BadMethodNameLegacyResponse },
         { "unrecognised info tr5 -> tr5", UnrecognisedInfoResponse, Style::Tr5, UnrecognisedInfoResponse},
         { "unrecognised info tr5 -> tr4", UnrecognisedInfoResponse, Style::Tr4, UnrecognisedInfoLegacyResponse},
+        { "unrecognised info tr4 -> tr5", UnrecognisedInfoLegacyResponse, Style::Tr5, UnrecognisedInfoResponse},
+        { "unrecognised info tr4 -> tr4", UnrecognisedInfoLegacyResponse, Style::Tr4, UnrecognisedInfoLegacyResponse},
 
         // TODO(ckerr): torrent-get with 'table'
     } };


### PR DESCRIPTION
Add fixes and test cases for these fixes as requested by https://github.com/transmission/transmission/pull/7917#discussion_r2616615233.

Apart from the usual edge case fixes, one noteworthy change is replacing all `auto* inner = map->try_emplace(TR_KEY, tr_variant::make_map()).first.get_if<tr_variant::Map>()` with `auto inner = tr_variant::Map{}` + `map->try_emplace(TR_KEY, std::move(inner))`. The former is dangerous because as you insert more elements into `map`, the internal vector will reallocate its memory and all the `inner` pointers you stored will be invalidated.