### PR TITLE
refactor: use `time_t` for all idle_seconds operations

### DIFF
--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -655,7 +655,7 @@ size_t tr_session::count_queue_free_slots(tr_direction dir) const noexcept
     // count how many torrents are active
     auto active_count = size_t{};
     auto const stalled_enabled = queueStalledEnabled();
-    auto const stalled_if_idle_for_n_seconds = queueStalledMinutes() * 60;
+    auto const stalled_if_idle_for_n_seconds = static_cast<time_t>(queueStalledMinutes() * 60);
     auto const now = tr_time();
     for (auto const* const tor : torrents())
     {

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1265,9 +1265,10 @@ bool tr_torrentCanManualUpdate(tr_torrent const* tor)
 
 tr_stat tr_torrent::stats() const
 {
-    static auto constexpr IsStalled = [](tr_torrent const* const tor, std::optional<size_t> idle_secs)
+    static auto constexpr IsStalled = [](tr_torrent const* const tor, std::optional<time_t> idle_secs)
     {
-        return tor->session->queueStalledEnabled() && idle_secs > tor->session->queueStalledMinutes() * 60U;
+        return tor->session->queueStalledEnabled() &&
+            idle_secs > static_cast<time_t>(tor->session->queueStalledMinutes() * 60U);
     };
 
     auto const lock = unique_lock();
@@ -1285,7 +1286,7 @@ tr_stat tr_torrent::stats() const
     stats.activity = activity;
     stats.error = this->error().error_type();
     stats.queuePosition = queue_position();
-    stats.idleSecs = idle_seconds ? static_cast<time_t>(*idle_seconds) : -1;
+    stats.idleSecs = idle_seconds ? *idle_seconds : time_t{ -1 };
     stats.isStalled = IsStalled(this, idle_seconds);
     stats.errorString = this->error().errmsg().c_str();
 

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -875,7 +875,7 @@ struct tr_torrent
         return idle_limit_minutes_;
     }
 
-    [[nodiscard]] constexpr std::optional<size_t> idle_seconds(time_t now) const noexcept
+    [[nodiscard]] constexpr std::optional<time_t> idle_seconds(time_t now) const noexcept
     {
         auto const activity = this->activity();
 
@@ -883,7 +883,7 @@ struct tr_torrent
         {
             if (auto const latest = std::max(date_started_, date_active_); latest != 0)
             {
-                return static_cast<size_t>(std::max(now - latest, time_t{ 0 }));
+                return std::max(now - latest, time_t{ 0 });
             }
         }
 
@@ -1214,8 +1214,8 @@ private:
             return {};
         }
 
-        auto const idle_limit_seconds = size_t{ *idle_limit_minutes } * 60U;
-        return idle_limit_seconds > *idle_seconds ? idle_limit_seconds - *idle_seconds : 0U;
+        auto const idle_limit_seconds = static_cast<time_t>(*idle_limit_minutes * 60U);
+        return idle_limit_seconds > *idle_seconds ? idle_limit_seconds - *idle_seconds : time_t{ 0U };
     }
 
     [[nodiscard]] constexpr bool is_piece_transfer_allowed(tr_direction direction) const noexcept


### PR DESCRIPTION
Use `time_t` for everything related to idle seconds. This eliminates a `bugprone-narrowing-conversions` warning.