### PR TITLE
feat(remote): console message for HTTP 204 response

### DIFF
--- a/utils/remote.cc
+++ b/utils/remote.cc
@@ -2478,6 +2478,7 @@ int flush(char const* rpcurl, tr_variant* const var, RemoteConfig& config)
             break;
 
         case 204:
+            fmt::print("{:s} acknowledged request\n", rpcurl);
             break;
 
         case 409:


### PR DESCRIPTION
Print something for HTTP 204 response so that the user have *some* feedback.