### PR TITLE
docs: deprecate `session_get.tcp_enabled`

### DIFF
--- a/docs/rpc-spec.md
+++ b/docs/rpc-spec.md
@@ -1081,7 +1081,7 @@ Transmission 4.1.0 (`rpc_version_semver` 6.0.0, `rpc_version`: 18)
 | `torrent_get` | new arg `files.begin_piece`
 | `torrent_get` | new arg `files.end_piece`
 | `port_test` | new arg `ip_protocol`
-| `torrent_get` | new arg `trackerStats.downloader_count`
+| `torrent_get` | new arg `tracker_stats.downloader_count`
 | `torrent_get` | :warning: **DEPRECATED** `manual_announce_time`, it never worked
 | `session_get` | new arg `preferred_transports`
 | `session_set` | new arg `preferred_transports`


### PR DESCRIPTION
`session_get.tcp_enabled` existed for a long time, but it was never documented until `4.1.0-beta.4`. Nevertheless, we deprecate it in favour of `preferred_transports` now.