### PR TITLE
fix(remote): attach id to methods that can return errors

### DIFF
--- a/utils/remote.cc
+++ b/utils/remote.cc
@@ -3431,10 +3431,11 @@ int process_args(char const* rpcurl, int argc, char const* const* argv, RemoteCo
                     args.try_emplace(TR_KEY_name, optarg_sv);
                     add_id_arg(args, config);
 
-                    auto map = tr_variant::Map{ 3U };
+                    auto map = tr_variant::Map{ 4U };
                     map.try_emplace(TR_KEY_jsonrpc, tr_variant::unmanaged_string(JsonRpc::Version));
                     map.try_emplace(TR_KEY_method, tr_variant::unmanaged_string(TR_KEY_torrent_rename_path));
                     map.try_emplace(TR_KEY_params, std::move(args));
+                    map.try_emplace(TR_KEY_id, ID_NOOP);
 
                     auto top = tr_variant{ std::move(map) };
                     status |= flush(rpcurl, &top, config);


### PR DESCRIPTION
Related to #8020.

`blocklist_update` is not the only method that needed an ID after migrating to JSON-RPC. This PR attaches IDs to other methods that needed one, otherwise transmission-remote can no longer receive any errors responses from them.