### PR TITLE
fix: remove unused `tr_strbuf::join()`

### DIFF
--- a/libtransmission/tr-strbuf.h
+++ b/libtransmission/tr-strbuf.h
@@ -251,26 +251,6 @@ public:
 
     ///
 
-    template<typename... Args>
-    void join(Char delim, Args const&... args)
-    {
-        ((append(args), append(delim)), ...);
-        resize(size() - 1);
-    }
-
-    template<typename ContiguousRange, typename... Args>
-    void join(ContiguousRange const& delim, Args const&... args)
-    {
-        ((append(args), append(delim)), ...);
-        resize(size() - std::size(delim));
-    }
-
-    template<typename... Args>
-    void join(Char const* sz_delim, Args const&... args)
-    {
-        join(std::basic_string_view<Char>{ sz_delim }, args...);
-    }
-
     // NOLINTNEXTLINE(google-explicit-constructor)
     [[nodiscard]] constexpr operator std::basic_string_view<Char>() const noexcept
     {

--- a/tests/libtransmission/strbuf-test.cc
+++ b/tests/libtransmission/strbuf-test.cc
@@ -136,23 +136,6 @@ TEST_F(StrbufTest, iterators)
     }
 }
 
-TEST_F(StrbufTest, join)
-{
-    auto buf = tr_pathbuf{};
-
-    buf.clear();
-    buf.join(' ', 'A', "short", "phrase"sv);
-    EXPECT_EQ("A short phrase"sv, buf.sv());
-
-    buf.clear();
-    buf.join("  ", 'A', "short", "phrase"sv);
-    EXPECT_EQ("A  short  phrase"sv, buf.sv());
-
-    buf.clear();
-    buf.join("--"sv, 'A', "short", "phrase"sv);
-    EXPECT_EQ("A--short--phrase"sv, buf.sv());
-}
-
 TEST_F(StrbufTest, move)
 {
     static auto constexpr Value = "/hello/world"sv;


### PR DESCRIPTION
Cherry-pick #8144 for 4.1.x.