### PR TITLE
fix: typo in User-Agent from requests posted by trqt

### DIFF
--- a/qt/RpcClient.cc
+++ b/qt/RpcClient.cc
@@ -118,7 +118,7 @@ void RpcClient::sendNetworkRequest(QByteArray const& body, QFutureInterface<RpcR
     auto req = QNetworkRequest{};
     req.setUrl(url_);
     req.setRawHeader("Content-Type", "application/json; charset=UTF-8");
-    req.setRawHeader("User-Agent", "Transmisson/" SHORT_VERSION_STRING);
+    req.setRawHeader("User-Agent", "Transmission/" SHORT_VERSION_STRING);
     if (!session_id_.isEmpty())
     {
         req.setRawHeader(TR_RPC_SESSION_ID_HEADER, session_id_);


### PR DESCRIPTION
Cherry-pick https://github.com/transmission/transmission/pull/8135 for 4.1.x.

The typo was added in 62c362eacbdc3c9a3f9be0b66a6c9e27cdae3e78 and found by https://github.com/transmission/transmission/pull/8137.

Notes: Fixed 4.1.0-beta.5 typo in User-Agent headers.