### PR TITLE
fix: incorrectly set error when moving across filesystems

### DIFF
--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -616,14 +616,21 @@ bool tr_file_move(std::string_view oldpath_in, std::string_view newpath_in, bool
         return false;
     }
 
-    /* they might be on the same filesystem... */
-    if (tr_sys_path_rename(oldpath, newpath, error))
+    if (allow_copy)
     {
-        return true;
+        // they might be on the same filesystem...
+        if (tr_sys_path_rename(oldpath, newpath))
+        {
+            return true;
+        }
     }
-
-    if (!allow_copy)
+    else
     {
+        // do the actual moving
+        if (tr_sys_path_rename(oldpath, newpath, error))
+        {
+            return true;
+        }
         error->prefix_message("Unable to move file: ");
         return false;
     }


### PR DESCRIPTION
Cherry-pick #8167.

Notes: Fixed `4.1.0-beta.1` bug where torrents are incorrectly paused when moving files to a different filesystem from the original directory.