### PR TITLE
ci: bump to `peter-evans/create-pull-request@v8`

### DIFF
--- a/.github/workflows/webapp.yml
+++ b/.github/workflows/webapp.yml
@@ -144,7 +144,7 @@ jobs:
           git diff --name-only
           git add --update web
       - name: Create pull request
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8
         with:
           branch: 'chore/update-webapp-files'
           commit-message: 'chore: update generated transmission-web files'


### PR DESCRIPTION
Missed from #8141, and it's causing CI failures like https://github.com/transmission/transmission/actions/runs/21189582414/job/60952842306.

```
  /usr/bin/git symbolic-ref HEAD --short
  main
  Working base is branch 'main'
  /usr/bin/git remote prune origin
  remote: Duplicate header: "Authorization"
  fatal: unable to access 'https://github.com/transmission/transmission/': The requested URL returned error: 400
  Error: The process '/usr/bin/git' failed with exit code 128
```

Ref: https://github.com/peter-evans/create-pull-request/issues/4272