### PR TITLE
refactor: fix trivial modernize-use-ranges warnings

### DIFF
--- a/gtk/Application.cc
+++ b/gtk/Application.cc
@@ -73,6 +73,7 @@
 #include <iterator> // std::back_inserter
 #include <map>
 #include <memory>
+#include <ranges>
 #include <sstream>
 #include <string>
 #include <thread>
@@ -251,7 +252,7 @@ void gtr_window_present(T const& window)
 std::string get_details_dialog_key(std::vector<tr_torrent_id_t> const& id_list)
 {
     auto tmp = id_list;
-    std::sort(tmp.begin(), tmp.end());
+    std::ranges::sort(tmp);
 
     std::ostringstream gstr;
 

--- a/gtk/DetailsDialog.cc
+++ b/gtk/DetailsDialog.cc
@@ -59,6 +59,7 @@
 #include <limits>
 #include <memory>
 #include <numeric>
+#include <ranges>
 #include <sstream>
 #include <string>
 #include <string_view>
@@ -280,9 +281,8 @@ void DetailsDialog::Impl::refreshOptions(std::vector<tr_torrent*> const& torrent
     if (!torrents.empty())
     {
         bool const baseline = tr_torrentUsesSessionLimits(torrents.front());
-        bool const is_uniform = std::all_of(
-            torrents.begin(),
-            torrents.end(),
+        bool const is_uniform = std::ranges::all_of(
+            torrents,
             [baseline](auto const* torrent) { return baseline == tr_torrentUsesSessionLimits(torrent); });
 
         if (is_uniform)
@@ -295,9 +295,8 @@ void DetailsDialog::Impl::refreshOptions(std::vector<tr_torrent*> const& torrent
     if (!torrents.empty())
     {
         auto const baseline = tr_torrentUsesSpeedLimit(torrents.front(), tr_direction::Down);
-        auto const is_uniform = std::all_of(
-            torrents.begin(),
-            torrents.end(),
+        auto const is_uniform = std::ranges::all_of(
+            torrents,
             [baseline](auto const* torrent) { return baseline == tr_torrentUsesSpeedLimit(torrent, tr_direction::Down); });
 
         if (is_uniform)
@@ -310,9 +309,8 @@ void DetailsDialog::Impl::refreshOptions(std::vector<tr_torrent*> const& torrent
     if (!torrents.empty())
     {
         auto const baseline = tr_torrentGetSpeedLimit_KBps(torrents.front(), tr_direction::Down);
-        auto const is_uniform = std::all_of(
-            torrents.begin(),
-            torrents.end(),
+        auto const is_uniform = std::ranges::all_of(
+            torrents,
             [baseline](auto const* torrent) { return baseline == tr_torrentGetSpeedLimit_KBps(torrent, tr_direction::Down); });
 
         if (is_uniform)
@@ -325,9 +323,8 @@ void DetailsDialog::Impl::refreshOptions(std::vector<tr_torrent*> const& torrent
     if (!torrents.empty())
     {
         auto const baseline = tr_torrentUsesSpeedLimit(torrents.front(), tr_direction::Up);
-        auto const is_uniform = std::all_of(
-            torrents.begin(),
-            torrents.end(),
+        auto const is_uniform = std::ranges::all_of(
+            torrents,
             [baseline](auto const* torrent) { return baseline == tr_torrentUsesSpeedLimit(torrent, tr_direction::Up); });
 
         if (is_uniform)
@@ -340,9 +337,8 @@ void DetailsDialog::Impl::refreshOptions(std::vector<tr_torrent*> const& torrent
     if (!torrents.empty())
     {
         auto const baseline = tr_torrentGetSpeedLimit_KBps(torrents.front(), tr_direction::Up);
-        auto const is_uniform = std::all_of(
-            torrents.begin(),
-            torrents.end(),
+        auto const is_uniform = std::ranges::all_of(
+            torrents,
             [baseline](auto const* torrent) { return baseline == tr_torrentGetSpeedLimit_KBps(torrent, tr_direction::Up); });
 
         if (is_uniform)
@@ -355,9 +351,8 @@ void DetailsDialog::Impl::refreshOptions(std::vector<tr_torrent*> const& torrent
     if (!torrents.empty())
     {
         auto const baseline = tr_torrentGetPriority(torrents.front());
-        bool const is_uniform = std::all_of(
-            torrents.begin(),
-            torrents.end(),
+        bool const is_uniform = std::ranges::all_of(
+            torrents,
             [baseline](auto const* torrent) { return baseline == tr_torrentGetPriority(torrent); });
 
         if (is_uniform)
@@ -376,9 +371,8 @@ void DetailsDialog::Impl::refreshOptions(std::vector<tr_torrent*> const& torrent
     if (!torrents.empty())
     {
         auto const baseline = tr_torrentGetRatioMode(torrents.front());
-        bool const is_uniform = std::all_of(
-            torrents.begin(),
-            torrents.end(),
+        bool const is_uniform = std::ranges::all_of(
+            torrents,
             [baseline](auto const* torrent) { return baseline == tr_torrentGetRatioMode(torrent); });
 
         if (is_uniform)
@@ -401,9 +395,8 @@ void DetailsDialog::Impl::refreshOptions(std::vector<tr_torrent*> const& torrent
     if (!torrents.empty())
     {
         auto const baseline = tr_torrentGetIdleMode(torrents.front());
-        bool const is_uniform = std::all_of(
-            torrents.begin(),
-            torrents.end(),
+        bool const is_uniform = std::ranges::all_of(
+            torrents,
             [baseline](auto const* torrent) { return baseline == tr_torrentGetIdleMode(torrent); });
 
         if (is_uniform)
@@ -588,9 +581,8 @@ void DetailsDialog::Impl::refreshInfo(std::vector<tr_torrent*> const& torrents)
     else
     {
         bool const baseline = infos.front().is_private;
-        bool const is_uniform = std::all_of(
-            infos.begin(),
-            infos.end(),
+        bool const is_uniform = std::ranges::all_of(
+            infos,
             [baseline](auto const& info) { return info.is_private == baseline; });
 
         if (is_uniform)
@@ -613,9 +605,8 @@ void DetailsDialog::Impl::refreshInfo(std::vector<tr_torrent*> const& torrents)
     else
     {
         auto const baseline = stats.front()->addedDate;
-        bool const is_uniform = std::all_of(
-            stats.begin(),
-            stats.end(),
+        bool const is_uniform = std::ranges::all_of(
+            stats,
             [baseline](auto const* stat) { return stat->addedDate == baseline; });
 
         if (is_uniform)
@@ -640,14 +631,10 @@ void DetailsDialog::Impl::refreshInfo(std::vector<tr_torrent*> const& torrents)
         auto const creator = tr_strv_strip(infos.front().creator != nullptr ? infos.front().creator : "");
         auto const date = infos.front().date_created;
         auto const datestr = get_date_string(date);
-        bool const mixed_creator = std::any_of(
-            infos.begin(),
-            infos.end(),
+        bool const mixed_creator = std::ranges::any_of(
+            infos,
             [&creator](auto const& info) { return creator != (info.creator != nullptr ? info.creator : ""); });
-        bool const mixed_date = std::any_of(
-            infos.begin(),
-            infos.end(),
-            [date](auto const& info) { return date != info.date_created; });
+        bool const mixed_date = std::ranges::any_of(infos, [date](auto const& info) { return date != info.date_created; });
 
         bool const empty_creator = std::empty(creator);
         bool const empty_date = date == 0;
@@ -687,9 +674,8 @@ void DetailsDialog::Impl::refreshInfo(std::vector<tr_torrent*> const& torrents)
     else
     {
         auto const baseline = Glib::ustring(infos.front().comment != nullptr ? infos.front().comment : "");
-        bool const is_uniform = std::all_of(
-            infos.begin(),
-            infos.end(),
+        bool const is_uniform = std::ranges::all_of(
+            infos,
             [&baseline](auto const& info) { return baseline == (info.comment != nullptr ? info.comment : ""); });
 
         str = is_uniform ? baseline : mixed;
@@ -705,9 +691,8 @@ void DetailsDialog::Impl::refreshInfo(std::vector<tr_torrent*> const& torrents)
     else
     {
         std::string_view const baseline = tr_torrentGetDownloadDir(torrents.front());
-        bool const is_uniform = std::all_of(
-            torrents.begin(),
-            torrents.end(),
+        bool const is_uniform = std::ranges::all_of(
+            torrents,
             [&baseline](auto const* torrent) { return baseline == tr_torrentGetDownloadDir(torrent); });
 
         str = is_uniform ? Glib::ustring{ baseline.data(), baseline.size() } : mixed;
@@ -723,11 +708,8 @@ void DetailsDialog::Impl::refreshInfo(std::vector<tr_torrent*> const& torrents)
     else
     {
         auto const activity = stats.front()->activity;
-        bool const is_uniform = std::all_of(
-            stats.begin(),
-            stats.end(),
-            [activity](auto const* st) { return activity == st->activity; });
-        bool const allFinished = std::all_of(stats.begin(), stats.end(), [](auto const* st) { return st->finished; });
+        bool const is_uniform = std::ranges::all_of(stats, [activity](auto const* st) { return activity == st->activity; });
+        bool const allFinished = std::ranges::all_of(stats, [](auto const* st) { return st->finished; });
 
         str = is_uniform ? activityString(activity, allFinished) : mixed;
     }
@@ -743,10 +725,7 @@ void DetailsDialog::Impl::refreshInfo(std::vector<tr_torrent*> const& torrents)
     else
     {
         time_t const baseline = stats.front()->startDate;
-        bool const is_uniform = std::all_of(
-            stats.begin(),
-            stats.end(),
-            [baseline](auto const* st) { return baseline == st->startDate; });
+        bool const is_uniform = std::ranges::all_of(stats, [baseline](auto const* st) { return baseline == st->startDate; });
 
         if (!is_uniform)
         {
@@ -772,10 +751,7 @@ void DetailsDialog::Impl::refreshInfo(std::vector<tr_torrent*> const& torrents)
     else
     {
         auto const baseline = stats.front()->eta;
-        auto const is_uniform = std::all_of(
-            stats.begin(),
-            stats.end(),
-            [baseline](auto const* st) { return baseline == st->eta; });
+        auto const is_uniform = std::ranges::all_of(stats, [baseline](auto const* st) { return baseline == st->eta; });
 
         if (!is_uniform)
         {
@@ -826,9 +802,8 @@ void DetailsDialog::Impl::refreshInfo(std::vector<tr_torrent*> const& torrents)
                 fmt::arg("file_count", file_count));
 
             auto const piece_size = std::empty(infos) ? uint32_t{} : infos.front().piece_size;
-            auto const piece_size_is_uniform = std::all_of(
-                std::begin(infos),
-                std::end(infos),
+            auto const piece_size_is_uniform = std::ranges::all_of(
+                infos,
                 [piece_size](auto const& info) { return info.piece_size == piece_size; });
 
             if (piece_size_is_uniform)
@@ -993,10 +968,7 @@ void DetailsDialog::Impl::refreshInfo(std::vector<tr_torrent*> const& torrents)
     else
     {
         auto const baseline = Glib::ustring(stats.front()->errorString);
-        bool const is_uniform = std::all_of(
-            stats.begin(),
-            stats.end(),
-            [&baseline](auto const* st) { return baseline == st->errorString; });
+        bool const is_uniform = std::ranges::all_of(stats, [&baseline](auto const* st) { return baseline == st->errorString; });
 
         str = is_uniform ? baseline : mixed;
     }
@@ -1015,9 +987,8 @@ void DetailsDialog::Impl::refreshInfo(std::vector<tr_torrent*> const& torrents)
     }
     else
     {
-        time_t const latest = (*std::max_element(
-                                   stats.begin(),
-                                   stats.end(),
+        time_t const latest = (*std::ranges::max_element(
+                                   stats,
                                    [](auto const* lhs, auto const* rhs) { return lhs->activityDate < rhs->activityDate; }))
                                   ->activityDate;
 

--- a/gtk/FileList.cc
+++ b/gtk/FileList.cc
@@ -38,6 +38,7 @@
 #include <memory>
 #include <optional>
 #include <queue>
+#include <ranges>
 #include <stack>
 #include <string>
 #include <string_view>
@@ -669,7 +670,7 @@ std::string build_filename(tr_torrent const* tor, Gtk::TreeModel::iterator const
     }
 
     tokens.emplace_back(tr_torrentGetCurrentDir(tor));
-    std::reverse(tokens.begin(), tokens.end());
+    std::ranges::reverse(tokens);
     return Glib::build_filename(tokens);
 }
 

--- a/gtk/FilterBar.cc
+++ b/gtk/FilterBar.cc
@@ -44,6 +44,7 @@
 #include <array>
 #include <map>
 #include <memory>
+#include <ranges>
 #include <string>
 #include <unordered_map>
 
@@ -243,7 +244,7 @@ bool FilterBar::Impl::tracker_filter_model_update()
 
     auto const n_sites = std::size(site_infos);
     auto sites_v = std::vector<site_info>(n_sites);
-    std::transform(std::begin(site_infos), std::end(site_infos), std::begin(sites_v), [](auto const& it) { return it.second; });
+    std::ranges::transform(site_infos, std::begin(sites_v), [](auto const& it) { return it.second; });
     std::sort(std::begin(sites_v), std::end(sites_v));
 
     // update the "all" count

--- a/gtk/MessageLogWindow.cc
+++ b/gtk/MessageLogWindow.cc
@@ -36,10 +36,12 @@
 #include <fmt/format.h>
 #include <fmt/ostream.h>
 
+#include <algorithm>
 #include <array>
 #include <chrono>
 #include <fstream>
 #include <memory>
+#include <ranges>
 #include <utility>
 
 class MessageLogColumnsModel : public Gtk::TreeModelColumnRecord
@@ -227,11 +229,10 @@ void MessageLogWindow::Impl::doSave(std::string const& filename)
             auto const* const node = row.get_value(message_log_cols.tr_msg);
             auto const date = gtr_asctime(node->when);
 
-            auto const iter = std::find_if(
-                std::begin(level_names_),
-                std::end(level_names_),
+            auto const iter = std::ranges::find_if(
+                level_names_,
                 [key = node->level](auto const& item) { return item.first == key; });
-            auto const* const level_str = iter != std::end(level_names_) ? iter->second : "???";
+            auto const* const level_str = iter != std::ranges::end(level_names_) ? iter->second : "???";
 
             fmt::print(stream, "{}\t{}\t{}\t{}\n", date, level_str, node->name, node->message);
         }

--- a/gtk/Session.cc
+++ b/gtk/Session.cc
@@ -52,6 +52,7 @@
 #include <map>
 #include <memory>
 #include <optional>
+#include <ranges>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -360,7 +361,7 @@ bool Session::Impl::watchdir_idle()
 
         adding_from_watch_dir_ = true;
         add_files(unchanging, do_start, do_prompt, true);
-        std::for_each(unchanging.begin(), unchanging.end(), rename_torrent);
+        std::ranges::for_each(unchanging, rename_torrent);
         adding_from_watch_dir_ = false;
     }
 
@@ -386,10 +387,7 @@ void Session::Impl::watchdir_monitor_file(Glib::RefPtr<Gio::File> const& file)
     if (is_torrent)
     {
         /* if we're not already watching this file, start watching it now */
-        bool const found = std::any_of(
-            monitor_files_.begin(),
-            monitor_files_.end(),
-            [file](auto const& f) { return file->equal(f); });
+        bool const found = std::ranges::any_of(monitor_files_, [file](auto const& f) { return file->equal(f); });
 
         if (!found)
         {
@@ -988,8 +986,8 @@ void Session::load(bool force_paused)
 
     auto torrents = std::vector<Glib::RefPtr<Torrent>>();
     torrents.reserve(raw_torrents.size());
-    std::transform(raw_torrents.begin(), raw_torrents.end(), std::back_inserter(torrents), &Torrent::create);
-    std::sort(torrents.begin(), torrents.end(), &Torrent::less_by_id);
+    std::ranges::transform(raw_torrents, std::back_inserter(torrents), &Torrent::create);
+    std::ranges::sort(torrents, &Torrent::less_by_id);
 
     auto const model = impl_->get_raw_model();
     model->splice(0, model->get_n_items(), torrents);

--- a/gtk/TorrentFilter.cc
+++ b/gtk/TorrentFilter.cc
@@ -11,7 +11,9 @@
 #include <libtransmission/transmission.h>
 #include <libtransmission/tr-macros.h>
 
+#include <algorithm>
 #include <array>
+#include <ranges>
 #include <utility>
 
 TorrentFilter::TorrentFilter()
@@ -142,11 +144,8 @@ void TorrentFilter::update(Torrent::ChangeFlags changes)
             { ShowMode::ShowVerifying, Flag::ACTIVITY },
         } };
 
-        auto const iter = std::find_if(
-            std::begin(ShowModeFlags),
-            std::end(ShowModeFlags),
-            [key = show_mode_](auto const& row) { return row.first == key; });
-        refilter_needed = iter != std::end(ShowModeFlags) && changes.test(iter->second);
+        auto const iter = std::ranges::find_if(ShowModeFlags, [key = show_mode_](auto const& row) { return row.first == key; });
+        refilter_needed = iter != std::ranges::end(ShowModeFlags) && changes.test(iter->second);
     }
 
     if (!refilter_needed)

--- a/gtk/TorrentSorter.cc
+++ b/gtk/TorrentSorter.cc
@@ -19,6 +19,7 @@
 
 #include <algorithm>
 #include <array>
+#include <ranges>
 #include <utility>
 
 using namespace std::string_view_literals;
@@ -248,11 +249,10 @@ void TorrentSorter::update(Torrent::ChangeFlags changes)
         { &compare_by_state, Flag::ACTIVITY | Flag::QUEUE_POSITION },
     } };
 
-    if (auto const iter = std::find_if(
-            std::begin(CompareFlags),
-            std::end(CompareFlags),
+    if (auto const iter = std::ranges::find_if(
+            CompareFlags,
             [key = compare_func_](auto const& row) { return row.first == key; });
-        iter != std::end(CompareFlags) && changes.test(iter->second))
+        iter != std::ranges::end(CompareFlags) && changes.test(iter->second))
     {
         changed(Change::DIFFERENT);
     }

--- a/libtransmission/announce-list.cc
+++ b/libtransmission/announce-list.cc
@@ -4,6 +4,7 @@
 // License text can be found in the licenses/ folder.
 
 #include <algorithm>
+#include <ranges>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -175,7 +176,7 @@ tr_announce_list::trackers_t::iterator tr_announce_list::find(tr_tracker_id_t id
     {
         return tracker.id == id;
     };
-    return std::find_if(std::begin(trackers_), std::end(trackers_), test);
+    return std::ranges::find_if(trackers_, test);
 }
 
 tr_announce_list::trackers_t::iterator tr_announce_list::find(std::string_view announce)
@@ -184,7 +185,7 @@ tr_announce_list::trackers_t::iterator tr_announce_list::find(std::string_view a
     {
         return announce == tracker.announce.sv();
     };
-    return std::find_if(std::begin(trackers_), std::end(trackers_), test);
+    return std::ranges::find_if(trackers_, test);
 }
 
 // if two announce URLs differ only by scheme, put them in the same tier.
@@ -206,8 +207,8 @@ tr_tracker_tier_t tr_announce_list::get_tier(tr_tracker_tier_t tier, tr_url_pars
         return candidate->host == announce.host && candidate->path == announce.path;
     };
 
-    auto const it = std::find_if(std::begin(trackers_), std::end(trackers_), is_sibling);
-    return it != std::end(trackers_) ? it->tier : tier;
+    auto const it = std::ranges::find_if(trackers_, is_sibling);
+    return it != std::ranges::end(trackers_) ? it->tier : tier;
 }
 
 bool tr_announce_list::can_add(tr_url_parsed_t const& announce) const noexcept
@@ -230,7 +231,7 @@ bool tr_announce_list::can_add(tr_url_parsed_t const& announce) const noexcept
             tracker_parsed->port == announce.port && tracker_parsed->path == announce.path &&
             tracker_parsed->query == announce.query;
     };
-    return std::none_of(std::begin(trackers_), std::end(trackers_), is_same);
+    return std::ranges::none_of(trackers_, is_same);
 }
 
 tr_variant tr_announce_list::to_tiers_variant() const

--- a/libtransmission/announcer-http.cc
+++ b/libtransmission/announcer-http.cc
@@ -12,6 +12,7 @@
 #include <iostream>
 #include <iterator>
 #include <optional>
+#include <ranges>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -595,16 +596,15 @@ void tr_announcerParseHttpScrapeResponse(tr_scrape_response& response, std::stri
             {
                 row_.reset();
             }
-            else if (auto const it = std::find_if(
-                         std::begin(response_.rows),
-                         std::end(response_.rows),
+            else if (auto const it = std::ranges::find_if(
+                         response_.rows,
                          [value](auto const& row)
                          {
                              auto const row_hash = std::string_view{ reinterpret_cast<char const*>(std::data(row.info_hash)),
                                                                      std::size(row.info_hash) };
                              return row_hash == value;
                          });
-                     it == std::end(response_.rows))
+                     it == std::ranges::end(response_.rows))
             {
                 row_.reset();
             }

--- a/libtransmission/announcer-udp.cc
+++ b/libtransmission/announcer-udp.cc
@@ -14,6 +14,7 @@
 #include <list>
 #include <memory>
 #include <optional>
+#include <ranges>
 #include <string>
 #include <string_view>
 #include <type_traits>
@@ -519,7 +520,7 @@ private:
 
     [[nodiscard]] constexpr bool has_addr() const noexcept
     {
-        return std::any_of(std::begin(addr_), std::end(addr_), [](auto const& o) { return !!o; });
+        return std::ranges::any_of(addr_, [](auto const& o) { return !!o; });
     }
 
     [[nodiscard]] MaybeSockaddr lookup(tr_address_type ip_protocol)
@@ -794,11 +795,10 @@ public:
             // is it a response to one of this tracker's announces?
             if (auto& reqs = tracker.announces; !std::empty(reqs))
             {
-                if (auto it = std::find_if(
-                        std::begin(reqs),
-                        std::end(reqs),
+                if (auto it = std::ranges::find_if(
+                        reqs,
                         [&transaction_id](auto const& req) { return req.transaction_id == transaction_id; });
-                    it != std::end(reqs))
+                    it != std::ranges::end(reqs))
                 {
                     logtrace(tracker.log_name(), fmt::format("{} is an announce request!", transaction_id));
                     it->on_response(ip_protocol, action_id, buf);
@@ -810,11 +810,10 @@ public:
             // is it a response to one of this tracker's scrapes?
             if (auto& reqs = tracker.scrapes; !std::empty(reqs))
             {
-                if (auto it = std::find_if(
-                        std::begin(reqs),
-                        std::end(reqs),
+                if (auto it = std::ranges::find_if(
+                        reqs,
                         [&transaction_id](auto const& req) { return req.transaction_id == transaction_id; });
-                    it != std::end(reqs))
+                    it != std::ranges::end(reqs))
                 {
                     logtrace(tracker.log_name(), fmt::format("{} is a scrape request!", transaction_id));
                     it->on_response(action_id, buf);
@@ -830,7 +829,7 @@ public:
 
     [[nodiscard]] bool is_idle() const noexcept override
     {
-        return std::all_of(std::begin(trackers_), std::end(trackers_), [](auto const& tracker) { return tracker.is_idle(); });
+        return std::ranges::all_of(trackers_, [](auto const& tracker) { return tracker.is_idle(); });
     }
 
 private:

--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -15,6 +15,7 @@
 #include <memory>
 #include <numeric>
 #include <optional>
+#include <ranges>
 #include <set>
 #include <string>
 #include <string_view>
@@ -611,7 +612,7 @@ struct tr_torrent_announcer
 
     [[nodiscard]] bool canManualAnnounce() const
     {
-        return std::any_of(std::begin(tiers), std::end(tiers), [](auto const& tier) { return tier.canManualAnnounce(); });
+        return std::ranges::any_of(tiers, [](auto const& tier) { return tier.canManualAnnounce(); });
     }
 
     [[nodiscard]] bool findTracker(
@@ -829,8 +830,7 @@ void tier_announce_event_push(tr_tier* tier, tr_announce_event e, time_t announc
          * dump everything leading up to it except "completed" */
         if (e == TR_ANNOUNCE_EVENT_STOPPED)
         {
-            auto const has_completed = std::find(std::begin(events), std::end(events), TR_ANNOUNCE_EVENT_COMPLETED) !=
-                std::end(events);
+            auto const has_completed = std::ranges::find(events, TR_ANNOUNCE_EVENT_COMPLETED) != std::ranges::end(events);
             events.clear();
             if (has_completed)
             {
@@ -868,7 +868,7 @@ bool isUnregistered(char const* errmsg)
 
     auto constexpr Keys = std::array<std::string_view, 2>{ "unregistered torrent"sv, "torrent not registered"sv };
 
-    return std::any_of(std::begin(Keys), std::end(Keys), [&lower](auto const& key) { return tr_strv_contains(lower, key); });
+    return std::ranges::any_of(Keys, [&lower](auto const& key) { return tr_strv_contains(lower, key); });
 }
 
 void on_announce_error(tr_tier* tier, char const* err, tr_announce_event e, time_t interval = {})
@@ -1244,10 +1244,7 @@ namespace on_scrape_done_helpers
         "Request-URI Too Long",
     };
 
-    return std::any_of(
-        std::begin(too_long_errors),
-        std::end(too_long_errors),
-        [&errmsg](auto const& substr) { return tr_strv_contains(errmsg, substr); });
+    return std::ranges::any_of(too_long_errors, [&errmsg](auto const& substr) { return tr_strv_contains(errmsg, substr); });
 }
 
 void on_scrape_error(tr_session const* /*session*/, tr_tier* tier, char const* errmsg)

--- a/libtransmission/api-compat.cc
+++ b/libtransmission/api-compat.cc
@@ -8,6 +8,7 @@
 #include <cstddef>
 #include <deque>
 #include <initializer_list>
+#include <ranges>
 #include <string_view>
 #include <vector>
 
@@ -778,12 +779,11 @@ void convert_files_wanted_response(tr_variant::Map& top, State const& state)
             if (auto* const first_vec = torrents->front().get_if<tr_variant::Vector>();
                 first_vec != nullptr && !std::empty(*first_vec))
             {
-                if (auto const wanted_iter = std::find_if(
-                        std::begin(*first_vec),
-                        std::end(*first_vec),
+                if (auto const wanted_iter = std::ranges::find_if(
+                        *first_vec,
                         [](tr_variant const& v)
                         { return v.value_if<std::string_view>() == tr_quark_get_string_view(TR_KEY_wanted); });
-                    wanted_iter != std::end(*first_vec))
+                    wanted_iter != std::ranges::end(*first_vec))
                 {
                     auto const wanted_idx = static_cast<size_t>(wanted_iter - std::begin(*first_vec));
                     for (auto it = std::next(std::begin(*torrents)); it != std::end(*torrents); ++it)

--- a/libtransmission/bandwidth.cc
+++ b/libtransmission/bandwidth.cc
@@ -10,6 +10,7 @@
 #include <initializer_list>
 #include <limits>
 #include <memory>
+#include <ranges>
 #include <utility> // for std::swap()
 #include <vector>
 
@@ -100,7 +101,7 @@ void remove_child(std::vector<tr_bandwidth*>& v, tr_bandwidth* remove_me) noexce
 {
     // the list isn't sorted -- so instead of erase()ing `it`,
     // do the cheaper option of overwriting it with the final item
-    if (auto it = std::find(std::begin(v), std::end(v), remove_me); it != std::end(v))
+    if (auto it = std::ranges::find(v, remove_me); it != std::ranges::end(v))
     {
         std::swap(*it, v.back());
         v.pop_back();
@@ -133,7 +134,7 @@ void tr_bandwidth::set_parent(tr_bandwidth* new_parent)
 #ifdef TR_ENABLE_ASSERTS
         TR_ASSERT(new_parent->parent_ != this);
         auto& children = new_parent->children_;
-        TR_ASSERT(std::find(std::begin(children), std::end(children), this) == std::end(children)); // not already there
+        TR_ASSERT(std::ranges::find(children, this) == std::ranges::end(children)); // not already there
 #endif
 
         new_parent->children_.push_back(this);

--- a/libtransmission/blocklist.cc
+++ b/libtransmission/blocklist.cc
@@ -11,6 +11,7 @@
 #include <initializer_list>
 #include <ios>
 #include <optional>
+#include <ranges>
 #include <string> // std::getline()
 #include <string_view>
 #include <utility> // for std::move, std::pair
@@ -286,7 +287,7 @@ auto parseFile(std::string_view filename)
     }
 
     // sort ranges by start address
-    std::sort(std::begin(ranges), std::end(ranges), [](auto const& a, auto const& b) { return a.first < b.first; });
+    std::ranges::sort(ranges, [](auto const& a, auto const& b) { return a.first < b.first; });
 
     // merge overlapping ranges
     auto keep = size_t{ 0U };
@@ -577,11 +578,10 @@ size_t Blocklists::update_primary_blocklist(std::string_view const external_file
     auto const n_rules = std::size(*added);
 
     // Add (or replace) it in our blocklists_ vector
-    if (auto iter = std::find_if(
-            std::begin(blocklists_),
-            std::end(blocklists_),
+    if (auto iter = std::ranges::find_if(
+            blocklists_,
             [&bin_file](auto const& candidate) { return bin_file == candidate.binFile(); });
-        iter != std::end(blocklists_))
+        iter != std::ranges::end(blocklists_))
     {
         *iter = std::move(*added);
     }

--- a/libtransmission/clients.cc
+++ b/libtransmission/clients.cc
@@ -191,8 +191,8 @@ bool decodeShad0wClient(char* buf, size_t buflen, std::string_view in)
 
     std::tie(buf, buflen) = buf_append(buf, buflen, name, ' ');
     std::for_each(
-        std::rbegin(vals),
-        std::rend(vals),
+        vals.rbegin(),
+        vals.rend(),
         [&buf, &buflen](int num) { std::tie(buf, buflen) = buf_append(buf, buflen, num, '.'); });
     if (buf > buf_in)
     {

--- a/libtransmission/crypto-utils.cc
+++ b/libtransmission/crypto-utils.cc
@@ -10,6 +10,7 @@
 #include <cstdint>
 #include <iterator>
 #include <optional>
+#include <ranges>
 #include <random>
 #include <string>
 #include <string_view>
@@ -70,11 +71,7 @@ std::string tr_ssha1(std::string_view plaintext)
     static_assert(std::size(Salter) == 64);
     auto constexpr SaltSize = size_t{ 8 };
     auto salt = tr_rand_obj<std::array<char, SaltSize>>();
-    std::transform(
-        std::begin(salt),
-        std::end(salt),
-        std::begin(salt),
-        [&Salter](auto ch) { return Salter[ch % std::size(Salter)]; });
+    std::ranges::for_each(salt, [&Salter](auto& ch) { ch = Salter[ch % std::size(Salter)]; });
 
     return tr_salt(plaintext, std::string_view{ std::data(salt), std::size(salt) });
 }
@@ -212,7 +209,7 @@ std::optional<tr_sha1_digest_t> tr_sha1_from_string(std::string_view hex)
         return {};
     }
 
-    if (!std::all_of(std::begin(hex), std::end(hex), [](unsigned char ch) { return isxdigit(ch); }))
+    if (!std::ranges::all_of(hex, [](unsigned char ch) { return isxdigit(ch); }))
     {
         return {};
     }
@@ -231,7 +228,7 @@ std::optional<tr_sha256_digest_t> tr_sha256_from_string(std::string_view hex)
         return {};
     }
 
-    if (!std::all_of(std::begin(hex), std::end(hex), [](unsigned char ch) { return isxdigit(ch); }))
+    if (!std::ranges::all_of(hex, [](unsigned char ch) { return isxdigit(ch); }))
     {
         return {};
     }

--- a/libtransmission/ip-cache.cc
+++ b/libtransmission/ip-cache.cc
@@ -10,6 +10,7 @@
 #include <memory>
 #include <mutex>
 #include <optional>
+#include <ranges>
 #include <string_view>
 #include <utility> // std::move
 
@@ -167,10 +168,7 @@ tr_ip_cache::~tr_ip_cache()
                                          source_addr_mutex_[TR_AF_INET],
                                          source_addr_mutex_[TR_AF_INET6] };
 
-    if (!std::all_of(
-            std::begin(is_updating_),
-            std::end(is_updating_),
-            [](is_updating_t const& v) { return v == is_updating_t::Abort; }))
+    if (!std::ranges::all_of(is_updating_, [](is_updating_t const& v) { return v == is_updating_t::Abort; }))
     {
         tr_logAddDebug("Destructed while some global IP queries were pending.");
     }
@@ -300,8 +298,8 @@ void tr_ip_cache::update_source_addr(tr_address_type type) noexcept
         upkeep_timers_[type]->set_interval(RetryUpkeepInterval);
 
         tr_logAddDebug(fmt::format("Couldn't obtain source {} address: {} ({})", protocol, tr_net_strerror(err), err));
-        if (std::all_of(std::begin(source_addr_checked_), std::end(source_addr_checked_), [](bool u) { return u; }) &&
-            std::all_of(std::begin(source_addr_), std::end(source_addr_), std::logical_not{}))
+        if (std::ranges::all_of(source_addr_checked_, [](bool u) { return u; }) &&
+            std::ranges::all_of(source_addr_, std::logical_not{}))
         {
             tr_logAddError(_("Couldn't obtain source address in any IP protocol, no network connections possible"));
         }

--- a/libtransmission/magnet-metainfo.cc
+++ b/libtransmission/magnet-metainfo.cc
@@ -9,6 +9,7 @@
 #include <cstring>
 #include <iterator> // back_inserter
 #include <optional>
+#include <ranges>
 #include <string>
 #include <string_view>
 
@@ -118,9 +119,8 @@ std::optional<tr_sha1_digest_t> parseBase32Hash(std::string_view sv)
         return {};
     }
 
-    if (!std::all_of(
-            std::begin(sv),
-            std::end(sv),
+    if (!std::ranges::all_of(
+            sv,
             [](unsigned char ch)
             { return '0' <= ch && ch < '0' + std::size(bitzi::Base32Lookup) && bitzi::Base32Lookup[ch - '0'] != 0xFF; }))
     {
@@ -207,7 +207,7 @@ void tr_magnet_metainfo::add_webseed(std::string_view webseed)
 
     auto& urls = webseed_urls_;
 
-    if (auto const it = std::find(std::begin(urls), std::end(urls), webseed); it != std::end(urls))
+    if (auto const it = std::ranges::find(urls, webseed); it != std::ranges::end(urls))
     {
         return;
     }

--- a/libtransmission/makemeta.cc
+++ b/libtransmission/makemeta.cc
@@ -8,6 +8,7 @@
 #include <cmath>
 #include <ctime> // time()
 #include <iterator>
+#include <ranges>
 #include <set>
 #include <string>
 #include <string_view>
@@ -232,7 +233,7 @@ bool tr_metainfo_builder::blocking_make_checksums(tr_error* error)
         TR_ASSERT(left_in_piece == 0);
         sha.add(std::data(buf), std::size(buf));
         auto const digest = sha.finish();
-        walk = std::copy(std::begin(digest), std::end(digest), walk);
+        walk = std::ranges::copy(digest, walk).out;
         sha.clear();
 
         total_remain -= piece_size;

--- a/libtransmission/peer-mgr-wishlist.cc
+++ b/libtransmission/peer-mgr-wishlist.cc
@@ -6,6 +6,7 @@
 #include <algorithm> // std::adjacent_find, std::sort
 #include <cstddef>
 #include <functional>
+#include <ranges>
 #include <utility>
 #include <vector>
 
@@ -115,7 +116,7 @@ public:
 private:
     constexpr void dec_replication() noexcept
     {
-        std::for_each(std::begin(candidates_), std::end(candidates_), [](Candidate& candidate) { --candidate.replication; });
+        std::ranges::for_each(candidates_, [](Candidate& candidate) { --candidate.replication; });
     }
 
     constexpr void dec_replication_bitfield(tr_bitfield const& bitfield)
@@ -144,7 +145,7 @@ private:
 
     constexpr void inc_replication() noexcept
     {
-        std::for_each(std::begin(candidates_), std::end(candidates_), [](Candidate& candidate) { ++candidate.replication; });
+        std::ranges::for_each(candidates_, [](Candidate& candidate) { ++candidate.replication; });
     }
 
     void inc_replication_bitfield(tr_bitfield const& bitfield)
@@ -308,18 +309,12 @@ private:
 
     [[nodiscard]] constexpr CandidateVec::iterator find_by_piece(tr_piece_index_t const piece)
     {
-        return std::find_if(
-            std::begin(candidates_),
-            std::end(candidates_),
-            [piece](auto const& c) { return c.piece == piece; });
+        return std::ranges::find_if(candidates_, [piece](auto const& c) { return c.piece == piece; });
     }
 
     [[nodiscard]] constexpr CandidateVec::iterator find_by_block(tr_block_index_t const block)
     {
-        return std::find_if(
-            std::begin(candidates_),
-            std::end(candidates_),
-            [block](auto const& c) { return c.block_belongs(block); });
+        return std::ranges::find_if(candidates_, [block](auto const& c) { return c.block_belongs(block); });
     }
 
     static constexpr tr_piece_index_t get_salt(

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -16,6 +16,7 @@
 #include <optional>
 #include <queue>
 #include <ratio>
+#include <ranges>
 #include <string>
 #include <string_view>
 #include <tuple>
@@ -552,7 +553,7 @@ private:
 
         if (auto const must_send_rej = io_->supports_fext(); must_send_rej)
         {
-            std::for_each(std::begin(queue), std::end(queue), [this](peer_request const& req) { protocol_send_reject(req); });
+            std::ranges::for_each(queue, [this](peer_request const& req) { protocol_send_reject(req); });
         }
 
         queue.clear();
@@ -1554,7 +1555,7 @@ ReadResult tr_peerMsgsImpl::process_peer_message(uint8_t id, MessageReader& payl
             logtrace(this, fmt::format("got a Cancel {:d}:{:d}->{:d}", r.index, r.offset, r.length));
 
             auto& requests = peer_requested_;
-            if (auto iter = std::find(std::begin(requests), std::end(requests), r); iter != std::end(requests))
+            if (auto iter = std::ranges::find(requests, r); iter != std::ranges::end(requests))
             {
                 requests.erase(iter);
 
@@ -1942,7 +1943,7 @@ void tr_peerMsgsImpl::maybe_send_block_requests()
 
 void tr_peerMsgsImpl::check_request_timeout(time_t const now)
 {
-    std::sort(std::begin(request_timeouts_), std::end(request_timeouts_));
+    std::ranges::sort(request_timeouts_);
 
     for (auto it = std::begin(request_timeouts_); it != std::end(request_timeouts_);)
     {

--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -10,6 +10,7 @@
 #include <cstring> /* for strcspn() */
 #include <ctime>
 #include <memory>
+#include <ranges>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -253,7 +254,7 @@ void send_simple_response(struct evhttp_request* req, int code, char const* text
         }
         else
         {
-            std::copy(std::begin(content), std::end(content), static_cast<char*>(iov.iov_base));
+            std::ranges::copy(content, static_cast<char*>(iov.iov_base));
             iov.iov_len = std::size(content);
         }
 
@@ -417,7 +418,7 @@ bool is_address_allowed(tr_rpc_server const* server, char const* address)
     auto const* const addr = std::empty(native) ? address : native.c_str();
 
     auto const& src = server->whitelist_;
-    return std::any_of(std::begin(src), std::end(src), [&addr](auto const& s) { return tr_wildmat(addr, s.c_str()); });
+    return std::ranges::any_of(src, [&addr](auto const& s) { return tr_wildmat(addr, s.c_str()); });
 }
 
 bool isIPAddressWithOptionalPort(char const* host)
@@ -468,10 +469,7 @@ bool isHostnameAllowed(tr_rpc_server const* server, evhttp_request* const req)
 
     auto const& src = server->host_whitelist_;
     auto const hostname_sz = tr_urlbuf{ hostname };
-    return std::any_of(
-        std::begin(src),
-        std::end(src),
-        [&hostname_sz](auto const& str) { return tr_wildmat(hostname_sz, str.c_str()); });
+    return std::ranges::any_of(src, [&hostname_sz](auto const& str) { return tr_wildmat(hostname_sz, str.c_str()); });
 }
 
 bool test_session_id(tr_rpc_server const* server, evhttp_request* const req)

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -12,6 +12,7 @@
 #include <iterator>
 #include <memory>
 #include <numeric>
+#include <ranges>
 #include <set>
 #include <string>
 #include <string_view>
@@ -254,7 +255,7 @@ void tr_rpc_idle_done(struct tr_rpc_idle_data* data, JsonRpc::Error::Code code, 
             {
                 auto const cutoff = tr_time() - RecentlyActiveSeconds;
                 auto const recent = torrents.get_matching([cutoff](auto* walk) { return walk->has_changed_since(cutoff); });
-                std::copy(std::begin(recent), std::end(recent), std::back_inserter(torrents_vec));
+                std::ranges::copy(recent, std::back_inserter(torrents_vec));
             }
             else
             {
@@ -274,7 +275,7 @@ void tr_rpc_idle_done(struct tr_rpc_idle_data* data, JsonRpc::Error::Code code, 
 
         if (auto const* ids_vec = ids_var.get_if<tr_variant::Vector>(); ids_vec != nullptr)
         {
-            std::for_each(std::begin(*ids_vec), std::end(*ids_vec), add_torrent_from_var);
+            std::ranges::for_each(*ids_vec, add_torrent_from_var);
         }
         else
         {
@@ -349,7 +350,7 @@ void notifyBatchQueueChange(tr_session* session, std::vector<tr_torrent*> const&
     tr_variant::Map& /*args_out*/)
 {
     auto torrents = getTorrents(session, args_in);
-    std::sort(std::begin(torrents), std::end(torrents), tr_torrent::CompareQueuePosition);
+    std::ranges::sort(torrents, tr_torrent::CompareQueuePosition);
     for (auto* tor : torrents)
     {
         if (!tor->is_running())
@@ -368,7 +369,7 @@ void notifyBatchQueueChange(tr_session* session, std::vector<tr_torrent*> const&
     tr_variant::Map& /*args_out*/)
 {
     auto torrents = getTorrents(session, args_in);
-    std::sort(std::begin(torrents), std::end(torrents), tr_torrent::CompareQueuePosition);
+    std::ranges::sort(torrents, tr_torrent::CompareQueuePosition);
     for (auto* tor : torrents)
     {
         if (!tor->is_running())
@@ -1034,11 +1035,7 @@ namespace make_torrent_field_helpers
         /* first entry is an array of property names */
         auto names = tr_variant::Vector{};
         names.reserve(std::size(keys));
-        std::transform(
-            std::begin(keys),
-            std::end(keys),
-            std::back_inserter(names),
-            [](tr_quark key) { return tr_quark_get_string_view(key); });
+        std::ranges::transform(keys, std::back_inserter(names), [](tr_quark key) { return tr_quark_get_string_view(key); });
         torrents_vec.emplace_back(std::move(names));
     }
 
@@ -1716,7 +1713,7 @@ bool isCurlURL(std::string_view url)
 {
     auto constexpr Schemes = std::array<std::string_view, 4>{ "http"sv, "https"sv, "ftp"sv, "sftp"sv };
     auto const parsed = tr_urlParse(url);
-    return parsed && std::find(std::begin(Schemes), std::end(Schemes), parsed->scheme) != std::end(Schemes);
+    return parsed && std::ranges::find(Schemes, parsed->scheme) != std::ranges::end(Schemes);
 }
 
 [[nodiscard]] auto file_list_from_list(tr_variant::Vector const& idx_vec)

--- a/libtransmission/torrent-files.cc
+++ b/libtransmission/torrent-files.cc
@@ -10,6 +10,7 @@
 #include <functional>
 #include <iterator>
 #include <optional>
+#include <ranges>
 #include <set>
 #include <string>
 #include <string_view>
@@ -106,7 +107,7 @@ bool is_junk_file(std::string_view filename)
         "desktop.ini"sv,
     };
 
-    return std::find(std::begin(Files), std::end(Files), base) != std::end(Files);
+    return std::ranges::find(Files, base) != std::ranges::end(Files);
 }
 
 } // unnamed namespace
@@ -324,7 +325,7 @@ namespace
         "."sv,
         ".."sv,
     };
-    return (std::find(std::begin(ReservedNames), std::end(ReservedNames), in) != std::end(ReservedNames));
+    return (std::ranges::find(ReservedNames, in) != std::ranges::end(ReservedNames));
 }
 
 // https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file
@@ -349,7 +350,7 @@ namespace
     }
 
     auto in_upper = tr_pathbuf{ in };
-    std::transform(std::begin(in_upper), std::end(in_upper), std::begin(in_upper), [](auto ch) { return toupper(ch); });
+    std::ranges::for_each(in_upper, [](auto& ch) { ch = toupper(ch); });
     auto const in_upper_sv = in_upper.sv();
 
     static auto constexpr ReservedNames = std::array<std::string_view, 22>{
@@ -357,7 +358,7 @@ namespace
         "COM1"sv, "COM2"sv, "COM3"sv, "COM4"sv, "COM5"sv, "COM6"sv, "COM7"sv, "COM8"sv, "COM9"sv, //
         "LPT1"sv, "LPT2"sv, "LPT3"sv, "LPT4"sv, "LPT5"sv, "LPT6"sv, "LPT7"sv, "LPT8"sv, "LPT9"sv, //
     };
-    if (std::find(std::begin(ReservedNames), std::end(ReservedNames), in_upper_sv) != std::end(ReservedNames))
+    if (std::ranges::find(ReservedNames, in_upper_sv) != std::ranges::end(ReservedNames))
     {
         return true;
     }
@@ -367,9 +368,8 @@ namespace
         "COM1."sv, "COM2."sv, "COM3."sv, "COM4."sv, "COM5."sv, "COM6."sv, "COM7."sv, "COM8."sv, "COM9."sv, //
         "LPT1."sv, "LPT2."sv, "LPT3."sv, "LPT4."sv, "LPT5."sv, "LPT6."sv, "LPT7."sv, "LPT8."sv, "LPT9."sv, //
     };
-    return std::any_of(
-        std::begin(ReservedPrefixes),
-        std::end(ReservedPrefixes),
+    return std::ranges::any_of(
+        ReservedPrefixes,
         [in_upper_sv](auto const& prefix) { return tr_strv_starts_with(in_upper_sv, prefix); });
 }
 
@@ -454,7 +454,7 @@ void append_sanitized_component(std::string_view in, tr_pathbuf& out, bool os_sp
     {
         return is_reserved_char(ch, os_specific) ? '_' : ch;
     };
-    std::transform(std::begin(in), std::end(in), std::back_inserter(out), add_char);
+    std::ranges::transform(in, std::back_inserter(out), add_char);
 }
 
 } // namespace

--- a/libtransmission/torrent-magnet.cc
+++ b/libtransmission/torrent-magnet.cc
@@ -11,6 +11,7 @@
 #include <ios>
 #include <memory>
 #include <optional>
+#include <ranges>
 #include <string>
 #include <string_view>
 #include <type_traits>
@@ -289,11 +290,8 @@ bool tr_metadata_download::set_metadata_piece(int64_t const piece, void const* c
 
     // do we need this piece?
     auto& needed = pieces_needed_;
-    auto const iter = std::find_if(
-        std::begin(needed),
-        std::end(needed),
-        [piece](auto const& item) { return item.piece == piece; });
-    if (iter == std::end(needed))
+    auto const iter = std::ranges::find_if(needed, [piece](auto const& item) { return item.piece == piece; });
+    if (iter == std::ranges::end(needed))
     {
         return false;
     }

--- a/libtransmission/torrent-queue.cc
+++ b/libtransmission/torrent-queue.cc
@@ -4,6 +4,7 @@
 // License text can be found in the licenses/ folder.
 
 #include <algorithm>
+#include <ranges>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -49,16 +50,14 @@ size_t tr_torrent_queue::get_pos(tr_torrent_id_t const id)
     if (auto n_cache = std::size(pos_cache_);
         uid >= n_cache || pos_cache_[uid] >= std::size(queue_) || id != queue_[pos_cache_[uid]])
     {
-        auto const begin = std::begin(queue_);
-        auto const end = std::end(queue_);
-        auto it = std::find(begin, end, id);
-        if (it == end)
+        auto it = std::ranges::find(queue_, id);
+        if (it == std::ranges::cend(queue_))
         {
             return MaxQueuePosition;
         }
 
         pos_cache_.resize(std::max(uid + 1U, n_cache));
-        pos_cache_[uid] = it - begin;
+        pos_cache_[uid] = std::ranges::distance(std::ranges::cbegin(queue_), it);
     }
 
     return pos_cache_[uid];

--- a/libtransmission/torrents.cc
+++ b/libtransmission/torrents.cc
@@ -102,6 +102,7 @@ std::vector<tr_torrent_id_t> tr_torrents::removedSince(time_t timestamp) const
     }
 
     std::sort(std::begin(ids), std::end(ids));
-    ids.erase(std::unique(std::begin(ids), std::end(ids)), std::end(ids));
+    auto const unique_it = std::unique(std::begin(ids), std::end(ids));
+    ids.erase(unique_it, std::end(ids));
     return ids;
 }

--- a/libtransmission/tr-dht.cc
+++ b/libtransmission/tr-dht.cc
@@ -13,6 +13,7 @@
 #include <fstream>
 #include <map>
 #include <memory>
+#include <ranges>
 #include <sstream>
 #include <string>
 #include <string_view>
@@ -385,7 +386,8 @@ private:
             return candidate.socket_address.port_ == tr_port::from_host(1);
         };
 
-        pex.erase(std::remove_if(std::begin(pex), std::end(pex), IsBadPex), std::end(pex));
+        auto const remove_it = std::remove_if(std::begin(pex), std::end(pex), IsBadPex);
+        pex.erase(remove_it, std::end(pex));
         return std::move(pex);
     }
 
@@ -493,7 +495,7 @@ private:
                 tr_variantDictFindStrView(&top, TR_KEY_id, &sv) && std::size(sv) == std::size(id_))
             {
                 id_timestamp_ = t;
-                std::copy(std::begin(sv), std::end(sv), std::begin(id_));
+                std::ranges::copy(sv, std::begin(id_));
             }
         }
 

--- a/libtransmission/tr-lpd.cc
+++ b/libtransmission/tr-lpd.cc
@@ -545,9 +545,8 @@ private:
             return info.allows_lpd && (info.activity == TR_STATUS_DOWNLOAD || info.activity == TR_STATUS_SEED) &&
                 info.announce_after < now;
         };
-        torrents.erase(
-            std::remove_if(std::begin(torrents), std::end(torrents), std::not_fn(needs_announce)),
-            std::end(torrents));
+        auto const remove_it = std::remove_if(std::begin(torrents), std::end(torrents), std::not_fn(needs_announce));
+        torrents.erase(remove_it, std::end(torrents));
 
         if (std::empty(torrents))
         {

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -18,6 +18,7 @@
 #include <iterator> // for std::back_inserter
 #include <locale>
 #include <memory>
+#include <ranges>
 #include <mutex>
 #include <optional>
 #include <stdexcept> // std::runtime_error
@@ -260,11 +261,11 @@ std::string_view tr_strv_strip(std::string_view str)
         return isspace(static_cast<unsigned char>(ch));
     };
 
-    auto const it = std::find_if_not(std::begin(str), std::end(str), Test);
-    str.remove_prefix(std::distance(std::begin(str), it));
+    auto const it = std::ranges::find_if_not(str, Test);
+    str.remove_prefix(std::ranges::distance(std::ranges::begin(str), it));
 
-    auto const rit = std::find_if_not(std::rbegin(str), std::rend(str), Test);
-    str.remove_suffix(std::distance(std::rbegin(str), rit));
+    auto const rit = std::ranges::find_if_not(std::ranges::rbegin(str), std::ranges::rend(str), Test);
+    str.remove_suffix(std::ranges::distance(std::ranges::rbegin(str), rit));
 
     return str;
 }

--- a/libtransmission/variant-benc.cc
+++ b/libtransmission/variant-benc.cc
@@ -10,6 +10,7 @@
 #include <cstdint> // int64_t
 #include <deque>
 #include <optional>
+#include <ranges>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -101,7 +102,7 @@ std::optional<std::string_view> ParseString(std::string_view* benc)
 
     // get the string length
     auto svtmp = benc->substr(0, colon_pos);
-    if (!std::all_of(std::begin(svtmp), std::end(svtmp), [](auto ch) { return isdigit(static_cast<unsigned char>(ch)) != 0; }))
+    if (!std::ranges::all_of(svtmp, [](auto ch) { return isdigit(static_cast<unsigned char>(ch)) != 0; }))
     {
         return {};
     }

--- a/libtransmission/verify.cc
+++ b/libtransmission/verify.cc
@@ -10,6 +10,7 @@
 #include <cstdint> // uint64_t, uint32_t
 #include <memory>
 #include <mutex>
+#include <ranges>
 #include <thread>
 #include <utility> // for std::move()
 #include <vector>
@@ -180,11 +181,8 @@ void tr_verify_worker::remove(tr_sha1_digest_t const& info_hash)
         stop_current_ = true;
         stop_current_cv_.wait(lock, [this]() { return !stop_current_; });
     }
-    else if (auto const iter = std::find_if(
-                 std::begin(todo_),
-                 std::end(todo_),
-                 [&info_hash](auto const& node) { return node.matches(info_hash); });
-             iter != std::end(todo_))
+    else if (auto const iter = std::ranges::find_if(todo_, [&info_hash](auto const& node) { return node.matches(info_hash); });
+             iter != std::ranges::end(todo_))
     {
         iter->mediator_->on_verify_done(true /*aborted*/);
         todo_.erase(iter);

--- a/libtransmission/web-utils.cc
+++ b/libtransmission/web-utils.cc
@@ -10,6 +10,7 @@
 #include <cstdlib> // for strtoul()
 #include <limits>
 #include <optional>
+#include <ranges>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -210,22 +211,18 @@ constexpr bool urlCharsAreValid(std::string_view url)
         "{}|\\^[]`" // unwise
     };
 
-    return !std::empty(url) &&
-        std::all_of(std::begin(url), std::end(url), [&ValidChars](auto ch) { return tr_strv_contains(ValidChars, ch); });
+    return !std::empty(url) && std::ranges::all_of(url, [&ValidChars](auto ch) { return tr_strv_contains(ValidChars, ch); });
 }
 
 bool tr_isValidTrackerScheme(std::string_view scheme)
 {
     auto constexpr Schemes = std::array<std::string_view, 3>{ "http"sv, "https"sv, "udp"sv };
-    return std::find(std::begin(Schemes), std::end(Schemes), scheme) != std::end(Schemes);
+    return std::ranges::find(Schemes, scheme) != std::ranges::end(Schemes);
 }
 
 bool isAsciiNonUpperCase(std::string_view host)
 {
-    return std::all_of(
-        std::begin(host),
-        std::end(host),
-        [](unsigned char ch) { return (ch < 128) && (std::isupper(ch) == 0); });
+    return std::ranges::all_of(host, [](unsigned char ch) { return (ch < 128) && (std::isupper(ch) == 0); });
 }
 
 // www.example.com -> example
@@ -434,7 +431,7 @@ bool tr_urlIsValid(std::string_view url)
 {
     auto constexpr Schemes = std::array<std::string_view, 5>{ "http"sv, "https"sv, "ftp"sv, "sftp"sv, "udp"sv };
     auto const parsed = tr_urlParse(url);
-    return parsed && std::find(std::begin(Schemes), std::end(Schemes), parsed->scheme) != std::end(Schemes);
+    return parsed && std::ranges::find(Schemes, parsed->scheme) != std::ranges::end(Schemes);
 }
 
 std::string tr_urlTrackerLogName(std::string_view url)

--- a/libtransmission/web.cc
+++ b/libtransmission/web.cc
@@ -17,6 +17,7 @@
 #include <list>
 #include <map>
 #include <memory>
+#include <ranges>
 #include <mutex>
 #include <stack>
 #include <string>
@@ -702,9 +703,9 @@ public:
     {
         auto const lock = std::unique_lock{ tasks_mutex_ };
 
-        auto const iter = std::find(std::begin(running_tasks_), std::end(running_tasks_), task);
-        TR_ASSERT(iter != std::end(running_tasks_));
-        if (iter == std::end(running_tasks_))
+        auto const iter = std::ranges::find(running_tasks_, task);
+        TR_ASSERT(iter != std::ranges::end(running_tasks_));
+        if (iter == std::ranges::end(running_tasks_))
         {
             return;
         }

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -9,6 +9,7 @@
 #include <iterator>
 #include <memory>
 #include <numeric> // std::accumulate()
+#include <ranges>
 #include <set>
 #include <string>
 #include <string_view>
@@ -241,7 +242,7 @@ public:
         idle_timer_->stop();
 
         // flag all the pending tasks as dead
-        std::for_each(std::begin(tasks), std::end(tasks), [](auto* task) { task->dead = true; });
+        std::ranges::for_each(tasks, [](auto* task) { task->dead = true; });
         tasks.clear();
     }
 

--- a/qt/DetailsDialog.cc
+++ b/qt/DetailsDialog.cc
@@ -8,6 +8,7 @@
 #include <ctime>
 #include <map>
 #include <set>
+#include <ranges>
 #include <utility>
 
 #include <QDateTime>
@@ -348,18 +349,13 @@ void DetailsDialog::onTorrentsEdited(torrent_ids_t const& ids)
 {
     // std::set_intersection requires sorted inputs
     auto a = std::vector<tr_torrent_id_t>{ ids.begin(), ids.end() };
-    std::sort(std::begin(a), std::end(a));
+    std::ranges::sort(a);
     auto b = std::vector<tr_torrent_id_t>{ ids_.begin(), ids_.end() };
-    std::sort(std::begin(b), std::end(b));
+    std::ranges::sort(b);
 
     // are any of the edited torrents on display here?
     torrent_ids_t interesting_ids;
-    std::set_intersection(
-        std::begin(a),
-        std::end(a),
-        std::begin(b),
-        std::end(b),
-        std::inserter(interesting_ids, std::begin(interesting_ids)));
+    std::ranges::set_intersection(a, b, std::inserter(interesting_ids, std::begin(interesting_ids)));
 
     if (!interesting_ids.empty())
     {
@@ -376,7 +372,7 @@ void DetailsDialog::onTorrentsChanged(torrent_ids_t const& ids, Torrent::fields_
         return;
     }
 
-    if (!std::any_of(ids.begin(), ids.end(), [this](auto const& id) { return ids_.count(id) != 0; }))
+    if (!std::ranges::any_of(ids, [this](auto const& id) { return ids_.count(id) != 0; }))
     {
         return;
     }
@@ -897,10 +893,8 @@ void DetailsDialog::refreshUI()
             ui_.labelsTextEdit->setReadOnly(true);
             ui_.labelsTextEdit->setEnabled(true);
         }
-        else if (auto const& baseline = torrents[0]->labels(); std::all_of(
-                     std::begin(torrents),
-                     std::end(torrents),
-                     [&baseline](auto const* tor) { return tor->labels() == baseline; }))
+        else if (auto const& baseline = torrents[0]->labels();
+                 std::ranges::all_of(torrents, [&baseline](auto const* tor) { return tor->labels() == baseline; }))
         {
             labels_baseline_ = baseline.join(QStringLiteral(", "));
             ui_.labelsTextEdit->setPlainText(labels_baseline_);

--- a/qt/FileTreeItem.cc
+++ b/qt/FileTreeItem.cc
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <cassert>
 #include <utility>
+#include <ranges>
 
 #include <small/set.hpp>
 
@@ -38,8 +39,8 @@ FileTreeItem::~FileTreeItem()
 
     // find the parent's reference to this child
     auto& siblings = parent_->children_;
-    auto it = std::find(std::begin(siblings), std::end(siblings), this);
-    if (it == std::end(siblings))
+    auto it = std::ranges::find(siblings, this);
+    if (it == std::ranges::end(siblings))
     {
         return;
     }

--- a/qt/FileTreeModel.cc
+++ b/qt/FileTreeModel.cc
@@ -8,6 +8,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <ranges>
 #include <set>
 
 #include <small/map.hpp>

--- a/qt/FileTreeView.cc
+++ b/qt/FileTreeView.cc
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <cassert>
 #include <queue>
+#include <ranges>
 #include <set>
 
 #include <QHeaderView>

--- a/qt/MainWindow.cc
+++ b/qt/MainWindow.cc
@@ -3,9 +3,11 @@
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.
 
+#include <algorithm>
 #include <array>
 #include <cassert>
 #include <memory>
+#include <ranges>
 #include <utility>
 
 #include <QCheckBox>
@@ -549,7 +551,7 @@ void openSelect(QString const& path)
     }
 
     auto top = first_filename.left(slash_index);
-    if (!std::all_of(std::begin(files), std::end(files), [&top](auto const& file) { return file.filename.startsWith(top); }))
+    if (!std::ranges::all_of(files, [&top](auto const& file) { return file.filename.startsWith(top); }))
     {
         return {};
     }
@@ -845,8 +847,8 @@ void MainWindow::refreshActionSensitivity()
     {
         return tor->isPaused();
     };
-    auto const any_paused = std::any_of(std::begin(torrents), std::end(torrents), is_paused);
-    auto const any_not_paused = !std::all_of(std::begin(torrents), std::end(torrents), is_paused);
+    auto const any_paused = std::ranges::any_of(torrents, is_paused);
+    auto const any_not_paused = !std::ranges::all_of(torrents, is_paused);
 
     auto const have_selection = selected > 0;
     auto const have_selection_with_metadata = selected_with_metadata > 0;

--- a/qt/Session.cc
+++ b/qt/Session.cc
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <array>
 #include <cassert>
+#include <ranges>
 #include <string_view>
 #include <utility>
 
@@ -650,11 +651,7 @@ void Session::refreshTorrents(torrent_ids_t const& torrent_ids, TorrentPropertie
     auto fields = tr_variant::Vector{};
     auto const keys = getKeys(props);
     fields.reserve(std::size(keys));
-    std::transform(
-        std::begin(keys),
-        std::end(keys),
-        std::back_inserter(fields),
-        [](auto key) { return tr_variant::unmanaged_string(key); });
+    std::ranges::transform(keys, std::back_inserter(fields), [](auto key) { return tr_variant::unmanaged_string(key); });
 
     auto map = tr_variant::Map{ 3U };
     map.try_emplace(TR_KEY_format, tr_variant::unmanaged_string("table"sv));

--- a/qt/Torrent.cc
+++ b/qt/Torrent.cc
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <set>
+#include <ranges>
 
 #include <QApplication>
 #include <QString>
@@ -52,7 +53,7 @@ std::optional<double> Torrent::getSeedRatioLimit() const
 
 bool Torrent::includesTracker(QString const& sitename) const
 {
-    return std::binary_search(std::begin(sitenames_), std::end(sitenames_), sitename);
+    return std::ranges::binary_search(sitenames_, sitename);
 }
 
 int Torrent::compareSeedProgress(Torrent const& that) const

--- a/qt/TorrentModel.cc
+++ b/qt/TorrentModel.cc
@@ -8,6 +8,7 @@
 #include <cstddef>
 #include <ctime>
 #include <iterator> // for std::back_inserter
+#include <ranges>
 #include <string_view>
 #include <vector>
 
@@ -193,8 +194,8 @@ void TorrentModel::updateTorrents(tr_variant* torrent_list, bool is_complete_lis
     }
 
     // Find the position of TR_KEY_id so we can do torrent lookup
-    auto const id_it = std::find(std::begin(keys), std::end(keys), TR_KEY_id);
-    if (id_it == std::end(keys)) // no ids provided; we can't proceed
+    auto const id_it = std::ranges::find(keys, TR_KEY_id);
+    if (id_it == std::ranges::end(keys)) // no ids provided; we can't proceed
     {
         return;
     }
@@ -325,16 +326,10 @@ void TorrentModel::updateTorrents(tr_variant* torrent_list, bool is_complete_lis
 
     if (is_complete_list)
     {
-        std::sort(processed.begin(), processed.end(), TorrentIdLessThan());
+        std::ranges::sort(processed, TorrentIdLessThan());
         torrents_t removed;
         removed.reserve(old.size());
-        std::set_difference(
-            old.begin(),
-            old.end(),
-            processed.begin(),
-            processed.end(),
-            std::back_inserter(removed),
-            TorrentIdLessThan());
+        std::ranges::set_difference(old, processed, std::back_inserter(removed), TorrentIdLessThan());
         rowsRemove(removed);
     }
 }
@@ -387,7 +382,7 @@ std::vector<TorrentModel::span_t> TorrentModel::getSpans(torrent_ids_t const& id
         }
     }
 
-    std::sort(rows.begin(), rows.end());
+    std::ranges::sort(rows);
 
     // rows -> spans
     std::vector<span_t> spans;
@@ -444,14 +439,14 @@ void TorrentModel::rowsAdd(torrents_t const& torrents)
     {
         beginInsertRows(QModelIndex{}, 0, torrents.size() - 1);
         torrents_ = torrents;
-        std::sort(torrents_.begin(), torrents_.end(), TorrentIdLessThan{});
+        std::ranges::sort(torrents_, TorrentIdLessThan{});
         endInsertRows();
     }
     else
     {
         for (auto const& tor : torrents)
         {
-            auto const it = std::lower_bound(torrents_.begin(), torrents_.end(), tor, compare);
+            auto const it = std::ranges::lower_bound(torrents_, tor, compare);
             auto const row = static_cast<int>(std::distance(torrents_.begin(), it));
 
             beginInsertRows(QModelIndex{}, row, row);
@@ -487,5 +482,5 @@ bool TorrentModel::hasTorrent(TorrentHash const& hash) const
     {
         return tor->hash() == hash;
     };
-    return std::any_of(torrents_.cbegin(), torrents_.cend(), test);
+    return std::ranges::any_of(torrents_, test);
 }

--- a/qt/TrackerModel.cc
+++ b/qt/TrackerModel.cc
@@ -4,6 +4,7 @@
 // License text can be found in the licenses/ folder.
 
 #include <algorithm> // std::sort()
+#include <ranges>
 
 #include <QUrl>
 
@@ -100,7 +101,7 @@ void TrackerModel::refresh(TorrentModel const& torrent_model, torrent_ids_t cons
 
     // sort 'em
     static auto constexpr Comp = CompareTrackers{};
-    std::sort(trackers.begin(), trackers.end(), Comp);
+    std::ranges::sort(trackers, Comp);
 
     // merge 'em with the existing list
     unsigned int old_index = 0;


### PR DESCRIPTION
Part 1 in a short  series to fix `modernize-use-ranges` warnings from clang-tidy.

This first pass fixes the easiest warnings, anything that could be changed like this:

```diff
- std::action(std::begin(foo), std::end(foo), ...
+ std::ranges::action(foo, ...)
```