### PR TITLE
fix: unconst variable to be moved

### DIFF
--- a/libtransmission/serializer.h
+++ b/libtransmission/serializer.h
@@ -447,7 +447,7 @@ bool to_optional(tr_variant const& src, std::optional<T>* ptgt)
         return true;
     }
 
-    if (auto const val = to_value<T>(src))
+    if (auto val = to_value<T>(src))
     {
         *ptgt = std::move(val);
         return true;


### PR DESCRIPTION
P.S. I'm surprised this wasn't caught by `performance-move-const-arg`.