### PR TITLE
refactor: migrate transmission-remote to JSON-RPC

### DIFF
--- a/utils/remote.cc
+++ b/utils/remote.cc
@@ -2464,6 +2464,9 @@ int flush(char const* rpcurl, tr_variant* const var, RemoteConfig& config)
             status |= process_response(rpcurl, buf, config);
             break;
 
+        case 204:
+            break;
+
         case 409:
             // Session id failed. Our curl header func has already
             // pulled the new session id from this response's headers.


### PR DESCRIPTION
Part of #7891

Migrate `transmission-remote` to JSON-RPC.

- Build outgoing requests in JSON-RPC format natively.
- Use `api_compat::convert() on outgoing requests: default to legacy format, but send JSON-RPC if we see X-Transmission-Rpc-Version
- Use `api_compat::convert_incoming_data()` to ensure incoming repsonses are in JSON-RPC
- Remove references to `_kebab`, `_camel` keys

Oof, I don't love doing remote.cc refactors  :roll_eyes: There are some crazy code smells in here and we don't have any tests. TBH we probably ought to break this into a couple of different files s.t. we could link the internals into a remote-test.cc gtest file :thinking: 