### PR TITLE
fix: `bufferevent_read` never returns -1

### DIFF
--- a/libtransmission/watchdir-inotify.cc
+++ b/libtransmission/watchdir-inotify.cc
@@ -138,17 +138,6 @@ private:
         auto nread = size_t{};
         while ((nread = bufferevent_read(event, &ev, sizeof(ev))) != 0)
         {
-            if (nread == (size_t)-1)
-            {
-                auto const error_code = errno;
-                tr_logAddError(
-                    fmt::format(
-                        fmt::runtime(_("Couldn't read event: {error} ({error_code})")),
-                        fmt::arg("error", tr_strerror(error_code)),
-                        fmt::arg("error_code", error_code)));
-                break;
-            }
-
             if (nread != sizeof(ev))
             {
                 tr_logAddError(
@@ -166,16 +155,6 @@ private:
             // consume entire name into buffer
             name.resize(ev.len);
             nread = bufferevent_read(event, name.data(), ev.len);
-            if (nread == static_cast<size_t>(-1))
-            {
-                auto const error_code = errno;
-                tr_logAddError(
-                    fmt::format(
-                        fmt::runtime(_("Couldn't read filename: {error} ({error_code})")),
-                        fmt::arg("error", tr_strerror(error_code)),
-                        fmt::arg("error_code", error_code)));
-                break;
-            }
 
             if (nread != ev.len)
             {


### PR DESCRIPTION
Remove some redundant code and fix some `modernize-use-integer-sign-comparison` warnings.