### PR TITLE
fix: detect `is_torrent` in rpc response too

### DIFF
--- a/libtransmission/api-compat.cc
+++ b/libtransmission/api-compat.cc
@@ -498,6 +498,7 @@ struct State
         {
             state.is_free_space_response = args->contains(TR_KEY_path) &&
                 args->contains(state.was_jsonrpc ? TR_KEY_size_bytes : TR_KEY_size_bytes_kebab_APICOMPAT);
+            state.is_torrent = args->contains(TR_KEY_torrents);
         }
     }
 


### PR DESCRIPTION
Fix legacy `torrent-get` returning `download-dir` instead of `downloadDir` reported at https://github.com/transmission/transmission/issues/8007#issuecomment-3692191196.