### PR TITLE
refactor: use serializer for `tr_session_stats`

### DIFF
--- a/libtransmission/stats.cc
+++ b/libtransmission/stats.cc
@@ -12,17 +12,30 @@
 #include "libtransmission/api-compat.h"
 #include "libtransmission/file.h"
 #include "libtransmission/quark.h"
+#include "libtransmission/serializer.h"
 #include "libtransmission/stats.h"
 #include "libtransmission/tr-strbuf.h"
 #include "libtransmission/utils.h" // for tr_getRatio(), tr_time()
 #include "libtransmission/variant.h"
 
 using namespace std::literals;
-namespace api_compat = libtransmission::api_compat;
+using namespace libtransmission;
 
 namespace
 {
-[[nodiscard]] auto load_stats(std::string_view config_dir)
+template<auto MemberPtr>
+using Field = serializer::Field<MemberPtr>;
+
+constexpr auto Fields = std::tuple{
+    Field<&tr_session_stats::downloadedBytes>{ TR_KEY_downloaded_bytes },
+    Field<&tr_session_stats::filesAdded>{ TR_KEY_files_added },
+    Field<&tr_session_stats::secondsActive>{ TR_KEY_seconds_active },
+    Field<&tr_session_stats::sessionCount>{ TR_KEY_session_count },
+    Field<&tr_session_stats::uploadedBytes>{ TR_KEY_uploaded_bytes },
+};
+} // namespace
+
+tr_session_stats tr_stats::load_old_stats(std::string_view const config_dir)
 {
     auto var = std::optional<tr_variant>{};
 
@@ -35,59 +48,20 @@ namespace
         var = tr_variant_serde::benc().parse_file(oldfile);
     }
 
-    if (var)
-    {
-        api_compat::convert_incoming_data(*var);
-    }
-
-    return var;
-}
-} // namespace
-
-tr_session_stats tr_stats::load_old_stats(std::string_view config_dir)
-{
-    auto const stats = load_stats(config_dir);
-    if (!stats)
+    if (!var)
     {
         return {};
     }
 
-    auto const* const map = stats->get_if<tr_variant::Map>();
-    if (map == nullptr)
-    {
-        return {};
-    }
-
-    auto const load = [map](auto const key, uint64_t& tgt)
-    {
-        if (auto const val = map->value_if<int64_t>(key))
-        {
-            tgt = *val;
-        }
-    };
-
+    api_compat::convert_incoming_data(*var);
     auto ret = tr_session_stats{};
-
-    load(TR_KEY_downloaded_bytes, ret.downloadedBytes);
-    load(TR_KEY_files_added, ret.filesAdded);
-    load(TR_KEY_seconds_active, ret.secondsActive);
-    load(TR_KEY_session_count, ret.sessionCount);
-    load(TR_KEY_uploaded_bytes, ret.uploadedBytes);
-
+    serializer::load(ret, Fields, *var);
     return ret;
 }
 
 void tr_stats::save() const
 {
-    auto const saveme = cumulative();
-    auto map = tr_variant::Map{ 5 };
-    map.try_emplace(TR_KEY_downloaded_bytes, saveme.downloadedBytes);
-    map.try_emplace(TR_KEY_files_added, saveme.filesAdded);
-    map.try_emplace(TR_KEY_seconds_active, saveme.secondsActive);
-    map.try_emplace(TR_KEY_session_count, saveme.sessionCount);
-    map.try_emplace(TR_KEY_uploaded_bytes, saveme.uploadedBytes);
-
-    auto var = tr_variant{ std::move(map) };
+    auto var = tr_variant{ serializer::save(cumulative(), Fields) };
     api_compat::convert_outgoing_data(var);
     tr_variant_serde::json().to_file(var, tr_pathbuf{ config_dir_, "/stats.json"sv });
 }


### PR DESCRIPTION
Followup to #7954 that uses `libtransmission::serializer` to load & save `stats.json`.