### PR TITLE
refactor: add new transmission::app namespace

### DIFF
--- a/gtk/FaviconCache.cc
+++ b/gtk/FaviconCache.cc
@@ -11,6 +11,7 @@
 #include <glibmm/main.h>
 #include <glibmm/miscutils.h>
 
+using namespace transmission::app;
 using Icon = Glib::RefPtr<Gdk::Pixbuf>;
 
 template<>

--- a/gtk/Session.cc
+++ b/gtk/Session.cc
@@ -57,6 +57,7 @@
 #include <utility>
 
 using namespace std::literals;
+using namespace transmission::app;
 
 class Session::Impl
 {

--- a/gtk/Session.h
+++ b/gtk/Session.h
@@ -71,7 +71,7 @@ public:
 
     tr_torrent* find_torrent(tr_torrent_id_t id) const;
 
-    FaviconCache<Glib::RefPtr<Gdk::Pixbuf>>& favicon_cache() const;
+    transmission::app::FaviconCache<Glib::RefPtr<Gdk::Pixbuf>>& favicon_cache() const;
 
     /******
     *******

--- a/libtransmission/favicon-cache.h
+++ b/libtransmission/favicon-cache.h
@@ -25,6 +25,9 @@
 #include <libtransmission/web-utils.h>
 #include <libtransmission/web.h>
 
+namespace transmission::app
+{
+
 template<typename Icon>
 class FaviconCache
 {
@@ -245,3 +248,5 @@ private:
 
     std::map<std::string /*sitename*/, Icon, std::less<>> icons_;
 };
+
+} // namespace transmission::app

--- a/qt/Application.h
+++ b/qt/Application.h
@@ -119,7 +119,7 @@ private:
     QTranslator qt_translator_;
     QTranslator app_translator_;
 
-    FaviconCache<QPixmap> favicon_cache_;
+    transmission::app::FaviconCache<QPixmap> favicon_cache_;
 };
 
 #define trApp dynamic_cast<Application*>(Application::instance())

--- a/qt/FaviconCache.cc
+++ b/qt/FaviconCache.cc
@@ -10,6 +10,7 @@
 #include <QPixmap>
 #include <QStandardPaths>
 
+using namespace transmission::app;
 using Icon = QPixmap;
 
 template<>

--- a/qt/TrackerDelegate.cc
+++ b/qt/TrackerDelegate.cc
@@ -18,6 +18,8 @@
 #include "TrackerModel.h"
 #include "Utils.h"
 
+using namespace transmission::app;
+
 /***
 ****
 ***/


### PR DESCRIPTION
Move `FavIconCache` into a new `transmission::app` namespace.

I intend to add a couple more small pieces into libtransmission to avoid code repetition between the Qt and GTK apps. (Migrating the `sort-by-foo` and `show-foo` settings in `settings.json` to snake_case).

We should consider making another module for these pieces if they start to pile up; but for now, let's cordon them into their own namespace.