### PR TITLE
perf: faster tests

### DIFF
--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -1281,7 +1281,7 @@ private:
     friend uint16_t tr_sessionGetPeerPort(tr_session const* session);
     friend uint16_t tr_sessionGetRPCPort(tr_session const* session);
     friend uint16_t tr_sessionSetPeerPortRandom(tr_session* session);
-    friend void tr_sessionClose(tr_session* session, size_t timeout_secs);
+    friend void tr_sessionClose(tr_session* session, double timeout_secs);
     friend tr_variant tr_sessionGetSettings(tr_session const* s);
     friend void tr_sessionLimitSpeed(tr_session* session, tr_direction dir, bool limited);
     friend void tr_sessionReloadBlocklists(tr_session* session);

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -234,7 +234,7 @@ void tr_sessionReloadBlocklists(tr_session* session);
  *
  * @param timeout_secs specifies how long to wait on these announces.
  */
-void tr_sessionClose(tr_session* session, size_t timeout_secs = 15);
+void tr_sessionClose(tr_session* session, double timeout_secs = 15.0);
 
 /**
  * @brief Return the session's configuration directory.

--- a/libtransmission/web.h
+++ b/libtransmission/web.h
@@ -102,9 +102,9 @@ public:
 
     [[nodiscard]] bool is_idle() const noexcept;
 
-    // If you want to give running tasks a chance to finish, call closeSoon()
-    // before destroying the tr_web object. Deleting the object will cancel
-    // all of its tasks.
+    // If you want to give running tasks a chance to finish,
+    // call startShutdown() before destroying the tr_web object.
+    // Deleting the object will cancel all of its tasks.
     ~tr_web();
 
     tr_web(tr_web const&) = delete;

--- a/tests/libtransmission/file-test.cc
+++ b/tests/libtransmission/file-test.cc
@@ -48,12 +48,12 @@ using namespace std::literals;
 namespace libtransmission::test
 {
 
-class FileTest : public SessionTest
+class FileTest : public SandboxedTest
 {
 protected:
     auto createTestDir(std::string const& child_name)
     {
-        auto test_dir = tr_pathbuf{ session_->configDir(), '/', child_name };
+        auto test_dir = tr_pathbuf{ sandboxDir(), '/', child_name };
         tr_sys_dir_create(test_dir, 0, 0777);
         return test_dir;
     }

--- a/tests/libtransmission/session-test.cc
+++ b/tests/libtransmission/session-test.cc
@@ -320,7 +320,7 @@ TEST_F(SessionTest, honorsSettings)
     EXPECT_TRUE(tr_sessionUsesAltSpeedTime(session));
     EXPECT_TRUE(tr_sessionIsRPCEnabled(session));
 
-    tr_sessionClose(session);
+    tr_sessionClose(session, 0.5);
 }
 
 TEST_F(SessionTest, savesSettings)

--- a/tests/libtransmission/test-fixtures.h
+++ b/tests/libtransmission/test-fixtures.h
@@ -348,7 +348,8 @@ private:
 
     static void sessionClose(tr_session* session)
     {
-        tr_sessionClose(session, 0.5);
+        static auto constexpr DeadlineSecs = 0.1;
+        tr_sessionClose(session, DeadlineSecs);
         tr_logFreeQueue(tr_logGetQueue());
     }
 

--- a/tests/libtransmission/test-fixtures.h
+++ b/tests/libtransmission/test-fixtures.h
@@ -348,7 +348,7 @@ private:
 
     static void sessionClose(tr_session* session)
     {
-        tr_sessionClose(session);
+        tr_sessionClose(session, 0.5);
         tr_logFreeQueue(tr_logGetQueue());
     }
 


### PR DESCRIPTION
Tests that create a `tr_session` currently take a full second to run. This happens when `tr_session` is created, it queues up a ping to `https://ip4.transmissionbt.com/` and `https://ip6.transmissionbt.com/` to get the public IP address of the box running Transmission. This means the libcurl task is no longer idle. A secondary issue is that the libcurl thread only wakes up once per second. This is good for steady state in production, but it's terrible for tests.

This PR changes the code to make tests faster:

1. Wake up the libcurl thread more often during startup. After a few seconds, throttle back to the old behavior of one wakeup per second.
2. Change the `deadline_secs` argument of `tr_sessionClose()` to be a double instead of an integral. This lets the tests specify <1s for shutdown.
3. Modify the calls to `tr_sessionClose()` in `tests/libtransmission/` to set a deadline of 0.2 seconds.
4. Modify (or, arguably, Fix) `tr_sessionClose()`'s call to use the caller's deadline arg when deciding what deadline value to pass to `tr_web::startShutdown()`.
5. Lastly, a side refactor: `file-test.cc` doesn't need a `tr_session` at all, so use `SandboxedTest` instead of `SessionTest` in that file.


