### PR TITLE
refactor: `tr_web` mediator run method should take lvalue ref

### DIFF
--- a/libtransmission/session-thread.cc
+++ b/libtransmission/session-thread.cc
@@ -224,8 +224,7 @@ public:
     }
 
 private:
-    using callback = std::function<void(void)>;
-    using work_queue_t = std::list<callback>;
+    using work_queue_t = std::list<std::function<void(void)>>;
 
     void session_thread_func(struct event_base* evbase)
     {

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -356,9 +356,9 @@ std::optional<std::string> tr_session::WebMediator::proxyUrl() const
     return session_->settings().proxy_url;
 }
 
-void tr_session::WebMediator::run(tr_web::FetchDoneFunc&& func, tr_web::FetchResponse&& response) const
+void tr_session::WebMediator::run(tr_web::FetchDoneFunc&& func, tr_web::FetchResponse const& response) const
 {
-    session_->run_in_session_thread(std::move(func), std::move(response));
+    session_->run_in_session_thread(std::move(func), response);
 }
 
 time_t tr_session::WebMediator::now() const

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -268,7 +268,7 @@ private:
         [[nodiscard]] std::optional<std::string> proxyUrl() const override;
         [[nodiscard]] time_t now() const override;
         // runs the tr_web::fetch response callback in the libtransmission thread
-        void run(tr_web::FetchDoneFunc&& func, tr_web::FetchResponse&& response) const override;
+        void run(tr_web::FetchDoneFunc&& func, tr_web::FetchResponse const& response) const override;
 
     private:
         tr_session* const session_;

--- a/libtransmission/web.cc
+++ b/libtransmission/web.cc
@@ -376,7 +376,7 @@ public:
                 return;
             }
 
-            impl.mediator.run(std::move(options_.done_func), std::move(this->response));
+            impl.mediator.run(std::move(options_.done_func), response);
             options_.done_func = {};
         }
 

--- a/libtransmission/web.h
+++ b/libtransmission/web.h
@@ -160,7 +160,7 @@ public:
         }
 
         // Invoke the user-provided fetch callback
-        virtual void run(FetchDoneFunc&& func, FetchResponse&& response) const
+        virtual void run(FetchDoneFunc&& func, FetchResponse const& response) const
         {
             func(response);
         }


### PR DESCRIPTION
Fixed a code smell where `tr_session::WebMediator::run()` takes `tr_web::FetchResponse&&` even though `tr_web::FetchDoneFunc` takes `tr_web::FetchResponse const&`.

No change in behaviour.