### PR TITLE
perf: unmanaged strings in rpcimpl

### DIFF
--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -2687,7 +2687,7 @@ void add_strings_from_var(std::set<std::string_view>& strings, tr_variant const&
         return RpcVersionMin;
     case TR_KEY_rpc_version_semver:
     case TR_KEY_rpc_version_semver_kebab:
-        return TrRpcVersionSemver;
+        return tr_variant::unmanaged_string(TrRpcVersionSemver);
     case TR_KEY_script_torrent_added_enabled:
     case TR_KEY_script_torrent_added_enabled_kebab:
         return session.useScript(TR_SCRIPT_ON_TORRENT_ADDED);


### PR DESCRIPTION
Small cleanup to rpcimpl.cc: there are a couple of places when building response messages where we can use unmanaged strings but weren't.