### PR TITLE
refactor: no macros in `transmission.h`

### DIFF
--- a/cli/cli.cc
+++ b/cli/cli.cc
@@ -49,8 +49,8 @@ sig_atomic_t manualUpdate = false;
 char const* torrentPath = nullptr;
 
 using Arg = tr_option::Arg;
-static_assert(TrDefaultPeerPort == 51413);
-static_assert(TrDefaultPeerSocketTos == "le");
+static_assert(TrDefaultPeerPort == 51413, "update 'port' desc");
+static_assert(TrDefaultPeerSocketTos == "le", "update 'tos' desc");
 auto constexpr Options = std::array<tr_option, 20>{ {
     { 'b', "blocklist", "Enable peer blocklists", "b", Arg::None, nullptr },
     { 'B', "no-blocklist", "Disable peer blocklists", "B", Arg::None, nullptr },

--- a/cli/cli.cc
+++ b/cli/cli.cc
@@ -50,6 +50,9 @@ sig_atomic_t manualUpdate = false;
 char const* torrentPath = nullptr;
 
 auto const peer_port_desc = fmt::format("Port for incoming peers (Default: {:d})", TrDefaultPeerPort);
+auto const tos_desc = fmt::format(
+    "Peer socket DSCP / ToS setting (number, or a DSCP string, e.g. 'af11' or 'cs0'. default={:s})",
+    TrDefaultPeerSocketTos);
 
 using Arg = tr_option::Arg;
 auto const options = std::array<tr_option, 20>{ {
@@ -65,13 +68,7 @@ auto const options = std::array<tr_option, 20>{ {
     { 'm', "portmap", "Enable portmapping via NAT-PMP or UPnP", "m", Arg::None, nullptr },
     { 'M', "no-portmap", "Disable portmapping", "M", Arg::None, nullptr },
     { 'p', "port", peer_port_desc.c_str(), "p", Arg::Required, "<port>" },
-    { 't',
-      "tos",
-      "Peer socket DSCP / ToS setting (number, or a DSCP string, e.g. 'af11' or 'cs0', default=" TR_DEFAULT_PEER_SOCKET_TOS_STR
-      ")",
-      "t",
-      Arg::Required,
-      "<dscp-or-tos>" },
+    { 't', "tos", tos_desc.c_str(), "t", Arg::Required, "<dscp-or-tos>" },
     { 'u', "uplimit", "Set max upload speed in " SPEED_K_STR, "u", Arg::Required, "<speed>" },
     { 'U', "no-uplimit", "Don't limit the upload speed", "U", Arg::None, nullptr },
     { 'v', "verify", "Verify the specified torrent", "v", Arg::None, nullptr },

--- a/daemon/daemon.cc
+++ b/daemon/daemon.cc
@@ -83,6 +83,7 @@ char constexpr Usage[] = "Transmission " LONG_VERSION_STRING
 auto const rpc_port_desc = fmt::format("RPC port (Default: {:d})", TrDefaultRpcPort);
 auto const peer_port_desc = fmt::format("Port for incoming peers (Default: {:d})", TrDefaultPeerPort);
 auto const global_peer_desc = fmt::format("Maximum overall number of peers (Default: {:d})", TrDefaultPeerLimitGlobal);
+auto const peers_tor_desc = fmt::format("Maximum number of peers per torrent (Default: {:d})", TrDefaultPeerLimitTorrent);
 
 using Arg = tr_option::Arg;
 auto const options = std::array<tr_option, 48>{ {
@@ -131,12 +132,7 @@ auto const options = std::array<tr_option, 48>{ {
     { 'm', "portmap", "Enable portmapping via NAT-PMP or UPnP", "m", Arg::None, nullptr },
     { 'M', "no-portmap", "Disable portmapping", "M", Arg::None, nullptr },
     { 'L', "peerlimit-global", global_peer_desc.c_str(), "L", Arg::Required, "<limit>" },
-    { 'l',
-      "peerlimit-torrent",
-      "Maximum number of peers per torrent (Default: " TR_DEFAULT_PEER_LIMIT_TORRENT_STR ")",
-      "l",
-      Arg::Required,
-      "<limit>" },
+    { 'l', "peerlimit-torrent", peers_tor_desc.c_str(), "l", Arg::Required, "<limit>" },
     { 910, "encryption-required", "Encrypt all peer connections", "er", Arg::None, nullptr },
     { 911, "encryption-preferred", "Prefer encrypted peer connections", "ep", Arg::None, nullptr },
     { 912, "encryption-tolerated", "Prefer unencrypted peer connections", "et", Arg::None, nullptr },

--- a/daemon/daemon.cc
+++ b/daemon/daemon.cc
@@ -82,6 +82,7 @@ char constexpr Usage[] = "Transmission " LONG_VERSION_STRING
 
 auto const rpc_port_desc = fmt::format("RPC port (Default: {:d})", TrDefaultRpcPort);
 auto const peer_port_desc = fmt::format("Port for incoming peers (Default: {:d})", TrDefaultPeerPort);
+auto const global_peer_desc = fmt::format("Maximum overall number of peers (Default: {:d})", TrDefaultPeerLimitGlobal);
 
 using Arg = tr_option::Arg;
 auto const options = std::array<tr_option, 48>{ {
@@ -129,12 +130,7 @@ auto const options = std::array<tr_option, 48>{ {
     { 'P', "peerport", peer_port_desc.c_str(), "P", Arg::Required, "<port>" },
     { 'm', "portmap", "Enable portmapping via NAT-PMP or UPnP", "m", Arg::None, nullptr },
     { 'M', "no-portmap", "Disable portmapping", "M", Arg::None, nullptr },
-    { 'L',
-      "peerlimit-global",
-      "Maximum overall number of peers (Default: " TR_DEFAULT_PEER_LIMIT_GLOBAL_STR ")",
-      "L",
-      Arg::Required,
-      "<limit>" },
+    { 'L', "peerlimit-global", global_peer_desc.c_str(), "L", Arg::Required, "<limit>" },
     { 'l',
       "peerlimit-torrent",
       "Maximum number of peers per torrent (Default: " TR_DEFAULT_PEER_LIMIT_TORRENT_STR ")",

--- a/daemon/daemon.cc
+++ b/daemon/daemon.cc
@@ -80,14 +80,15 @@ char constexpr Usage[] = "Transmission " LONG_VERSION_STRING
                          "\n"
                          "Usage: transmission-daemon [options]";
 
-auto const rpc_port_desc = fmt::format("RPC port (Default: {:d})", TrDefaultRpcPort);
-auto const peer_port_desc = fmt::format("Port for incoming peers (Default: {:d})", TrDefaultPeerPort);
 auto const global_peer_desc = fmt::format("Maximum overall number of peers (Default: {:d})", TrDefaultPeerLimitGlobal);
+auto const peer_port_desc = fmt::format("Port for incoming peers (Default: {:d})", TrDefaultPeerPort);
 auto const peers_tor_desc = fmt::format("Maximum number of peers per torrent (Default: {:d})", TrDefaultPeerLimitTorrent);
+auto const rpc_port_desc = fmt::format("RPC port (Default: {:d})", TrDefaultRpcPort);
+auto const whitelist_desc = fmt::format("Allowed IP addresses. (Default: {:s})", TrDefaultRpcWhitelist);
 
 using Arg = tr_option::Arg;
 auto const options = std::array<tr_option, 48>{ {
-    { 'a', "allowed", "Allowed IP addresses. (Default: " TR_DEFAULT_RPC_WHITELIST ")", "a", Arg::Required, "<list>" },
+    { 'a', "allowed", whitelist_desc.c_str(), "a", Arg::Required, "<list>" },
     { 'b', "blocklist", "Enable peer blocklists", "b", Arg::None, nullptr },
     { 'B', "no-blocklist", "Disable peer blocklists", "B", Arg::None, nullptr },
     { 'c', "watch-dir", "Where to watch for new torrent files", "c", Arg::Required, "<directory>" },

--- a/daemon/daemon.cc
+++ b/daemon/daemon.cc
@@ -80,7 +80,8 @@ char constexpr Usage[] = "Transmission " LONG_VERSION_STRING
                          "\n"
                          "Usage: transmission-daemon [options]";
 
-auto rpc_port_desc = fmt::format("RPC port (Default: {:d})", TrDefaultRpcPort);
+auto const rpc_port_desc = fmt::format("RPC port (Default: {:d})", TrDefaultRpcPort);
+auto const peer_port_desc = fmt::format("Port for incoming peers (Default: {:d})", TrDefaultPeerPort);
 
 using Arg = tr_option::Arg;
 auto const options = std::array<tr_option, 48>{ {
@@ -125,7 +126,7 @@ auto const options = std::array<tr_option, 48>{ {
       "<protocol(s)>" },
     { 831, "utp", "*DEPRECATED* Enable µTP for peer connections", nullptr, Arg::None, nullptr },
     { 832, "no-utp", "*DEPRECATED* Disable µTP for peer connections", nullptr, Arg::None, nullptr },
-    { 'P', "peerport", "Port for incoming peers (Default: " TR_DEFAULT_PEER_PORT_STR ")", "P", Arg::Required, "<port>" },
+    { 'P', "peerport", peer_port_desc.c_str(), "P", Arg::Required, "<port>" },
     { 'm', "portmap", "Enable portmapping via NAT-PMP or UPnP", "m", Arg::None, nullptr },
     { 'M', "no-portmap", "Disable portmapping", "M", Arg::None, nullptr },
     { 'L',

--- a/daemon/daemon.cc
+++ b/daemon/daemon.cc
@@ -80,11 +80,11 @@ char constexpr Usage[] = "Transmission " LONG_VERSION_STRING
                          "Usage: transmission-daemon [options]";
 
 using Arg = tr_option::Arg;
-static_assert(TrDefaultRpcWhitelist == "127.0.0.1,::1");
-static_assert(TrDefaultPeerPort == 51413);
-static_assert(TrDefaultPeerLimitTorrent == 50);
-static_assert(TrDefaultPeerLimitGlobal == 200);
-static_assert(TrDefaultRpcPort == 9091);
+static_assert(TrDefaultRpcWhitelist == "127.0.0.1,::1", "update 'allowed' desc");
+static_assert(TrDefaultPeerPort == 51413, "update 'peerport' desc");
+static_assert(TrDefaultPeerLimitTorrent == 50, "update 'peerlimit-torrent' desc");
+static_assert(TrDefaultPeerLimitGlobal == 200, "update 'peerlimit-global' desc");
+static_assert(TrDefaultRpcPort == 9091 && R"(update "port" desc)");
 auto constexpr Options = std::array<tr_option, 48>{ {
     { 'a', "allowed", "Allowed IP addresses. (Default: '127.0.0.1,::1')", "a", Arg::Required, "<list>" },
     { 'b', "blocklist", "Enable peer blocklists", "b", Arg::None, nullptr },

--- a/libtransmission/blocklist.cc
+++ b/libtransmission/blocklist.cc
@@ -565,7 +565,7 @@ size_t Blocklists::update_primary_blocklist(std::string_view external_file, bool
 {
     // These rules will replace the default blocklist.
     // Build the path of the default blocklist .bin file where we'll save these rules.
-    auto const bin_file = tr_pathbuf{ folder_, '/', DEFAULT_BLOCKLIST_FILENAME };
+    auto const bin_file = tr_pathbuf{ folder_, '/', TrDefaultBlocklistFilename };
 
     // Try to save it
     auto added = Blocklist::saveNew(external_file, bin_file, is_enabled);

--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -634,15 +634,14 @@ void handle_request(struct evhttp_request* req, void* arg)
         auto const body = fmt::format(
             "<p>Your request had an invalid session_id header.</p>"
             "<p>To fix this, follow these steps:"
-            "<ol><li> When reading a response, get its {:s} header and remember it"
+            "<ol><li> When reading a response, get its {0:s} header and remember it"
             "<li> Add the updated header to your outgoing requests"
             "<li> When you get this 409 error message, resend your request with the updated header"
             "</ol></p>"
             "<p>This requirement has been added to help prevent "
             "<a href=\"https://en.wikipedia.org/wiki/Cross-site_request_forgery\">CSRF</a> "
             "attacks.</p>"
-            "<p><code>{:s}: {:s}</code></p>",
-            TrRpcSessionIdHeader,
+            "<p><code>{0:s}: {1:s}</code></p>",
             TrRpcSessionIdHeader,
             session_id);
         send_simple_response(req, 409, body.c_str());

--- a/libtransmission/rpc-server.h
+++ b/libtransmission/rpc-server.h
@@ -69,7 +69,7 @@ public:
         std::string salted_password;
         std::string url = std::string{ TrHttpServerDefaultBasePath };
         std::string username;
-        std::string whitelist_str = TR_DEFAULT_RPC_WHITELIST;
+        std::string whitelist_str = std::string{ TrDefaultRpcWhitelist };
         tr_mode_t socket_mode = 0750;
         tr_port port = tr_port::from_host(TrDefaultRpcPort);
 

--- a/libtransmission/rpc-server.h
+++ b/libtransmission/rpc-server.h
@@ -67,7 +67,7 @@ public:
         std::string bind_address_str = "0.0.0.0";
         std::string host_whitelist_str;
         std::string salted_password;
-        std::string url = std::string{ TrHttpServerDefaultBasePath };
+        std::string url = std::string{ TrDefaultHttpServerBasePath };
         std::string username;
         std::string whitelist_str = std::string{ TrDefaultRpcWhitelist };
         tr_mode_t socket_mode = 0750;

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -31,6 +31,20 @@ using tr_tracker_id_t = uint32_t;
 using tr_torrent_id_t = int;
 using tr_mode_t = uint16_t;
 
+inline auto constexpr TrDefaultBlocklistFilename = std::string_view{ "blocklist.bin" };
+inline auto constexpr TrDefaultHttpServerBasePath = std::string_view{ "/transmission/" };
+inline auto constexpr TrDefaultPeerLimitGlobal = 200U;
+inline auto constexpr TrDefaultPeerLimitTorrent = 50U;
+inline auto constexpr TrDefaultPeerPort = 51413U;
+inline auto constexpr TrDefaultPeerSocketTos = std::string_view{ "le" };
+inline auto constexpr TrDefaultRpcPort = 9091U;
+inline auto constexpr TrDefaultRpcWhitelist = std::string_view{ "127.0.0.1,::1" };
+
+inline auto constexpr TrHttpServerRpcRelativePath = std::string_view{ "rpc" };
+inline auto constexpr TrHttpServerWebRelativePath = std::string_view{ "web/" };
+inline auto constexpr TrRpcSessionIdHeader = std::string_view{ "X-Transmission-Session-Id" };
+inline auto constexpr TrRpcVersionHeader = std::string_view{ "X-Transmission-Rpc-Version" };
+
 struct tr_block_span_t
 {
     tr_block_index_t begin;
@@ -49,9 +63,6 @@ struct tr_session;
 struct tr_torrent;
 struct tr_torrent_metainfo;
 struct tr_variant;
-
-inline auto constexpr TrRpcSessionIdHeader = std::string_view{ "X-Transmission-Session-Id" };
-inline auto constexpr TrRpcVersionHeader = std::string_view{ "X-Transmission-Rpc-Version" };
 
 enum tr_verify_added_mode : uint8_t
 {
@@ -123,18 +134,6 @@ size_t tr_getDefaultConfigDirToBuf(char const* appname, char* buf, size_t buflen
 
 /** @brief buffer variant of `tr_getDefaultDownloadDir()`. See `tr_strv_to_buf()`. */
 size_t tr_getDefaultDownloadDirToBuf(char* buf, size_t buflen);
-
-inline auto constexpr TrDefaultBlocklistFilename = std::string_view{ "blocklist.bin" };
-inline auto constexpr TrDefaultHttpServerBasePath = std::string_view{ "/transmission/" };
-inline auto constexpr TrDefaultPeerLimitGlobal = 200U;
-inline auto constexpr TrDefaultPeerLimitTorrent = 50U;
-inline auto constexpr TrDefaultPeerPort = 51413U;
-inline auto constexpr TrDefaultPeerSocketTos = std::string_view{ "le" };
-inline auto constexpr TrDefaultRpcPort = 9091U;
-inline auto constexpr TrDefaultRpcWhitelist = std::string_view{ "127.0.0.1,::1" };
-
-inline auto constexpr TrHttpServerRpcRelativePath = std::string_view{ "rpc" };
-inline auto constexpr TrHttpServerWebRelativePath = std::string_view{ "web/" };
 
 /**
  * Add libtransmission's default settings to the benc dictionary.

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -50,8 +50,8 @@ struct tr_torrent;
 struct tr_torrent_metainfo;
 struct tr_variant;
 
-#define TR_RPC_SESSION_ID_HEADER "X-Transmission-Session-Id"
-#define TR_RPC_RPC_VERSION_HEADER "X-Transmission-Rpc-Version"
+inline auto constexpr TrRpcSessionIdHeader = std::string_view{ "X-Transmission-Session-Id" };
+inline auto constexpr TrRpcVersionHeader = std::string_view{ "X-Transmission-Rpc-Version" };
 
 enum tr_verify_added_mode : uint8_t
 {

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -126,7 +126,6 @@ size_t tr_getDefaultDownloadDirToBuf(char* buf, size_t buflen);
 
 #define TR_DEFAULT_RPC_WHITELIST "127.0.0.1,::1"
 inline auto constexpr TrDefaultRpcPort = 9091U;
-#define TR_DEFAULT_PEER_PORT_STR "51413"
 inline auto constexpr TrDefaultPeerPort = 51413U;
 #define TR_DEFAULT_PEER_SOCKET_TOS_STR "le"
 #define TR_DEFAULT_PEER_LIMIT_GLOBAL_STR "200"

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -124,12 +124,13 @@ size_t tr_getDefaultConfigDirToBuf(char const* appname, char* buf, size_t buflen
 /** @brief buffer variant of `tr_getDefaultDownloadDir()`. See `tr_strv_to_buf()`. */
 size_t tr_getDefaultDownloadDirToBuf(char* buf, size_t buflen);
 
-#define TR_DEFAULT_RPC_WHITELIST "127.0.0.1,::1"
-inline auto constexpr TrDefaultRpcPort = 9091U;
-inline auto constexpr TrDefaultPeerPort = 51413U;
+inline auto constexpr TrDefaultBlocklistFilename = std::string_view{ "blocklist.bin" };
 inline auto constexpr TrDefaultPeerLimitGlobal = 200U;
 inline auto constexpr TrDefaultPeerLimitTorrent = 50U;
+inline auto constexpr TrDefaultPeerPort = 51413U;
 inline auto constexpr TrDefaultPeerSocketTos = std::string_view{ "le" };
+inline auto constexpr TrDefaultRpcPort = 9091U;
+inline auto constexpr TrDefaultRpcWhitelist = std::string_view{ "127.0.0.1,::1" };
 
 inline auto constexpr TrHttpServerDefaultBasePath = std::string_view{ "/transmission/" };
 inline auto constexpr TrHttpServerRpcRelativePath = std::string_view{ "rpc" };
@@ -712,10 +713,6 @@ char const* tr_blocklistGetURL(tr_session const* session);
 /** @brief The blocklist that gets updated when an RPC client
            invokes the "blocklist_update" method */
 void tr_blocklistSetURL(tr_session* session, char const* url);
-
-/** @brief the file in the $config/blocklists/ directory that's
-           used by `tr_blocklistSetContent()` and "blocklist_update" */
-#define DEFAULT_BLOCKLIST_FILENAME "blocklist.bin"
 
 /** @} */
 

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -129,7 +129,6 @@ inline auto constexpr TrDefaultRpcPort = 9091U;
 inline auto constexpr TrDefaultPeerPort = 51413U;
 #define TR_DEFAULT_PEER_SOCKET_TOS_STR "le"
 inline auto constexpr TrDefaultPeerLimitGlobal = 200U;
-#define TR_DEFAULT_PEER_LIMIT_TORRENT_STR "50"
 inline auto constexpr TrDefaultPeerLimitTorrent = 50U;
 
 inline auto constexpr TrHttpServerDefaultBasePath = std::string_view{ "/transmission/" };

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -31,19 +31,19 @@ using tr_tracker_id_t = uint32_t;
 using tr_torrent_id_t = int;
 using tr_mode_t = uint16_t;
 
-inline auto constexpr TrDefaultBlocklistFilename = std::string_view{ "blocklist.bin" };
-inline auto constexpr TrDefaultHttpServerBasePath = std::string_view{ "/transmission/" };
+inline auto constexpr TrDefaultBlocklistFilename = std::string_view{ "blocklist.bin", 13 };
+inline auto constexpr TrDefaultHttpServerBasePath = std::string_view{ "/transmission/", 14 };
 inline auto constexpr TrDefaultPeerLimitGlobal = 200U;
 inline auto constexpr TrDefaultPeerLimitTorrent = 50U;
 inline auto constexpr TrDefaultPeerPort = 51413U;
-inline auto constexpr TrDefaultPeerSocketTos = std::string_view{ "le" };
+inline auto constexpr TrDefaultPeerSocketTos = std::string_view{ "le", 2 };
 inline auto constexpr TrDefaultRpcPort = 9091U;
-inline auto constexpr TrDefaultRpcWhitelist = std::string_view{ "127.0.0.1,::1" };
+inline auto constexpr TrDefaultRpcWhitelist = std::string_view{ "127.0.0.1,::1", 13 };
 
-inline auto constexpr TrHttpServerRpcRelativePath = std::string_view{ "rpc" };
-inline auto constexpr TrHttpServerWebRelativePath = std::string_view{ "web/" };
-inline auto constexpr TrRpcSessionIdHeader = std::string_view{ "X-Transmission-Session-Id" };
-inline auto constexpr TrRpcVersionHeader = std::string_view{ "X-Transmission-Rpc-Version" };
+inline auto constexpr TrHttpServerRpcRelativePath = std::string_view{ "rpc", 3 };
+inline auto constexpr TrHttpServerWebRelativePath = std::string_view{ "web/", 4 };
+inline auto constexpr TrRpcSessionIdHeader = std::string_view{ "X-Transmission-Session-Id", 25 };
+inline auto constexpr TrRpcVersionHeader = std::string_view{ "X-Transmission-Rpc-Version", 26 };
 
 struct tr_block_span_t
 {

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -31,19 +31,19 @@ using tr_tracker_id_t = uint32_t;
 using tr_torrent_id_t = int;
 using tr_mode_t = uint16_t;
 
-inline auto constexpr TrDefaultBlocklistFilename = std::string_view{ "blocklist.bin", 13 };
-inline auto constexpr TrDefaultHttpServerBasePath = std::string_view{ "/transmission/", 14 };
+inline auto constexpr TrDefaultBlocklistFilename = std::string_view{ "blocklist.bin" };
+inline auto constexpr TrDefaultHttpServerBasePath = std::string_view{ "/transmission/" };
 inline auto constexpr TrDefaultPeerLimitGlobal = 200U;
 inline auto constexpr TrDefaultPeerLimitTorrent = 50U;
 inline auto constexpr TrDefaultPeerPort = 51413U;
-inline auto constexpr TrDefaultPeerSocketTos = std::string_view{ "le", 2 };
+inline auto constexpr TrDefaultPeerSocketTos = std::string_view{ "le" };
 inline auto constexpr TrDefaultRpcPort = 9091U;
-inline auto constexpr TrDefaultRpcWhitelist = std::string_view{ "127.0.0.1,::1", 13 };
+inline auto constexpr TrDefaultRpcWhitelist = std::string_view{ "127.0.0.1,::1" };
 
-inline auto constexpr TrHttpServerRpcRelativePath = std::string_view{ "rpc", 3 };
-inline auto constexpr TrHttpServerWebRelativePath = std::string_view{ "web/", 4 };
-inline auto constexpr TrRpcSessionIdHeader = std::string_view{ "X-Transmission-Session-Id", 25 };
-inline auto constexpr TrRpcVersionHeader = std::string_view{ "X-Transmission-Rpc-Version", 26 };
+inline auto constexpr TrHttpServerRpcRelativePath = std::string_view{ "rpc" };
+inline auto constexpr TrHttpServerWebRelativePath = std::string_view{ "web/" };
+inline auto constexpr TrRpcSessionIdHeader = std::string_view{ "X-Transmission-Session-Id" };
+inline auto constexpr TrRpcVersionHeader = std::string_view{ "X-Transmission-Rpc-Version" };
 
 struct tr_block_span_t
 {

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -125,6 +125,7 @@ size_t tr_getDefaultConfigDirToBuf(char const* appname, char* buf, size_t buflen
 size_t tr_getDefaultDownloadDirToBuf(char* buf, size_t buflen);
 
 inline auto constexpr TrDefaultBlocklistFilename = std::string_view{ "blocklist.bin" };
+inline auto constexpr TrDefaultHttpServerBasePath = std::string_view{ "/transmission/" };
 inline auto constexpr TrDefaultPeerLimitGlobal = 200U;
 inline auto constexpr TrDefaultPeerLimitTorrent = 50U;
 inline auto constexpr TrDefaultPeerPort = 51413U;
@@ -132,7 +133,6 @@ inline auto constexpr TrDefaultPeerSocketTos = std::string_view{ "le" };
 inline auto constexpr TrDefaultRpcPort = 9091U;
 inline auto constexpr TrDefaultRpcWhitelist = std::string_view{ "127.0.0.1,::1" };
 
-inline auto constexpr TrHttpServerDefaultBasePath = std::string_view{ "/transmission/" };
 inline auto constexpr TrHttpServerRpcRelativePath = std::string_view{ "rpc" };
 inline auto constexpr TrHttpServerWebRelativePath = std::string_view{ "web/" };
 

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -125,7 +125,6 @@ size_t tr_getDefaultConfigDirToBuf(char const* appname, char* buf, size_t buflen
 size_t tr_getDefaultDownloadDirToBuf(char* buf, size_t buflen);
 
 #define TR_DEFAULT_RPC_WHITELIST "127.0.0.1,::1"
-#define TR_DEFAULT_RPC_PORT_STR "9091"
 inline auto constexpr TrDefaultRpcPort = 9091U;
 #define TR_DEFAULT_PEER_PORT_STR "51413"
 inline auto constexpr TrDefaultPeerPort = 51413U;

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -127,9 +127,9 @@ size_t tr_getDefaultDownloadDirToBuf(char* buf, size_t buflen);
 #define TR_DEFAULT_RPC_WHITELIST "127.0.0.1,::1"
 inline auto constexpr TrDefaultRpcPort = 9091U;
 inline auto constexpr TrDefaultPeerPort = 51413U;
-#define TR_DEFAULT_PEER_SOCKET_TOS_STR "le"
 inline auto constexpr TrDefaultPeerLimitGlobal = 200U;
 inline auto constexpr TrDefaultPeerLimitTorrent = 50U;
+inline auto constexpr TrDefaultPeerSocketTos = std::string_view{ "le" };
 
 inline auto constexpr TrHttpServerDefaultBasePath = std::string_view{ "/transmission/" };
 inline auto constexpr TrHttpServerRpcRelativePath = std::string_view{ "rpc" };

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -128,7 +128,6 @@ size_t tr_getDefaultDownloadDirToBuf(char* buf, size_t buflen);
 inline auto constexpr TrDefaultRpcPort = 9091U;
 inline auto constexpr TrDefaultPeerPort = 51413U;
 #define TR_DEFAULT_PEER_SOCKET_TOS_STR "le"
-#define TR_DEFAULT_PEER_LIMIT_GLOBAL_STR "200"
 inline auto constexpr TrDefaultPeerLimitGlobal = 200U;
 #define TR_DEFAULT_PEER_LIMIT_TORRENT_STR "50"
 inline auto constexpr TrDefaultPeerLimitTorrent = 50U;

--- a/macosx/PrefsController.mm
+++ b/macosx/PrefsController.mm
@@ -138,9 +138,11 @@ static NSString* const kWebUIURLFormat = @"http://localhost:%ld/";
 
             NSURL* blocklistDir = [[NSFileManager.defaultManager URLsForDirectory:NSApplicationDirectory inDomains:NSUserDomainMask][0]
                 URLByAppendingPathComponent:@"Transmission/blocklists/"];
-            [NSFileManager.defaultManager moveItemAtURL:[blocklistDir URLByAppendingPathComponent:@"level1.bin"]
-                                                  toURL:[blocklistDir URLByAppendingPathComponent:@DEFAULT_BLOCKLIST_FILENAME]
-                                                  error:nil];
+            [NSFileManager.defaultManager
+                moveItemAtURL:[blocklistDir URLByAppendingPathComponent:@"level1.bin"]
+                        toURL:[blocklistDir
+                                  URLByAppendingPathComponent:[NSString stringWithUTF8String:TrDefaultBlocklistFilename.data()]]
+                        error:nil];
         }
 
         //save a new random port

--- a/qt/Prefs.cc
+++ b/qt/Prefs.cc
@@ -238,7 +238,7 @@ tr_variant::Map Prefs::defaults()
     map.try_emplace(TR_KEY_remote_session_password, tr_variant::unmanaged_string(""sv));
     map.try_emplace(TR_KEY_remote_session_port, TrDefaultRpcPort);
     map.try_emplace(TR_KEY_remote_session_requires_authentication, false);
-    map.try_emplace(TR_KEY_remote_session_url_base_path, tr_variant::unmanaged_string(TrHttpServerDefaultBasePath));
+    map.try_emplace(TR_KEY_remote_session_url_base_path, tr_variant::unmanaged_string(TrDefaultHttpServerBasePath));
     map.try_emplace(TR_KEY_remote_session_username, tr_variant::unmanaged_string(""sv));
     map.try_emplace(TR_KEY_show_backup_trackers, false);
     map.try_emplace(TR_KEY_show_filterbar, true);

--- a/qt/RpcClient.h
+++ b/qt/RpcClient.h
@@ -86,6 +86,9 @@ private slots:
     void localRequestFinished(TrVariantPtr response);
 
 private:
+    QByteArray const SessionIdHeaderName = std::data(TrRpcSessionIdHeader);
+    QByteArray const VersionHeaderName = std::data(TrRpcVersionHeader);
+
     QNetworkAccessManager* networkAccessManager();
 
     void sendNetworkRequest(QByteArray const& body, QFutureInterface<RpcResponse> const& promise);

--- a/utils/remote.cc
+++ b/utils/remote.cc
@@ -5,7 +5,6 @@
 
 #include <algorithm>
 #include <array>
-#include <cassert>
 #include <cctype> // isspace
 #include <cmath> // floor
 #include <chrono>
@@ -212,11 +211,10 @@ enum
 };
 
 // --- Command-Line Arguments
-//
-auto const peer_port_desc = fmt::format("Port for incoming peers (Default: {:d})", TrDefaultPeerPort);
 
 using Arg = tr_option::Arg;
-auto const options = std::array<tr_option, 106U>{ {
+static_assert(TrDefaultPeerPort == 51413);
+auto constexpr Options = std::array<tr_option, 106>{ {
     { 'a', "add", "Add torrent files by filename or URL", "a", Arg::None, nullptr },
     { 970, "alt-speed", "Use the alternate Limits", "as", Arg::None, nullptr },
     { 971, "no-alt-speed", "Don't use the alternate Limits", "AS", Arg::None, nullptr },
@@ -274,7 +272,7 @@ auto const options = std::array<tr_option, 106U>{ {
     { 820, "ssl", "Use SSL when talking to daemon", nullptr, Arg::None, nullptr },
     { 'o', "dht", "Enable distributed hash tables (DHT)", "o", Arg::None, nullptr },
     { 'O', "no-dht", "Disable distributed hash tables (DHT)", "O", Arg::None, nullptr },
-    { 'p', "port", peer_port_desc.c_str(), "p", Arg::Required, "<port>" },
+    { 'p', "port", "Port for incoming peers (Default: 51413)", "p", Arg::Required, "<port>" },
     { 962, "port-test", "Port testing", "pt", Arg::None, nullptr },
     { 'P', "random-port", "Random port for incoming peers", "P", Arg::None, nullptr },
     { 900, "priority-high", "Try to download these file(s) first", "ph", Arg::Required, "<files>" },
@@ -385,13 +383,14 @@ auto const options = std::array<tr_option, 106U>{ {
     { 941, "peer-info", "List the current torrent(s)' peers", "pi", Arg::None, nullptr },
     { 0, nullptr, nullptr, nullptr, Arg::None, nullptr },
 } };
+static_assert(Options[std::size(Options) - 2].val != 0);
 } // namespace
 
 namespace
 {
 void show_usage()
 {
-    tr_getopt_usage(MyName, Usage, std::data(options));
+    tr_getopt_usage(MyName, Usage, std::data(Options));
 }
 
 [[nodiscard]] auto numarg(std::string_view arg)
@@ -2578,7 +2577,7 @@ int process_args(char const* rpcurl, int argc, char const* const* argv, RemoteCo
 
     for (;;)
     {
-        int const c = tr_getopt(Usage, argc, argv, std::data(options), &optarg);
+        int const c = tr_getopt(Usage, argc, argv, std::data(Options), &optarg);
         if (c == TR_OPT_DONE)
         {
             break;
@@ -3561,8 +3560,6 @@ void get_host_and_port_and_rpc_url(
 
 int tr_main(int argc, char* argv[])
 {
-    assert(options[std::size(options) - 2].val != 0);
-
     tr_lib_init();
 
     tr_locale_set_global("");

--- a/utils/remote.cc
+++ b/utils/remote.cc
@@ -3582,7 +3582,7 @@ int tr_main(int argc, char* argv[])
 
     if (std::empty(rpcurl))
     {
-        rpcurl = fmt::format("{:s}:{:d}{:s}{:s}", host, port, TrHttpServerDefaultBasePath, TrHttpServerRpcRelativePath);
+        rpcurl = fmt::format("{:s}:{:d}{:s}{:s}", host, port, TrDefaultHttpServerBasePath, TrHttpServerRpcRelativePath);
     }
 
     return process_args(rpcurl.c_str(), argc, (char const* const*)argv, config);

--- a/utils/remote.cc
+++ b/utils/remote.cc
@@ -213,7 +213,7 @@ enum
 // --- Command-Line Arguments
 
 using Arg = tr_option::Arg;
-static_assert(TrDefaultPeerPort == 51413);
+static_assert(TrDefaultPeerPort == 51413, "update 'port' desc");
 auto constexpr Options = std::array<tr_option, 106>{ {
     { 'a', "add", "Add torrent files by filename or URL", "a", Arg::None, nullptr },
     { 970, "alt-speed", "Use the alternate Limits", "as", Arg::None, nullptr },

--- a/utils/remote.cc
+++ b/utils/remote.cc
@@ -875,8 +875,8 @@ void warn_if_unsupported_rpc_version(std::string_view const semver)
 [[nodiscard]] size_t parse_response_header(void* ptr, size_t size, size_t nmemb, void* vconfig)
 {
     using namespace header_utils;
-    static auto const session_id_header = tr_strlower(TR_RPC_SESSION_ID_HEADER);
-    static auto const rpc_version_header = tr_strlower(TR_RPC_RPC_VERSION_HEADER);
+    static auto const session_id_header = tr_strlower(TrRpcSessionIdHeader);
+    static auto const rpc_version_header = tr_strlower(TrRpcVersionHeader);
 
     auto& config = *static_cast<RemoteConfig*>(vconfig);
 
@@ -2403,7 +2403,7 @@ CURL* tr_curl_easy_init(std::string* writebuf, RemoteConfig& config)
 
     if (auto const& str = config.session_id; !std::empty(str))
     {
-        auto const h = fmt::format("{:s}: {:s}", TR_RPC_SESSION_ID_HEADER, str);
+        auto const h = fmt::format("{:s}: {:s}", TrRpcSessionIdHeader, str);
         auto* const custom_headers = curl_slist_append(nullptr, h.c_str());
 
         (void)curl_easy_setopt(curl, CURLOPT_HTTPHEADER, custom_headers);

--- a/utils/remote.cc
+++ b/utils/remote.cc
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cassert>
 #include <cctype> // isspace
 #include <cmath> // floor
 #include <chrono>
@@ -211,9 +212,11 @@ enum
 };
 
 // --- Command-Line Arguments
+//
+auto const peer_port_desc = fmt::format("Port for incoming peers (Default: {:d})", TrDefaultPeerPort);
 
 using Arg = tr_option::Arg;
-auto constexpr Options = std::array<tr_option, 106>{ {
+auto const options = std::array<tr_option, 106U>{ {
     { 'a', "add", "Add torrent files by filename or URL", "a", Arg::None, nullptr },
     { 970, "alt-speed", "Use the alternate Limits", "as", Arg::None, nullptr },
     { 971, "no-alt-speed", "Don't use the alternate Limits", "AS", Arg::None, nullptr },
@@ -271,7 +274,7 @@ auto constexpr Options = std::array<tr_option, 106>{ {
     { 820, "ssl", "Use SSL when talking to daemon", nullptr, Arg::None, nullptr },
     { 'o', "dht", "Enable distributed hash tables (DHT)", "o", Arg::None, nullptr },
     { 'O', "no-dht", "Disable distributed hash tables (DHT)", "O", Arg::None, nullptr },
-    { 'p', "port", "Port for incoming peers (Default: " TR_DEFAULT_PEER_PORT_STR ")", "p", Arg::Required, "<port>" },
+    { 'p', "port", peer_port_desc.c_str(), "p", Arg::Required, "<port>" },
     { 962, "port-test", "Port testing", "pt", Arg::None, nullptr },
     { 'P', "random-port", "Random port for incoming peers", "P", Arg::None, nullptr },
     { 900, "priority-high", "Try to download these file(s) first", "ph", Arg::Required, "<files>" },
@@ -382,14 +385,13 @@ auto constexpr Options = std::array<tr_option, 106>{ {
     { 941, "peer-info", "List the current torrent(s)' peers", "pi", Arg::None, nullptr },
     { 0, nullptr, nullptr, nullptr, Arg::None, nullptr },
 } };
-static_assert(Options[std::size(Options) - 2].val != 0);
 } // namespace
 
 namespace
 {
 void show_usage()
 {
-    tr_getopt_usage(MyName, Usage, std::data(Options));
+    tr_getopt_usage(MyName, Usage, std::data(options));
 }
 
 [[nodiscard]] auto numarg(std::string_view arg)
@@ -2576,7 +2578,7 @@ int process_args(char const* rpcurl, int argc, char const* const* argv, RemoteCo
 
     for (;;)
     {
-        int const c = tr_getopt(Usage, argc, argv, std::data(Options), &optarg);
+        int const c = tr_getopt(Usage, argc, argv, std::data(options), &optarg);
         if (c == TR_OPT_DONE)
         {
             break;
@@ -3559,6 +3561,8 @@ void get_host_and_port_and_rpc_url(
 
 int tr_main(int argc, char* argv[])
 {
+    assert(options[std::size(options) - 2].val != 0);
+
     tr_lib_init();
 
     tr_locale_set_global("");


### PR DESCRIPTION
Supersedes https://github.com/transmission/transmission/pull/8087.
Stacks on top of https://github.com/transmission/transmission/pull/8098, which should land first.

This addresses the review feedback @ https://github.com/transmission/transmission/pull/8087#pullrequestreview-3642220754 that keeps the string literals, keeps the `tr_getopt` arrays as `constexpr`, and preserves the previous `static_assert()` calls.

This is accomplished by using hardcoded strings for `tr_getopt` and ensuring they're correct by adding `static_assert()` guards for the hardcoded values. This still has a code smell, but IMO it's less smelly than either (a) the previous non-constexpr approach and (b) the previous status quo of having `#define` macros hardcode this in `transmission.h`