### PR TITLE
build: support building with system utf8cpp

### DIFF
--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -58,7 +58,8 @@ runs:
             libnatpmp-devel \
             libpsl-devel \
             miniupnpc-devel \
-            openssl-devel
+            openssl-devel \
+            utf8cpp-devel
 
           # Compiler packages
           if [[ "${{ inputs.compiler }}" == "clang" ]]; then
@@ -116,6 +117,13 @@ runs:
           # https://github.com/transmission/transmission/pull/6900
           if [ "$DISTRO" = 'debian' ]; then
             BASE_PACKAGES+=(libgtest-dev)
+          fi
+
+          if [ ! "$DISTRO" = 'debian' ] || [ ! "$DISTRO_VERSION" = '11' ]; then
+            BASE_PACKAGES+=(
+              libfmt-dev
+              libutfcpp-dev
+            )
           fi
 
           # Compiler packages
@@ -213,6 +221,7 @@ runs:
           libnatpmp
           libpsl
           miniupnpc
+          utf8cpp
         )
 
         brew install --formulae "${BASE_PACKAGES[@]}"

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -464,6 +464,7 @@ jobs:
             ninja \
             npm \
             pkgconfig \
+            utfcpp \
             xz
       - name: Get Dependencies (GTK)
         if: ${{ needs.what-to-make.outputs.make-gtk == 'true' }}
@@ -777,6 +778,7 @@ jobs:
             -DUSE_SYSTEM_DHT=OFF `# Not packaged in Debian 11` \
             -DUSE_SYSTEM_FMT=OFF `# Debian 11 package too old` \
             -DUSE_SYSTEM_SMALL=OFF `# Not packaged in Debian 11` \
+            -DUSE_SYSTEM_UTF8CPP=OFF `# Debian 11 package too old` \
             -DUSE_SYSTEM_UTP=OFF `# Not packaged in Debian 11` \
             -DUSE_SYSTEM_WIDE_INTEGER=OFF `# Not packaged in Debian 11`
       - name: Build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,9 @@ set(NPM_MINIMUM 10.2.3) # Node.js 20.10 (eslint-plugin-unicorn)
 set(PSL_MINIMUM 0.21.0)
 set(QT_MINIMUM 5.15)
 set(SMALL_MINIMUM 0.2.2)
+# utf8cpp v4's version file is configured with `COMPATIBILITY SameMajorVersion`
+# and does not support version range.
+# set(UTF8CPP_MINIMUM 3.1...4)
 
 option(ENABLE_DAEMON "Build daemon" ON)
 tr_auto_option(ENABLE_GTK "Build GTK client" AUTO)
@@ -82,6 +85,7 @@ tr_auto_option(USE_SYSTEM_FMT "Use system fmt library" ${USE_SYSTEM_DEFAULT})
 tr_auto_option(USE_SYSTEM_MINIUPNPC "Use system miniupnpc library" ${USE_SYSTEM_DEFAULT})
 tr_auto_option(USE_SYSTEM_NATPMP "Use system natpmp library" ${USE_SYSTEM_DEFAULT})
 tr_auto_option(USE_SYSTEM_SMALL "Use system small library" ${USE_SYSTEM_DEFAULT})
+tr_auto_option(USE_SYSTEM_UTF8CPP "Use system uft8cpp library" ${USE_SYSTEM_DEFAULT})
 tr_auto_option(USE_SYSTEM_UTP "Use system utp library" ${USE_SYSTEM_DEFAULT})
 tr_auto_option(USE_SYSTEM_WIDE_INTEGER "Use system WideInteger library" ${USE_SYSTEM_DEFAULT})
 tr_auto_option(USE_SYSTEM_B64 "Use system b64 library" ${USE_SYSTEM_DEFAULT})
@@ -251,7 +255,6 @@ set(SOURCE_ICONS_DIR "${PROJECT_SOURCE_DIR}/icons")
 
 find_package(FastFloat)
 find_package(RapidJSON)
-find_package(UtfCpp)
 
 find_package(Threads)
 find_package(PkgConfig QUIET)
@@ -609,6 +612,13 @@ target_link_libraries(transmission::small
 target_compile_definitions(transmission::small
     INTERFACE
         SMALL_DISABLE_EXCEPTIONS=1)
+
+tr_add_external_auto_library(UTF8CPP utf8cpp
+    SUBPROJECT
+    SOURCE_DIR utfcpp)
+if (NOT TARGET utf8::cpp)
+    add_library(utf8::cpp ALIAS utf8cpp)
+endif()
 
 tr_add_external_auto_library(WIDE_INTEGER WideInteger
     SUBPROJECT

--- a/cmake/FindUtfCpp.cmake
+++ b/cmake/FindUtfCpp.cmake
@@ -1,5 +1,0 @@
-add_library(utf8::cpp INTERFACE IMPORTED)
-
-target_include_directories(utf8::cpp
-    INTERFACE
-        ${TR_THIRD_PARTY_SOURCE_DIR}/utfcpp/source)

--- a/cmake/Findutf8cpp.cmake
+++ b/cmake/Findutf8cpp.cmake
@@ -1,0 +1,34 @@
+find_package(${CMAKE_FIND_PACKAGE_NAME} QUIET NO_MODULE)
+
+include(FindPackageHandleStandardArgs)
+if(${CMAKE_FIND_PACKAGE_NAME}_FOUND)
+    if(${CMAKE_FIND_PACKAGE_NAME}_VERSION VERSION_LESS 4.0.0)
+        # Before 4.0.0, some compiler options from their tests leaked into the
+        # main target. We workaround by clearing them here.
+        set_property(TARGET utf8cpp PROPERTY INTERFACE_COMPILE_OPTIONS)
+    endif()
+
+    find_package_handle_standard_args(${CMAKE_FIND_PACKAGE_NAME} CONFIG_MODE)
+    return()
+endif()
+
+find_path(${CMAKE_FIND_PACKAGE_NAME}_INCLUDE_DIR
+    NAMES utf8.h
+    PATH_SUFFIXES utf8cpp)
+
+find_package_handle_standard_args(${CMAKE_FIND_PACKAGE_NAME}
+    REQUIRED_VARS ${CMAKE_FIND_PACKAGE_NAME}_INCLUDE_DIR)
+
+if(${CMAKE_FIND_PACKAGE_NAME}_FOUND)
+    set(${CMAKE_FIND_PACKAGE_NAME}_INCLUDE_DIRS ${${CMAKE_FIND_PACKAGE_NAME}_INCLUDE_DIR})
+
+    if(NOT TARGET utf8::cpp)
+        add_library(utf8::cpp INTERFACE IMPORTED)
+
+        target_include_directories(utf8::cpp
+            INTERFACE
+                ${${CMAKE_FIND_PACKAGE_NAME}_INCLUDE_DIR})
+    endif()
+endif()
+
+mark_as_advanced(${CMAKE_FIND_PACKAGE_NAME}_INCLUDE_DIR)


### PR DESCRIPTION
Part of a series of PRs to pick out good, independent changes from #7554 (now reverted).

Notes: Added support for building with utf8cpp system library.