### PR TITLE
fix: FTBFS with rapidjson 1.1.0 release on GCC < 12

### DIFF
--- a/libtransmission/variant-json.cc
+++ b/libtransmission/variant-json.cc
@@ -381,7 +381,9 @@ std::string tr_variant_serde::to_json_string(tr_variant const& var) const
     }
     else
     {
-        auto writer = rapidjson::PrettyWriter{ buf };
+        // Explicitly specify template parameter to workaround
+        // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=85790
+        auto writer = rapidjson::PrettyWriter<FmtOutputStream>{ buf };
         var.visit(JsonWriter{ writer });
     }
     return buf.to_string();


### PR DESCRIPTION
Workaround FTBFS caused by [GCC bug 85790](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=85790) when built with rapidjson 1.1.0 release on GCC < 12.

Here is the FTBFS demonstrated on a [CI run](https://github.com/transmission/transmission/actions/runs/20218103468/job/58034775890):

```
[107/314] Building CXX object libtransmission/CMakeFiles/transmission.dir/variant-json.cc.o
FAILED: libtransmission/CMakeFiles/transmission.dir/variant-json.cc.o 
/usr/bin/c++ -DENABLE_GETTEXT -DFMT_EXCEPTIONS=0 -DFMT_HEADER_ONLY=1 -DFMT_USE_EXCEPTIONS=0 -DHAVE_COPY_FILE_RANGE -DHAVE_FALLOCATE64 -DHAVE_FLOCK -DHAVE_GETMNTENT -DHAVE_MKDTEMP -DHAVE_POSIX_FADVISE -DHAVE_POSIX_FALLOCATE -DHAVE_PREAD -DHAVE_PWRITE -DHAVE_SENDFILE64 -DHAVE_SO_REUSEPORT=1 -DHAVE_STATVFS -DHAVE_SYS_STATVFS_H -DNOMINMAX -DPACKAGE_DATA_DIR=\"/__w/transmission/transmission/pfx/share\" -DPOSIX -DRAPIDJSON_HAS_STDSTRING=1 -DSMALL_DISABLE_EXCEPTIONS=1 -DUSE_SYSTEM_B64 -DWIDE_INTEGER_DISABLE_FLOAT_INTEROP -DWIDE_INTEGER_DISABLE_IOSTREAM -DWIDE_INTEGER_HAS_LIMB_TYPE_UINT64 -DWITH_INOTIFY -DWITH_OPENSSL -DWITH_UTP -D__TRANSMISSION__ -I/__w/transmission/transmission/src/libtransmission/.. -Ilibtransmission/.. -I/__w/transmission/transmission/src/third-party/fast_float/include -I/__w/transmission/transmission/src/third-party/libutp/include -I/__w/transmission/transmission/src/third-party/utfcpp/source -I/__w/transmission/transmission/src/third-party/wildmat -isystem third-party/dht.bld/pfx/include -isystem /__w/transmission/transmission/src/third-party/wide-integer -isystem third-party/crc32c.bld/pfx/include -isystem /__w/transmission/transmission/src/third-party/fmt/include -isystem /__w/transmission/transmission/src/third-party/small/include -O2 -g -DNDEBUG -W -Wall -Wextra -Wcast-align -Wduplicated-cond -Wextra-semi -Wfloat-equal -Winit-self -Wint-in-bool-context -Wlogical-op -Wmissing-format-attribute -Wnull-dereference -Wpointer-arith -Wredundant-decls -Wredundant-move -Wrestrict -Wshadow -Wsign-compare -Wsuggest-override -Wuninitialized -Wunreachable-code -Wunused -Wunused-const-variable -Wunused-parameter -Wunused-result -Wwrite-strings -std=gnu++17 -MD -MT libtransmission/CMakeFiles/transmission.dir/variant-json.cc.o -MF libtransmission/CMakeFiles/transmission.dir/variant-json.cc.o.d -o libtransmission/CMakeFiles/transmission.dir/variant-json.cc.o -c /__w/transmission/transmission/src/libtransmission/variant-json.cc
In file included from /__w/transmission/transmission/src/libtransmission/variant-json.cc:28:
/usr/include/rapidjson/prettywriter.h: In function 'PrettyWriter(OutputStream&, StackAllocator*, std::size_t)-> rapidjson::PrettyWriter<OutputStream, SourceEncoding, TargetEncoding, StackAllocator, writeFlags> [with OutputStream = {anonymous}::to_string_helpers::FmtOutputStream; SourceEncoding = rapidjson::UTF8<>; TargetEncoding = rapidjson::UTF8<>; StackAllocator = rapidjson::CrtAllocator; unsigned int writeFlags = 0; std::size_t = long unsigned int]':
/usr/include/rapidjson/prettywriter.h:53:102: error: 'const size_t rapidjson::Writer<{anonymous}::to_string_helpers::FmtOutputStream, rapidjson::UTF8<>, rapidjson::UTF8<>, rapidjson::CrtAllocator, 0>::kDefaultLevelDepth' is protected within this context
   53 |     explicit PrettyWriter(OutputStream& os, StackAllocator* allocator = 0, size_t levelDepth = Base::kDefaultLevelDepth) :
      |                                                                                                      ^~~~~~~~~~~~~~~~~~
In file included from /usr/include/rapidjson/prettywriter.h:18,
                 from /__w/transmission/transmission/src/libtransmission/variant-json.cc:28:
/usr/include/rapidjson/writer.h:262:25: note: declared protected here
  262 |     static const size_t kDefaultLevelDepth = 32;
      |                         ^~~~~~~~~~~~~~~~~~
```