### PR TITLE
fix: potential use-after-free of `NSString` in `tr_strv_convert_utf8()`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -677,6 +677,7 @@ else()
         -W
         -Wall
         -Wextra
+        -Warc-unsafe-retained-assign
         -Wcast-align
         -Wduplicated-cond
         -Wextra-semi

--- a/libtransmission/utils.mm
+++ b/libtransmission/utils.mm
@@ -19,11 +19,10 @@ std::string tr_strv_convert_utf8(std::string_view sv)
     @autoreleasepool
     {
         // UTF-8 encoding
-        char const* validUTF8 = [[NSString alloc] initWithBytes:std::data(sv) length:std::size(sv) encoding:NSUTF8StringEncoding]
-                                    .UTF8String;
-        if (validUTF8)
+        NSString* const utf8 = [[NSString alloc] initWithBytes:std::data(sv) length:std::size(sv) encoding:NSUTF8StringEncoding];
+        if (utf8 != nil)
         {
-            return std::string(validUTF8);
+            return std::string{ utf8.UTF8String };
         }
 
         // autodetection of the encoding (#3434)
@@ -39,12 +38,12 @@ std::string tr_strv_convert_utf8(std::string_view sv)
                   }
                   convertedString:&convertedString
               usedLossyConversion:nil];
+
         if (stringEncoding)
         {
-            validUTF8 = convertedString.UTF8String;
-            if (validUTF8)
+            if (convertedString.UTF8String != nullptr)
             {
-                return std::string(validUTF8);
+                return std::string{ convertedString.UTF8String };
             }
         }
 


### PR DESCRIPTION
Fix a potential use-after-free error in `tr_strv_convert_utf8()` on macOS. We used a temporary NSString as a local variable without holding a strong reference to it.

Add `-Warc-unsafe-retained-assign` to the CMake-based builds to smoke out any future issues like this.

This _may_ have been the cause of [this CI failure on macOS](https://productionresultssa9.blob.core.windows.net/actions-results/f7ebca91-85fc-4e65-8d38-07b82b46cd4c/workflow-job-run-de3baf6f-c3d4-5d37-b954-f51685512b6a/logs/job/job-logs.txt?rsct=text%2Fplain&se=2026-01-14T02%3A16%3A51Z&sig=vO8SiTZTX1S88SY6dODpDlJSJhKKvuGM8LLQ0Sem%2BM8%3D&ske=2026-01-14T02%3A45%3A00Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2026-01-14T01%3A45%3A00Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2025-11-05&sp=r&spr=https&sr=b&st=2026-01-14T02%3A06%3A46Z&sv=2025-11-05) but, due to the lack of crash info, it's difficult to be sure.

Notes: Fixed potential use-after-free bug when parsing torrent files on macOS.