### PR TITLE
UI: removing menu icons on older Macs

### DIFF
--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -813,8 +813,17 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
 
     [self updateMainWindow];
 
+    if (@available(macOS 26.0, *))
+        ;
+    else
+    {
+        // <#7908> Keep older macOS clean of visual noise
+        for (NSMenuItem* item in _fWindow.menu.itemArray)
+            for (NSMenuItem* subItem in item.submenu.itemArray)
+                subItem.image = nil;
+    }
+
     //timer to update the interface every second
-    [self updateUI];
     self.fTimer = [NSTimer scheduledTimerWithTimeInterval:kUpdateUISeconds target:self selector:@selector(updateUI) userInfo:nil
                                                   repeats:YES];
     [NSRunLoop.currentRunLoop addTimer:self.fTimer forMode:NSModalPanelRunLoopMode];

--- a/macosx/TorrentTableView.mm
+++ b/macosx/TorrentTableView.mm
@@ -91,6 +91,16 @@ static NSTimeInterval const kToggleProgressSeconds = 0.175;
 - (void)awakeFromNib
 {
     [super awakeFromNib];
+    if (@available(macOS 26.0, *))
+        ;
+    else
+    {
+        // <#7908> Keep older macOS clean of visual noise
+        for (NSMenuItem* item in _fContextRow.itemArray)
+            item.image = nil;
+        for (NSMenuItem* item in _fContextNoRow.itemArray)
+            item.image = nil;
+    }
     [NSNotificationCenter.defaultCenter addObserver:self selector:@selector(refreshTorrentTable) name:@"RefreshTorrentTable"
                                              object:nil];
 }


### PR DESCRIPTION
Fix #7908

On macOS 15.7.3 (latest before Liquid Glass):
![Capture d’écran 2025-12-24 à 07 44 43](https://github.com/user-attachments/assets/ac1dc1c1-188b-46f8-aa40-fe8f58713c6c)
![Capture d’écran 2025-12-24 à 07 45 07](https://github.com/user-attachments/assets/1c644ca4-2a65-44a7-9183-6073d7569d97)

Note: Removed menu icons on older Macs.