### PR TITLE
fix: `tr_torrent::seed_ratio_` should be double

### DIFF
--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -1409,7 +1409,7 @@ private:
     time_t seconds_seeding_before_current_start_ = 0;
 
     float verify_progress_ = -1.0F;
-    float seed_ratio_ = 0.0F;
+    double seed_ratio_ = 0.0;
 
     tr_announce_key_t announce_key_ = tr_rand_obj<tr_announce_key_t>();
 


### PR DESCRIPTION
Everywhere else, seed ratio is declared as `double`, but the source of truth is `float`. IMO, views of `tr_torrent` (e.g. `tr_stat`) can use `float` to save space, but the source of truth shouldn't, especially not when the getters and setters all use `double`.

Judging from e6c0bdef6a7022b9aeedaf379f5e0a1f2d370897, this was done intentionally to save space...? In any case, all other `tr_torrent` fields that were converted from `double` to `float` in e6c0bdef6a7022b9aeedaf379f5e0a1f2d370897 has been converted back to `double` over the years.