### PR TITLE
build: support building with system fast_float

### DIFF
--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -49,6 +49,7 @@ runs:
 
           # Transmission-specific libraries with Fedora names
           dnf install -y \
+            fast_float-devel \
             fmt-devel \
             google-crc32c-devel \
             libb64-devel \
@@ -102,7 +103,6 @@ runs:
             libcurl4-openssl-dev
             libdeflate-dev
             libevent-dev
-            libfmt-dev
             libminiupnpc-dev
             libnatpmp-dev
             libpsl-dev
@@ -121,6 +121,7 @@ runs:
 
           if [ ! "$DISTRO" = 'debian' ] || [ ! "$DISTRO_VERSION" = '11' ]; then
             BASE_PACKAGES+=(
+              libfast-float-dev
               libfmt-dev
               libutfcpp-dev
             )
@@ -214,6 +215,7 @@ runs:
         # Transmission-specific libraries
         BASE_PACKAGES+=(
           crc32c
+          fast_float
           fmt
           libb64
           libdeflate

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -451,6 +451,7 @@ jobs:
             cmake \
             crc32c-dev \
             curl-dev \
+            fast_float \
             fmt-dev \
             gettext-dev \
             git \
@@ -776,6 +777,7 @@ jobs:
             -DUSE_SYSTEM_DEFAULT=ON \
             -DUSE_SYSTEM_CRC32C=OFF `# Not packaged in Debian 11` \
             -DUSE_SYSTEM_DHT=OFF `# Not packaged in Debian 11` \
+            -DUSE_SYSTEM_FAST_FLOAT=OFF `# Not packaged in Debian 11` \
             -DUSE_SYSTEM_FMT=OFF `# Debian 11 package too old` \
             -DUSE_SYSTEM_SMALL=OFF `# Not packaged in Debian 11` \
             -DUSE_SYSTEM_UTF8CPP=OFF `# Debian 11 package too old` \
@@ -955,10 +957,10 @@ jobs:
           name: binaries-${{ github.job }}-${{ matrix.version }}
           path: pfx/**/*
 
-  ubuntu-22-04-from-tarball:
+  ubuntu-24-04-from-tarball:
     needs: [ make-source-tarball, what-to-make ]
     if: ${{ needs.what-to-make.outputs.make-cli == 'true' || needs.what-to-make.outputs.make-daemon == 'true' || needs.what-to-make.outputs.make-gtk == 'true' || needs.what-to-make.outputs.make-qt == 'true' || needs.what-to-make.outputs.make-tests == 'true' || needs.what-to-make.outputs.make-utils == 'true' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Show Configuration
         run: |
@@ -976,7 +978,7 @@ jobs:
       - name: Get Dependencies
         uses: ./.github/actions/install-deps
         with:
-          compiler: clang
+          compiler: clang # Workaround https://gcc.gnu.org/bugzilla/show_bug.cgi?id=109717
           enable-gtk: ${{ needs.what-to-make.outputs.make-gtk == 'true' }}
           enable-qt: ${{ needs.what-to-make.outputs.make-qt == 'true' && 'qt5' || 'false' }}
           use-sudo: true
@@ -998,6 +1000,8 @@ jobs:
             -B obj \
             -G Ninja \
             -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DCMAKE_CXX_COMPILER='clang++' \
+            -DCMAKE_C_COMPILER='clang' \
             -DCMAKE_INSTALL_PREFIX=pfx \
             -DENABLE_CLI=${{ (needs.what-to-make.outputs.make-cli == 'true') && 'ON' || 'OFF' }} \
             -DENABLE_DAEMON=${{ (needs.what-to-make.outputs.make-daemon == 'true') && 'ON' || 'OFF' }} \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,9 @@ set(WOLFSSL_MINIMUM 3.4)
 set(CRC32C_MINIMUM 1.1.0)
 set(DEFLATE_MINIMUM 1.7)
 set(EVENT2_MINIMUM 2.1.0)
+# fast_float's version file is configured with `COMPATIBILITY SameMajorVersion`
+# The version range currently distributed varies greatly (e.g. Debian Trixie -> 8.0.0, Ubuntu 24.04 -> 3.9.0)
+# set(FAST_FLOAT_MINIMUM 3...8)
 set(FMT_MINIMUM 8.0.1)
 set(GIOMM_MINIMUM 2.26.0)
 set(GLIBMM_MINIMUM 2.60.0)
@@ -82,6 +85,7 @@ tr_auto_option(RUN_CLANG_TIDY "Run clang-tidy on the code" ${USE_SYSTEM_DEFAULT}
 tr_auto_option(USE_SYSTEM_EVENT2 "Use system event2 library" ${USE_SYSTEM_DEFAULT})
 tr_auto_option(USE_SYSTEM_DEFLATE "Use system deflate library" ${USE_SYSTEM_DEFAULT})
 tr_auto_option(USE_SYSTEM_DHT "Use system dht library" ${USE_SYSTEM_DEFAULT})
+tr_auto_option(USE_SYSTEM_FAST_FLOAT "Use system fast_float library" ${USE_SYSTEM_DEFAULT})
 tr_auto_option(USE_SYSTEM_FMT "Use system fmt library" ${USE_SYSTEM_DEFAULT})
 tr_auto_option(USE_SYSTEM_MINIUPNPC "Use system miniupnpc library" ${USE_SYSTEM_DEFAULT})
 tr_auto_option(USE_SYSTEM_NATPMP "Use system natpmp library" ${USE_SYSTEM_DEFAULT})
@@ -254,7 +258,6 @@ set(CMAKE_FOLDER "${TR_THIRD_PARTY_DIR_NAME}")
 
 set(SOURCE_ICONS_DIR "${PROJECT_SOURCE_DIR}/icons")
 
-find_package(FastFloat)
 find_package(RapidJSON)
 
 find_package(Threads)
@@ -596,6 +599,15 @@ tr_add_external_auto_library(CRC32C Crc32c
         -DCRC32C_BUILD_BENCHMARKS=OFF
         -DCRC32C_USE_GLOG=OFF
         -DCRC32C_INSTALL=ON)
+
+tr_add_external_auto_library(FAST_FLOAT FastFloat
+    SUBPROJECT
+    SOURCE_DIR fast_float
+    CMAKE_ARGS
+        -DFASTFLOAT_INSTALL=OFF
+        -DFASTFLOAT_TEST=OFF
+        -DFASTFLOAT_SANITIZE=OFF
+        -DFASTFLOAT_CXX_STANDARD=${CMAKE_CXX_STANDARD})
 
 tr_add_external_auto_library(FMT fmt
     SUBPROJECT

--- a/cmake/FindFastFloat.cmake
+++ b/cmake/FindFastFloat.cmake
@@ -1,5 +1,0 @@
-add_library(FastFloat::fast_float INTERFACE IMPORTED)
-
-target_include_directories(FastFloat::fast_float
-    INTERFACE
-        ${TR_THIRD_PARTY_SOURCE_DIR}/fast_float/include)


### PR DESCRIPTION
Part of a series of PRs to pick out good, independent changes from #7554 (now reverted).

Notes: Added support for building with fast_float system library.