### PR TITLE
fix: cache the value of `tr_peerMgrGetDesiredAvailable()`

### DIFF
--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -495,6 +495,7 @@ public:
         {
             peers.erase(iter);
             TR_ASSERT(stats.peer_count == peerCount());
+            mark_swarm_piece_completeness_dirty();
         }
     }
 


### PR DESCRIPTION
Mitigates the risks of the long-standing `tr_torrentStat()` threading issue (#3811, #4571, #4936, #5853, #7948, to name a few).

This PR doesn't compete with #7948. Both can be evaluated independently.

From the crash logs, it looks like `tr_peerMgrGetDesiredAvailable()` is the most common culprit. This makes sense: as currently implemented, that function iterates through all the peer connections. That iteration is inherently risky without a lock, particularly because the calculation is slow.

This PR has `tr_peerMgrGetDesiredAvailable()` cache its value instead of recalculating it every time. The cache is invalidated when either (a) the user changes which files they want or (b) the swarm changes, e.g. by a peer closing connection or a peer sending us have, have all, have none, or bitfield messages.

By caching this, we reduce both the cost and risk of calculating it.