### PR TITLE
refactor: remove unused tr_variant initializer-list methods

### DIFF
--- a/libtransmission/variant.h
+++ b/libtransmission/variant.h
@@ -9,7 +9,6 @@
 #include <cstddef> // size_t
 #include <cstdint> // int64_t
 #include <functional> // std::invoke
-#include <initializer_list>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -106,20 +105,6 @@ public:
             return find(key) != end(); // NOLINT(readability-container-contains)
         }
 
-        [[nodiscard]] TR_CONSTEXPR20 auto find(std::initializer_list<tr_quark> keys) noexcept
-        {
-            auto constexpr Predicate = [](auto const& item, tr_quark key)
-            {
-                return item.first == key;
-            };
-            return std::find_first_of(std::begin(vec_), std::end(vec_), std::begin(keys), std::end(keys), Predicate);
-        }
-
-        [[nodiscard]] TR_CONSTEXPR20 auto find(std::initializer_list<tr_quark> keys) const noexcept
-        {
-            return Vector::const_iterator{ const_cast<Map*>(this)->find(keys) };
-        }
-
         [[nodiscard]] TR_CONSTEXPR20 auto size() const noexcept
         {
             return std::size(vec_);
@@ -211,33 +196,9 @@ public:
         }
 
         template<typename Type>
-        [[nodiscard]] TR_CONSTEXPR20 auto* find_if(std::initializer_list<tr_quark> keys) noexcept
-        {
-            auto const iter = find(keys);
-            return iter != end() ? iter->second.get_if<Type>() : nullptr;
-        }
-
-        template<typename Type>
-        [[nodiscard]] TR_CONSTEXPR20 auto* find_if(std::initializer_list<tr_quark> keys) const noexcept
-        {
-            return const_cast<Map*>(this)->find_if<Type>(keys);
-        }
-
-        template<typename Type>
         [[nodiscard]] std::optional<Type> value_if(tr_quark const key) const noexcept
         {
             if (auto it = find(key); it != end())
-            {
-                return it->second.value_if<Type>();
-            }
-
-            return std::nullopt;
-        }
-
-        template<typename Type>
-        [[nodiscard]] std::optional<Type> value_if(std::initializer_list<tr_quark> keys) const noexcept
-        {
-            if (auto it = find(keys); it != end())
             {
                 return it->second.value_if<Type>();
             }


### PR DESCRIPTION
Another #7891 cleanup PR. This PR removes `tr_variant`'s now-unused `std::initializer_list`  methods.

Notes: Fixed `4.1.0-beta.4` issue that included backwards-incompatible keys in the settings file.