### PR TITLE
fix: remove artificial max metadata size limit

### DIFF
--- a/libtransmission/torrent-magnet.h
+++ b/libtransmission/torrent-magnet.h
@@ -13,7 +13,6 @@
 #include <cstdint> // int64_t
 #include <ctime> // time_t
 #include <deque>
-#include <limits>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -35,7 +34,7 @@ public:
 
     [[nodiscard]] static constexpr auto is_valid_metadata_size(int64_t const size) noexcept
     {
-        return size > 0 && size <= std::numeric_limits<int>::max();
+        return size > 0;
     }
 
     bool set_metadata_piece(int64_t piece, void const* data, size_t len);


### PR DESCRIPTION
`4.1.x` cherry-pick of #8082.