### PR TITLE
fix: remove block from wishlist when received

### DIFF
--- a/libtransmission/peer-mgr-wishlist.cc
+++ b/libtransmission/peer-mgr-wishlist.cc
@@ -242,6 +242,17 @@ private:
 
     // ---
 
+    TR_CONSTEXPR20 void client_got_block(tr_block_index_t block)
+    {
+        if (auto const iter = find_by_block(block); iter != std::end(candidates_))
+        {
+            iter->unrequested.erase(block);
+            resort_piece(iter);
+        }
+    }
+
+    // ---
+
     TR_CONSTEXPR20 void peer_disconnect(tr_bitfield const& have, tr_bitfield const& requests)
     {
         dec_replication_bitfield(have);
@@ -517,7 +528,7 @@ private:
 
     CandidateVec candidates_;
 
-    std::array<libtransmission::ObserverTag, 14U> const tags_;
+    std::array<libtransmission::ObserverTag, 15U> const tags_;
 
     Mediator& mediator_;
 };
@@ -534,6 +545,8 @@ Wishlist::Impl::Impl(Mediator& mediator_in)
           mediator_in.observe_got_bad_piece([this](tr_torrent*, tr_piece_index_t p) { got_bad_piece(p); }),
           // replication
           mediator_in.observe_got_bitfield([this](tr_torrent*, tr_bitfield const& b) { inc_replication_bitfield(b); }),
+          // unrequested
+          mediator_in.observe_got_block([this](tr_torrent*, tr_block_index_t b) { client_got_block(b); }),
           // unrequested
           mediator_in.observe_got_choke([this](tr_torrent*, tr_bitfield const& b) { reset_blocks_bitfield(b); }),
           // replication

--- a/libtransmission/peer-mgr-wishlist.h
+++ b/libtransmission/peer-mgr-wishlist.h
@@ -48,6 +48,8 @@ public:
             libtransmission::SimpleObservable<tr_torrent*, tr_piece_index_t>::Observer observer) = 0;
         [[nodiscard]] virtual libtransmission::ObserverTag observe_got_bitfield(
             libtransmission::SimpleObservable<tr_torrent*, tr_bitfield const&>::Observer observer) = 0;
+        [[nodiscard]] virtual libtransmission::ObserverTag observe_got_block(
+            libtransmission::SimpleObservable<tr_torrent*, tr_block_index_t>::Observer observer) = 0;
         [[nodiscard]] virtual libtransmission::ObserverTag observe_got_choke(
             libtransmission::SimpleObservable<tr_torrent*, tr_bitfield const&>::Observer observer) = 0;
         [[nodiscard]] virtual libtransmission::ObserverTag observe_got_have(


### PR DESCRIPTION
Partial fix for #7919.
Fixes #8045.

This PR restores some code that was removed in #7744. It was not needed back then, because Transmission did not process any incoming BT blocks that was not requested, but that premised changed after #7866.

Given the unreliable nature of network transfers, it's entirely possible for a requested block to arrive after it has timed out. We need to update the wishlist accordingly in cases like this.