### PR TITLE
fix(remote): increase the width of up/down ratio display to 8

### DIFF
--- a/utils/remote.cc
+++ b/utils/remote.cc
@@ -1423,7 +1423,7 @@ void print_file_list(tr_variant::Map const& result)
 
 void print_peers_impl(tr_variant::Vector const& peers)
 {
-    fmt::print("{:<40s}  {:<12s}  {:<5s} {:<6s}  {:<6s}  {:s}\n", "Address", "Flags", "Done", "Down", "Up", "Client");
+    fmt::print("{:<40s}  {:<12s}  {:<5s} {:<8s}  {:<8s}  {:s}\n", "Address", "Flags", "Done", "Down", "Up", "Client");
 
     for (auto const& peer_var : peers)
     {
@@ -1443,7 +1443,7 @@ void print_peers_impl(tr_variant::Vector const& peers)
         if (address && client && progress && flagstr && rate_to_client && rate_to_peer)
         {
             fmt::print(
-                "{:<40s}  {:<12s}  {:<5s} {:6.1f}  {:6.1f}  {:s}\n",
+                "{:<40s}  {:<12s}  {:<5s} {:8.1f}  {:8.1f}  {:s}\n",
                 *address,
                 *flagstr,
                 strlpercent(*progress * 100.0),
@@ -1558,7 +1558,7 @@ void print_torrent_list(tr_variant::Map const& result)
     }
 
     fmt::print(
-        "{:>6s}   {:>5s}  {:>9s}  {:<9s}  {:>6s}  {:>6s}  {:<5s}  {:<11s}  {:<s}\n",
+        "{:>6s}   {:>5s}  {:>9s}  {:<9s}  {:>8s}  {:>8s}  {:<5s}  {:<11s}  {:<s}\n",
         "ID",
         "Done",
         "Have",
@@ -1624,7 +1624,7 @@ void print_torrent_list(tr_variant::Map const& result)
             std::string{ "n/a" };
 
         fmt::print(
-            "{:>6d}{:c}  {:>5s}  {:>9s}  {:<9s}  {:6.1f}  {:6.1f}  {:>5s}  {:<11s}  {:<s}\n",
+            "{:>6d}{:c}  {:>5s}  {:>9s}  {:<9s}  {:8.1f}  {:8.1f}  {:>5s}  {:<11s}  {:<s}\n",
             *o_tor_id,
             error_mark,
             done_str,
@@ -1642,7 +1642,7 @@ void print_torrent_list(tr_variant::Map const& result)
     }
 
     fmt::print(
-        "Sum:            {:>9s}             {:6.1f}  {:6.1f}\n",
+        "Sum:            {:>9s}             {:8.1f}  {:8.1f}\n",
         strlsize(total_size).c_str(),
         Speed{ total_up, Speed::Units::Byps }.count(Speed::Units::KByps),
         Speed{ total_down, Speed::Units::Byps }.count(Speed::Units::KByps));


### PR DESCRIPTION
Fixes: #7926 

Notes: Fixed layout bug that caused columns to be misaligned when transfer speed  was >= 10MB.

Another prepared option is to remove the fractional part, I also have a branch prepared for that ([link](/transmission/transmission/compare/main...sanapci:transmission:bugfix/print_aligment_over_10mbps_nofraction)). Let me know if you prefer that solution.