### PR TITLE
fixup! feat: sync the values of `preferred_transports` and `*_enabled`

### DIFF
--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -401,7 +401,7 @@ public:
 
             if (auto const* map = src.get_if<tr_variant::Map>())
             {
-                if (map->contains(TR_KEY_preferred_transports))
+                if (map->find_if<tr_variant::Vector>(TR_KEY_preferred_transports) != nullptr)
                 {
                     fixup_from_preferred_transports();
                 }


### PR DESCRIPTION
When loading `settings.json`, the value of `preferred_transports` should only be used to fixup `tcp_enabled ` and `utp_enabled` if it is a vector.