### PR TITLE
fix: ignore clang extension usage in ObjC

### DIFF
--- a/macosx/PiecesView.mm
+++ b/macosx/PiecesView.mm
@@ -184,19 +184,16 @@ typedef struct PieceInfo
     if (numCells > 0)
     {
         self.image = [NSImage imageWithSize:self.bounds.size flipped:NO drawingHandler:^BOOL(NSRect /*dstRect*/) {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wvla-cxx-extension"
-            NSRect cFillRects[numCells];
+            NSRect cFillRects[kMaxCells];
             for (int i = 0; i < numCells; ++i)
             {
                 cFillRects[i] = cellBounds[i].rectValue;
             }
-            NSColor* cFillColors[numCells];
+            NSColor* cFillColors[kMaxCells];
             for (int i = 0; i < numCells; ++i)
             {
                 cFillColors[i] = cellColors[i];
             }
-#pragma clang diagnostic pop
             NSRectFillListWithColors(cFillRects, cFillColors, numCells);
             return YES;
         }];

--- a/macosx/PiecesView.mm
+++ b/macosx/PiecesView.mm
@@ -184,6 +184,8 @@ typedef struct PieceInfo
     if (numCells > 0)
     {
         self.image = [NSImage imageWithSize:self.bounds.size flipped:NO drawingHandler:^BOOL(NSRect /*dstRect*/) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wvla-cxx-extension"
             NSRect cFillRects[numCells];
             for (int i = 0; i < numCells; ++i)
             {
@@ -194,6 +196,7 @@ typedef struct PieceInfo
             {
                 cFillColors[i] = cellColors[i];
             }
+#pragma clang diagnostic pop
             NSRectFillListWithColors(cFillRects, cFillColors, numCells);
             return YES;
         }];


### PR DESCRIPTION
This removes a warning for using a clang extension when writing `NSRect cFillRects[numCells];`.

Notes: address minor clang warning