### PR TITLE
fix: rebind udp sockets on bind-address change

### DIFF
--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -855,7 +855,7 @@ void tr_session::setSettings(tr_session::Settings&& settings_in, bool force)
         port_forwarding_->local_port_changed();
     }
 
-    if (!udp_core_ || force || port_changed || utp_changed)
+    if (!udp_core_ || force || addr_changed || port_changed || utp_changed)
     {
         udp_core_ = std::make_unique<tr_session::tr_udp_core>(*this, udpPort());
     }


### PR DESCRIPTION
`4.1.x` cherry-pick of #8096.

Notes: Fixed a bug where the UDP sockets are not rebound after changing the bind addresses.