### PR TITLE
fix: crash on invalid command-line value for `--cache` / `-e` arg

### DIFF
--- a/utils/remote.cc
+++ b/utils/remote.cc
@@ -2885,6 +2885,11 @@ int process_args(char const* rpcurl, int argc, char const* const* argv, RemoteCo
                 {
                     args.insert_or_assign(TR_KEY_cache_size_mib, *val);
                 }
+                else
+                {
+                    fmt::print(stderr, "Argument to '-e'/'--cache' should be an integer");
+                    status |= EXIT_FAILURE;
+                }
                 break;
 
             case 910:


### PR DESCRIPTION
Fixup #8148.

Notes: Fixed 4.1.0-beta.1 crash when passing an invalid value for numeric command-line args.