### PR TITLE
fix: crash on invalid command-line value for `--cache` / `-e` arg

### DIFF
--- a/utils/remote.cc
+++ b/utils/remote.cc
@@ -2878,7 +2878,10 @@ int process_args(char const* rpcurl, int argc, char const* const* argv, RemoteCo
                 break;
 
             case 'e':
-                args.insert_or_assign(TR_KEY_cache_size_mib, tr_num_parse<int64_t>(optarg_sv).value());
+                if (auto val = tr_num_parse<int64_t>(optarg_sv))
+                {
+                    args.insert_or_assign(TR_KEY_cache_size_mib, *val);
+                }
                 break;
 
             case 910:

--- a/utils/remote.cc
+++ b/utils/remote.cc
@@ -2882,6 +2882,11 @@ int process_args(char const* rpcurl, int argc, char const* const* argv, RemoteCo
                 {
                     args.insert_or_assign(TR_KEY_cache_size_mib, *val);
                 }
+                else
+                {
+                    fmt::print(stderr, "Argument to '-e'/'--cache' should be an integer");
+                    status |= EXIT_FAILURE;
+                }
                 break;
 
             case 910:


### PR DESCRIPTION
Fixes #8134.
Introduced in #6798 (4.1.0-beta.1).

Notes: Fixed 4.1.0-beta.1 crash when passing an invalid value for numeric command-line args.