### PR TITLE
fix: don't generate zero size files in makemeta-test.cc

### DIFF
--- a/tests/libtransmission/makemeta-test.cc
+++ b/tests/libtransmission/makemeta-test.cc
@@ -39,7 +39,7 @@ protected:
 
     static auto makeRandomFiles(
         std::string_view top,
-        size_t n_files = std::max(size_t{ 1U }, static_cast<size_t>(tr_rand_int(DefaultMaxFileCount))),
+        size_t n_files = std::max(size_t{ 1U }, tr_rand_int(DefaultMaxFileCount)),
         size_t max_size = DefaultMaxFileSize)
     {
         auto files = std::vector<std::pair<std::string, std::vector<std::byte>>>{};


### PR DESCRIPTION
#6394 does not actually fix the flaky tests, and this PR corrects it.

Most recent example of flaky test: https://github.com/transmission/transmission/actions/runs/21242463265/job/61124610937

```
190/540 Test #192: LT.MakemetaTest.nameIsRootMultifile .......................................................................................................***Failed    0.03 sec
Running main() from D:\a\transmission\transmission\third-party\googletest\googletest\src\gtest_main.cc
Note: Google Test filter = MakemetaTest.nameIsRootMultifile
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from MakemetaTest
[ RUN      ] MakemetaTest.nameIsRootMultifile
D:\a\transmission\transmission\tests\libtransmission\makemeta-test.cc(77): error: Value of: error
  Actual: true
Expected: false
zero-length torrents are not allowed 2

D:\a\transmission\transmission\tests\libtransmission\makemeta-test.cc(80): error: Value of: metainfo.parse_benc(builder.benc())
  Actual: false
Expected: true

D:\a\transmission\transmission\tests\libtransmission\makemeta-test.cc(81): error: Expected equality of these values:
  builder.file_count()
    Which is: 1
  metainfo.file_count()
    Which is: 0

D:\a\transmission\transmission\tests\libtransmission\makemeta-test.cc(82): error: Expected equality of these values:
  builder.piece_size()
    Which is: 16384
  metainfo.piece_size()
    Which is: 0

D:\a\transmission\transmission\tests\libtransmission\makemeta-test.cc(90): error: Expected equality of these values:
  builder.name()
    Which is: "test.47Jtpp"
  metainfo.name()
    Which is: ""

D:\a\transmission\transmission\tests\libtransmission\makemeta-test.cc(201): error: Expected equality of these values:
  tr_sys_path_basename(filename)
    Which is: "test.47Jtpp"
  testBuilder(builder).name()
    Which is: ""

[  FAILED  ] MakemetaTest.nameIsRootMultifile (5 ms)
```