### PR TITLE
refactor: simplify `tr_sessionLoadSettings()` args

### DIFF
--- a/cli/cli.cc
+++ b/cli/cli.cc
@@ -326,7 +326,7 @@ int tr_main(int argc, char* argv[])
 
     /* load the defaults from config file + libtransmission defaults */
     auto const config_dir = getConfigDir(argc, (char const**)argv);
-    auto settings = tr_sessionLoadSettings(nullptr, config_dir);
+    auto settings = tr_sessionLoadSettings(config_dir);
 
     /* the command line overrides defaults */
     if (parseCommandLine(&settings, argc, (char const**)argv) != 0)

--- a/daemon/daemon.cc
+++ b/daemon/daemon.cc
@@ -402,7 +402,7 @@ tr_variant load_settings(char const* config_dir)
     app_defaults_map.try_emplace(TR_KEY_start_paused, false);
     app_defaults_map.try_emplace(TR_KEY_pidfile, tr_variant::unmanaged_string(""sv));
     auto const app_defaults = tr_variant{ std::move(app_defaults_map) };
-    return tr_sessionLoadSettings(&app_defaults, config_dir);
+    return tr_sessionLoadSettings(config_dir, &app_defaults);
 }
 
 } // namespace

--- a/gtk/Prefs.cc
+++ b/gtk/Prefs.cc
@@ -108,7 +108,7 @@ tr_variant& getPrefs()
     if (!settings.has_value())
     {
         auto const app_defaults = get_default_app_settings();
-        settings.merge(tr_sessionLoadSettings(&app_defaults, gl_confdir));
+        settings.merge(tr_sessionLoadSettings(gl_confdir, &app_defaults));
         ensure_sound_cmd_is_a_list(&settings);
     }
 

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -479,7 +479,7 @@ tr_variant tr_sessionGetSettings(tr_session const* session)
     return settings;
 }
 
-tr_variant tr_sessionLoadSettings(tr_variant const* app_defaults, std::string_view const config_dir)
+tr_variant tr_sessionLoadSettings(std::string_view const config_dir, tr_variant const* const app_defaults)
 {
     // start with session defaults...
     auto settings = tr_sessionGetDefaultSettings();
@@ -561,7 +561,7 @@ tr_session* tr_sessionInit(char const* config_dir, bool message_queueing_enabled
     // - client settings
     // - previous session's values in settings.json
     // - hardcoded defaults
-    auto settings = tr_sessionLoadSettings(nullptr, config_dir);
+    auto settings = tr_sessionLoadSettings(config_dir);
     settings.merge(client_settings);
 
     // if logging is desired, start it now before doing more work

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -179,14 +179,14 @@ tr_variant tr_sessionGetSettings(tr_session const* session);
  *
  * TODO: if we ever make libtransmissionapp, this would go there.
  *
- * @param app_defaults tr_variant containing the app defaults
  * @param config_dir the configuration directory to find settings.json
+ * @param app_defaults optional tr_variant containing the app-specific defaults
  * @return the loaded settings
  * @see `tr_sessionGetDefaultSettings()`
  * @see `tr_sessionInit()`
  * @see `tr_sessionSaveSettings()`
  */
-tr_variant tr_sessionLoadSettings(tr_variant const* app_defaults, std::string_view config_dir);
+[[nodiscard]] tr_variant tr_sessionLoadSettings(std::string_view config_dir, tr_variant const* app_defaults = nullptr);
 
 /**
  * Add the session's configuration settings to the benc dictionary

--- a/qt/Prefs.cc
+++ b/qt/Prefs.cc
@@ -238,7 +238,7 @@ Prefs::Prefs(QString config_dir)
 #endif
 
     auto const app_defaults = get_default_app_settings();
-    auto settings = tr_sessionLoadSettings(&app_defaults, config_dir_.toStdString());
+    auto settings = tr_sessionLoadSettings(config_dir_.toStdString(), &app_defaults);
     ensureSoundCommandIsAList(&settings);
 
     for (int i = 0; i < PREFS_COUNT; ++i)

--- a/qt/Session.cc
+++ b/qt/Session.cc
@@ -371,7 +371,7 @@ void Session::start()
     }
     else
     {
-        auto const settings = tr_sessionLoadSettings(nullptr, config_dir_.toStdString());
+        auto const settings = tr_sessionLoadSettings(config_dir_.toStdString());
         session_ = tr_sessionInit(config_dir_.toUtf8().constData(), true, settings);
 
         rpc_.start(session_);


### PR DESCRIPTION
The `appname` argument to `tr_sessionLoadSettings()` is only used if the caller passes in a nullptr `config_dir`.

Since no callers pass in a `nullptr` anymore, the `appname` argument can be removed.