### PR TITLE
refactor: convert `tr_bandwidth::RateControl::newest_` to unsigned

### DIFF
--- a/libtransmission/bandwidth.cc
+++ b/libtransmission/bandwidth.cc
@@ -39,18 +39,18 @@ Speed tr_bandwidth::get_speed(RateControl& r, unsigned int interval_msec, uint64
         uint64_t bytes = 0U;
         uint64_t const cutoff = now - interval_msec;
 
-        for (int i = r.newest_; r.date_[i] > cutoff;)
+        for (auto i = r.newest_; r.date_[i] > cutoff;)
         {
             bytes += r.size_[i];
 
-            if (--i == -1)
+            if (--i >= HistorySize) // overflowed below zero
             {
-                i = HistorySize - 1; /* circular history */
+                i = HistorySize - 1U; // circular history
             }
 
             if (i == r.newest_)
             {
-                break; /* we've come all the way around */
+                break; // we've come all the way around
             }
         }
 
@@ -71,7 +71,7 @@ void tr_bandwidth::notify_bandwidth_consumed_bytes(uint64_t const now, RateContr
     {
         if (++r.newest_ == HistorySize)
         {
-            r.newest_ = 0;
+            r.newest_ = 0U;
         }
 
         r.date_[r.newest_] = now;

--- a/libtransmission/bandwidth.h
+++ b/libtransmission/bandwidth.h
@@ -237,7 +237,7 @@ private:
         std::array<size_t, HistorySize> size_;
         uint64_t cache_time_;
         Speed cache_val_;
-        int newest_;
+        size_t newest_;
     };
 
     struct Band


### PR DESCRIPTION
This fixes a `modernize-use-integer-sign-comparison` warning here:

https://github.com/transmission/transmission/blob/54665bbab346eb62914e595416b8ca4c9a437c6a/libtransmission/bandwidth.cc#L72

```
/transmission/libtransmission/bandwidth.cc:72:13: warning: comparison between 'signed' and 'unsigned' integers [modernize-use-integer-sign-comparison]
   72 |         if (++r.newest_ == HistorySize)
      |             ^           ~~
      |             std::cmp_equal( ,         )
```

Also, `tr_bandwidth::HistorySize` is no longer limited by the max possible value of `int` (not that it matters).