### PR TITLE
fix: torrent dates were not bumped in some cases

### DIFF
--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1961,6 +1961,7 @@ void tr_torrent::set_file_priorities(tr_file_index_t const* files, tr_file_index
         file_priorities_.set(files, file_count, priority);
         priority_changed_.emit(this, files, file_count, priority);
         set_dirty();
+        mark_changed();
     }
 }
 

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -440,6 +440,7 @@ struct tr_torrent
             file_priorities_.set(file, priority);
             priority_changed_.emit(this, &file, 1U, priority);
             set_dirty();
+            mark_changed();
         }
     }
 


### PR DESCRIPTION
Fixes #7993.

Notes: Fixed remote RPC bug where querying `recently_active` torrents missed some torrents.