### PR TITLE
fixup! refactor: use a map of getters, setters for `session_get` and `session_set` properties (#8024)

### DIFF
--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -2612,8 +2612,8 @@ using SessionAccessors = std::pair<SessionGetter, SessionSetter>;
 
         map.try_emplace(
             row.enabled_key,
-            [&](tr_session const& src) -> tr_variant { return src.useScript(script); },
-            [&](tr_session& tgt, tr_variant const& src, ErrorInfo& /*err*/)
+            [script](tr_session const& src) -> tr_variant { return src.useScript(script); },
+            [script](tr_session& tgt, tr_variant const& src, ErrorInfo& /*err*/)
             {
                 if (auto const val = src.value_if<bool>())
                 {
@@ -2623,8 +2623,8 @@ using SessionAccessors = std::pair<SessionGetter, SessionSetter>;
 
         map.try_emplace(
             row.filename_key,
-            [&](tr_session const& src) -> tr_variant { return src.script(script); },
-            [&](tr_session& tgt, tr_variant const& src, ErrorInfo& /*err*/)
+            [script](tr_session const& src) -> tr_variant { return src.script(script); },
+            [script](tr_session& tgt, tr_variant const& src, ErrorInfo& /*err*/)
             {
                 if (auto const val = src.value_if<std::string_view>())
                 {


### PR DESCRIPTION
fix: capture-by-reference error in session_accessors()