### PR TITLE
refactor: remove `tr_isDirection()`

### DIFF
--- a/daemon/daemon.cc
+++ b/daemon/daemon.cc
@@ -436,8 +436,8 @@ bool tr_daemon::reopen_log_file(char const* filename)
 
 void tr_daemon::report_status()
 {
-    double const up = tr_sessionGetRawSpeed_KBps(my_session_, TR_UP);
-    double const dn = tr_sessionGetRawSpeed_KBps(my_session_, TR_DOWN);
+    auto const up = tr_sessionGetRawSpeed_KBps(my_session_, tr_direction::Up);
+    auto const dn = tr_sessionGetRawSpeed_KBps(my_session_, tr_direction::Down);
 
     if (up > 0 || dn > 0)
     {

--- a/gtk/Application.cc
+++ b/gtk/Application.cc
@@ -1172,19 +1172,19 @@ void Application::Impl::on_prefs_changed(tr_quark const key)
         break;
 
     case TR_KEY_speed_limit_down_enabled:
-        tr_sessionLimitSpeed(tr, TR_DOWN, gtr_pref_flag_get(key));
+        tr_sessionLimitSpeed(tr, tr_direction::Down, gtr_pref_flag_get(key));
         break;
 
     case TR_KEY_speed_limit_down:
-        tr_sessionSetSpeedLimit_KBps(tr, TR_DOWN, gtr_pref_int_get(key));
+        tr_sessionSetSpeedLimit_KBps(tr, tr_direction::Down, gtr_pref_int_get(key));
         break;
 
     case TR_KEY_speed_limit_up_enabled:
-        tr_sessionLimitSpeed(tr, TR_UP, gtr_pref_flag_get(key));
+        tr_sessionLimitSpeed(tr, tr_direction::Up, gtr_pref_flag_get(key));
         break;
 
     case TR_KEY_speed_limit_up:
-        tr_sessionSetSpeedLimit_KBps(tr, TR_UP, gtr_pref_int_get(key));
+        tr_sessionSetSpeedLimit_KBps(tr, tr_direction::Up, gtr_pref_int_get(key));
         break;
 
     case TR_KEY_ratio_limit_enabled:
@@ -1216,7 +1216,7 @@ void Application::Impl::on_prefs_changed(tr_quark const key)
         break;
 
     case TR_KEY_download_queue_size:
-        tr_sessionSetQueueSize(tr, TR_DOWN, gtr_pref_int_get(key));
+        tr_sessionSetQueueSize(tr, tr_direction::Down, gtr_pref_int_get(key));
         break;
 
     case TR_KEY_queue_stalled_minutes:
@@ -1264,11 +1264,11 @@ void Application::Impl::on_prefs_changed(tr_quark const key)
         break;
 
     case TR_KEY_alt_speed_up:
-        tr_sessionSetAltSpeed_KBps(tr, TR_UP, gtr_pref_int_get(key));
+        tr_sessionSetAltSpeed_KBps(tr, tr_direction::Up, gtr_pref_int_get(key));
         break;
 
     case TR_KEY_alt_speed_down:
-        tr_sessionSetAltSpeed_KBps(tr, TR_DOWN, gtr_pref_int_get(key));
+        tr_sessionSetAltSpeed_KBps(tr, tr_direction::Down, gtr_pref_int_get(key));
         break;
 
     case TR_KEY_alt_speed_enabled:

--- a/gtk/DetailsDialog.cc
+++ b/gtk/DetailsDialog.cc
@@ -294,11 +294,11 @@ void DetailsDialog::Impl::refreshOptions(std::vector<tr_torrent*> const& torrent
     /* down_limited_check */
     if (!torrents.empty())
     {
-        bool const baseline = tr_torrentUsesSpeedLimit(torrents.front(), TR_DOWN);
-        bool const is_uniform = std::all_of(
+        auto const baseline = tr_torrentUsesSpeedLimit(torrents.front(), tr_direction::Down);
+        auto const is_uniform = std::all_of(
             torrents.begin(),
             torrents.end(),
-            [baseline](auto const* torrent) { return baseline == tr_torrentUsesSpeedLimit(torrent, TR_DOWN); });
+            [baseline](auto const* torrent) { return baseline == tr_torrentUsesSpeedLimit(torrent, tr_direction::Down); });
 
         if (is_uniform)
         {
@@ -309,11 +309,11 @@ void DetailsDialog::Impl::refreshOptions(std::vector<tr_torrent*> const& torrent
     /* down_limit_spin */
     if (!torrents.empty())
     {
-        auto const baseline = tr_torrentGetSpeedLimit_KBps(torrents.front(), TR_DOWN);
-        bool const is_uniform = std::all_of(
+        auto const baseline = tr_torrentGetSpeedLimit_KBps(torrents.front(), tr_direction::Down);
+        auto const is_uniform = std::all_of(
             torrents.begin(),
             torrents.end(),
-            [baseline](auto const* torrent) { return baseline == tr_torrentGetSpeedLimit_KBps(torrent, TR_DOWN); });
+            [baseline](auto const* torrent) { return baseline == tr_torrentGetSpeedLimit_KBps(torrent, tr_direction::Down); });
 
         if (is_uniform)
         {
@@ -324,11 +324,11 @@ void DetailsDialog::Impl::refreshOptions(std::vector<tr_torrent*> const& torrent
     /* up_limited_check */
     if (!torrents.empty())
     {
-        bool const baseline = tr_torrentUsesSpeedLimit(torrents.front(), TR_UP);
-        bool const is_uniform = std::all_of(
+        auto const baseline = tr_torrentUsesSpeedLimit(torrents.front(), tr_direction::Up);
+        auto const is_uniform = std::all_of(
             torrents.begin(),
             torrents.end(),
-            [baseline](auto const* torrent) { return baseline == tr_torrentUsesSpeedLimit(torrent, TR_UP); });
+            [baseline](auto const* torrent) { return baseline == tr_torrentUsesSpeedLimit(torrent, tr_direction::Up); });
 
         if (is_uniform)
         {
@@ -339,11 +339,11 @@ void DetailsDialog::Impl::refreshOptions(std::vector<tr_torrent*> const& torrent
     /* up_limit_sping */
     if (!torrents.empty())
     {
-        auto const baseline = tr_torrentGetSpeedLimit_KBps(torrents.front(), TR_UP);
-        bool const is_uniform = std::all_of(
+        auto const baseline = tr_torrentGetSpeedLimit_KBps(torrents.front(), tr_direction::Up);
+        auto const is_uniform = std::all_of(
             torrents.begin(),
             torrents.end(),
-            [baseline](auto const* torrent) { return baseline == tr_torrentGetSpeedLimit_KBps(torrent, TR_UP); });
+            [baseline](auto const* torrent) { return baseline == tr_torrentGetSpeedLimit_KBps(torrent, tr_direction::Up); });
 
         if (is_uniform)
         {

--- a/gtk/MainWindow.cc
+++ b/gtk/MainWindow.cc
@@ -409,24 +409,24 @@ void MainWindow::Impl::onAltSpeedToggledIdle()
 void MainWindow::Impl::onSpeedToggled(std::string const& action_name, tr_direction dir, bool enabled)
 {
     options_actions_->change_action_state(action_name, VariantInt::create(enabled ? 1 : 0));
-    core_->set_pref(dir == TR_UP ? TR_KEY_speed_limit_up_enabled : TR_KEY_speed_limit_down_enabled, enabled);
+    core_->set_pref(dir == tr_direction::Up ? TR_KEY_speed_limit_up_enabled : TR_KEY_speed_limit_down_enabled, enabled);
 }
 
 void MainWindow::Impl::onSpeedSet(tr_direction dir, int KBps)
 {
-    core_->set_pref(dir == TR_UP ? TR_KEY_speed_limit_up : TR_KEY_speed_limit_down, KBps);
-    core_->set_pref(dir == TR_UP ? TR_KEY_speed_limit_up_enabled : TR_KEY_speed_limit_down_enabled, true);
+    core_->set_pref(dir == tr_direction::Up ? TR_KEY_speed_limit_up : TR_KEY_speed_limit_down, KBps);
+    core_->set_pref(dir == tr_direction::Up ? TR_KEY_speed_limit_up_enabled : TR_KEY_speed_limit_down_enabled, true);
 }
 
 Glib::RefPtr<Gio::MenuModel> MainWindow::Impl::createSpeedMenu(
     Glib::RefPtr<Gio::SimpleActionGroup> const& actions,
     tr_direction dir)
 {
-    auto& info = speed_menu_info_.at(dir);
+    auto& info = speed_menu_info_.at(static_cast<uint8_t>(dir));
 
     auto m = Gio::Menu::create();
 
-    auto const action_name = fmt::format("speed-limit-{}", dir == TR_UP ? "up" : "down");
+    auto const action_name = fmt::format("speed-limit-{}", dir == tr_direction::Up ? "up" : "down");
     auto const full_action_name = fmt::format("{}.{}", OptionsMenuActionGroupName, action_name);
     info.action = actions->add_action_radio_integer(
         action_name,
@@ -537,8 +537,8 @@ Glib::RefPtr<Gio::MenuModel> MainWindow::Impl::createOptionsMenu()
     auto actions = Gio::SimpleActionGroup::create();
 
     auto section = Gio::Menu::create();
-    section->append_submenu(_("Limit Download Speed"), createSpeedMenu(actions, TR_DOWN));
-    section->append_submenu(_("Limit Upload Speed"), createSpeedMenu(actions, TR_UP));
+    section->append_submenu(_("Limit Download Speed"), createSpeedMenu(actions, tr_direction::Down));
+    section->append_submenu(_("Limit Upload Speed"), createSpeedMenu(actions, tr_direction::Up));
     top->append_section(section);
 
     section = Gio::Menu::create();
@@ -570,12 +570,12 @@ void MainWindow::Impl::onOptionsClicked()
     };
 
     update_menu(
-        speed_menu_info_[TR_DOWN],
+        speed_menu_info_[static_cast<uint8_t>(tr_direction::Down)],
         Speed{ gtr_pref_int_get(TR_KEY_speed_limit_down), Speed::Units::KByps }.to_string(),
         TR_KEY_speed_limit_down_enabled);
 
     update_menu(
-        speed_menu_info_[TR_UP],
+        speed_menu_info_[static_cast<uint8_t>(tr_direction::Up)],
         Speed{ gtr_pref_int_get(TR_KEY_speed_limit_up), Speed::Units::KByps }.to_string(),
         TR_KEY_speed_limit_up_enabled);
 

--- a/gtk/SystemTrayIcon.cc
+++ b/gtk/SystemTrayIcon.cc
@@ -205,6 +205,10 @@ std::string SystemTrayIcon::Impl::make_tooltip_text() const
     auto const* const session = core_->get_session();
     return fmt::format(
         fmt::runtime(_("{upload_speed} ▲ {download_speed} ▼")),
-        fmt::arg("upload_speed", Speed{ tr_sessionGetRawSpeed_KBps(session, TR_UP), Speed::Units::KByps }.to_string()),
-        fmt::arg("download_speed", Speed{ tr_sessionGetRawSpeed_KBps(session, TR_DOWN), Speed::Units::KByps }.to_string()));
+        fmt::arg(
+            "upload_speed",
+            Speed{ tr_sessionGetRawSpeed_KBps(session, tr_direction::Up), Speed::Units::KByps }.to_string()),
+        fmt::arg(
+            "download_speed",
+            Speed{ tr_sessionGetRawSpeed_KBps(session, tr_direction::Down), Speed::Units::KByps }.to_string()));
 }

--- a/libtransmission/announcer-http.cc
+++ b/libtransmission/announcer-http.cc
@@ -52,7 +52,7 @@ void verboseLog(std::string_view description, tr_direction direction, std::strin
         return;
     }
 
-    auto const direction_sv = direction == TR_DOWN ? "<< "sv : ">> "sv;
+    auto const direction_sv = direction == tr_direction::Down ? "<< "sv : ">> "sv;
     auto& out = std::cerr;
     out << description << '\n' << "[raw]"sv << direction_sv;
     for (unsigned char const ch : message)
@@ -322,7 +322,7 @@ void tr_tracker_http_announce(
 
 void tr_announcerParseHttpAnnounceResponse(tr_announce_response& response, std::string_view benc, std::string_view log_name)
 {
-    verboseLog("Announce response:", TR_DOWN, benc);
+    verboseLog("Announce response:", tr_direction::Down, benc);
 
     struct AnnounceHandler final : public transmission::benc::BasicHandler<MaxBencDepth>
     {
@@ -563,7 +563,7 @@ void tr_tracker_http_scrape(tr_session const* session, tr_scrape_request const& 
 
 void tr_announcerParseHttpScrapeResponse(tr_scrape_response& response, std::string_view benc, std::string_view log_name)
 {
-    verboseLog("Scrape response:", TR_DOWN, benc);
+    verboseLog("Scrape response:", tr_direction::Down, benc);
 
     struct ScrapeHandler final : public transmission::benc::BasicHandler<MaxBencDepth>
     {

--- a/libtransmission/bandwidth.h
+++ b/libtransmission/bandwidth.h
@@ -141,17 +141,13 @@ public:
     /** @brief Get the raw total of bytes read or sent by this bandwidth subtree. */
     [[nodiscard]] auto get_raw_speed(uint64_t const now, tr_direction const dir) const
     {
-        TR_ASSERT(tr_isDirection(dir));
-
-        return get_speed(band_[dir].raw_, HistoryMSec, now);
+        return get_speed(band_[static_cast<uint8_t>(dir)].raw_, HistoryMSec, now);
     }
 
     /** @brief Get the number of piece data bytes read or sent by this bandwidth subtree. */
     [[nodiscard]] auto get_piece_speed(uint64_t const now, tr_direction const dir) const
     {
-        TR_ASSERT(tr_isDirection(dir));
-
-        return get_speed(band_[dir].piece_, HistoryMSec, now);
+        return get_speed(band_[static_cast<uint8_t>(dir)].piece_, HistoryMSec, now);
     }
 
     /**
@@ -161,7 +157,7 @@ public:
      */
     constexpr bool set_desired_speed(tr_direction dir, Speed desired_speed)
     {
-        auto& value = band_[dir].desired_speed_;
+        auto& value = band_[static_cast<uint8_t>(dir)].desired_speed_;
         auto const did_change = desired_speed != value;
         value = desired_speed;
         return did_change;
@@ -173,7 +169,7 @@ public:
      */
     [[nodiscard]] constexpr auto get_desired_speed(tr_direction dir) const
     {
-        return band_[dir].desired_speed_;
+        return band_[static_cast<uint8_t>(dir)].desired_speed_;
     }
 
     [[nodiscard]] bool is_maxed_out(tr_direction dir, uint64_t now_msec) const noexcept
@@ -193,7 +189,7 @@ public:
      */
     constexpr bool set_limited(tr_direction dir, bool is_limited)
     {
-        auto& value = band_[dir].is_limited_;
+        auto& value = band_[static_cast<uint8_t>(dir)].is_limited_;
         auto const did_change = is_limited != value;
         value = is_limited;
         return did_change;
@@ -204,7 +200,7 @@ public:
      */
     [[nodiscard]] constexpr bool is_limited(tr_direction dir) const noexcept
     {
-        return band_[dir].is_limited_;
+        return band_[static_cast<uint8_t>(dir)].is_limited_;
     }
 
     /**
@@ -215,7 +211,7 @@ public:
      */
     constexpr bool honor_parent_limits(tr_direction direction, bool is_enabled)
     {
-        auto& value = band_[direction].honor_parent_limits_;
+        auto& value = band_[static_cast<uint8_t>(direction)].honor_parent_limits_;
         auto const did_change = is_enabled != value;
         value = is_enabled;
         return did_change;
@@ -223,7 +219,7 @@ public:
 
     [[nodiscard]] constexpr bool are_parent_limits_honored(tr_direction direction) const
     {
-        return band_[direction].honor_parent_limits_;
+        return band_[static_cast<uint8_t>(direction)].honor_parent_limits_;
     }
 
     [[nodiscard]] tr_bandwidth_limits get_limits() const;

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -161,7 +161,10 @@ public:
 
     size_t flush_outgoing_protocol_msgs();
 
-    size_t flush(tr_direction dir, size_t byte_limit);
+    size_t flush(tr_direction dir, size_t byte_limit)
+    {
+        return dir == tr_direction::Down ? try_read(byte_limit) : try_write(byte_limit);
+    }
 
     ///
 

--- a/libtransmission/peer-msgs.h
+++ b/libtransmission/peer-msgs.h
@@ -102,7 +102,7 @@ public:
 
     [[nodiscard]] constexpr auto is_active(tr_direction direction) const noexcept
     {
-        return is_active_[direction];
+        return is_active_[static_cast<uint8_t>(direction)];
     }
 
     [[nodiscard]] constexpr auto is_disconnecting() const noexcept
@@ -157,7 +157,7 @@ protected:
 
     constexpr void set_active(tr_direction direction, bool active) noexcept
     {
-        is_active_[direction] = active;
+        is_active_[static_cast<uint8_t>(direction)] = active;
     }
 
     constexpr void set_user_agent(tr_interned_string val) noexcept

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -245,8 +245,8 @@ tr_variant::Map save_single_speed_limit(tr_torrent const* tor, tr_direction dir)
 
 void save_speed_limits(tr_variant::Map& map, tr_torrent const* tor)
 {
-    map.insert_or_assign(TR_KEY_speed_limit_down, save_single_speed_limit(tor, TR_DOWN));
-    map.insert_or_assign(TR_KEY_speed_limit_up, save_single_speed_limit(tor, TR_UP));
+    map.insert_or_assign(TR_KEY_speed_limit_down, save_single_speed_limit(tor, tr_direction::Down));
+    map.insert_or_assign(TR_KEY_speed_limit_up, save_single_speed_limit(tor, tr_direction::Up));
 }
 
 void save_ratio_limits(tr_variant::Map& map, tr_torrent const* tor)
@@ -293,13 +293,13 @@ auto load_speed_limits(tr_variant::Map const& map, tr_torrent* tor)
 
     if (auto const* child = map.find_if<tr_variant::Map>(TR_KEY_speed_limit_up))
     {
-        load_single_speed_limit(*child, TR_UP, tor);
+        load_single_speed_limit(*child, tr_direction::Up, tor);
         ret = tr_resume::Speedlimit;
     }
 
     if (auto const* child = map.find_if<tr_variant::Map>(TR_KEY_speed_limit_down))
     {
-        load_single_speed_limit(*child, TR_DOWN, tor);
+        load_single_speed_limit(*child, tr_direction::Down, tor);
         ret = tr_resume::Speedlimit;
     }
 

--- a/libtransmission/session-alt-speeds.h
+++ b/libtransmission/session-alt-speeds.h
@@ -158,13 +158,13 @@ public:
 
     [[nodiscard]] auto speed_limit(tr_direction const dir) const noexcept
     {
-        auto const kbyps = dir == TR_DOWN ? settings().speed_down_kbyps : settings().speed_up_kbyps;
+        auto const kbyps = dir == tr_direction::Down ? settings().speed_down_kbyps : settings().speed_up_kbyps;
         return Speed{ kbyps, Speed::Units::KByps };
     }
 
     constexpr void set_speed_limit(tr_direction dir, Speed const limit) noexcept
     {
-        if (dir == TR_DOWN)
+        if (dir == tr_direction::Down)
         {
             settings_.speed_down_kbyps = limit.count(Speed::Units::KByps);
         }

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -942,12 +942,12 @@ public:
 
     [[nodiscard]] constexpr auto queueEnabled(tr_direction dir) const noexcept
     {
-        return dir == TR_DOWN ? settings_.download_queue_enabled : settings_.seed_queue_enabled;
+        return dir == tr_direction::Down ? settings_.download_queue_enabled : settings_.seed_queue_enabled;
     }
 
     [[nodiscard]] constexpr auto queueSize(tr_direction dir) const noexcept
     {
-        return dir == TR_DOWN ? settings_.download_queue_size : settings_.seed_queue_size;
+        return dir == tr_direction::Down ? settings_.download_queue_size : settings_.seed_queue_size;
     }
 
     [[nodiscard]] constexpr auto queueStalledEnabled() const noexcept
@@ -1132,20 +1132,20 @@ public:
 
     [[nodiscard]] auto speed_limit(tr_direction const dir) const noexcept
     {
-        auto const kbyps = dir == TR_DOWN ? settings_.speed_limit_down : settings_.speed_limit_up;
+        auto const kbyps = dir == tr_direction::Down ? settings_.speed_limit_down : settings_.speed_limit_up;
         return Speed{ kbyps, Speed::Units::KByps };
     }
 
     void set_speed_limit(tr_direction dir, Speed limit) noexcept
     {
-        auto& tgt = dir == TR_DOWN ? settings_.speed_limit_down : settings_.speed_limit_up;
+        auto& tgt = dir == tr_direction::Down ? settings_.speed_limit_down : settings_.speed_limit_up;
         tgt = limit.count(Speed::Units::KByps);
         update_bandwidth(dir);
     }
 
     [[nodiscard]] constexpr auto is_speed_limited(tr_direction dir) const noexcept
     {
-        return dir == TR_DOWN ? settings_.speed_limit_down_enabled : settings_.speed_limit_up_enabled;
+        return dir == tr_direction::Down ? settings_.speed_limit_down_enabled : settings_.speed_limit_up_enabled;
     }
 
     [[nodiscard]] auto piece_speed(tr_direction dir) const noexcept

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -240,7 +240,7 @@ struct tr_torrent
 
     [[nodiscard]] constexpr auto uses_session_limits() const noexcept
     {
-        return bandwidth().are_parent_limits_honored(TR_UP);
+        return bandwidth().are_parent_limits_honored(tr_direction::Up);
     }
 
     [[nodiscard]] constexpr auto uses_speed_limit(tr_direction dir) const noexcept
@@ -651,7 +651,7 @@ struct tr_torrent
 
     [[nodiscard]] constexpr auto queue_direction() const noexcept
     {
-        return is_done() ? TR_UP : TR_DOWN;
+        return is_done() ? tr_direction::Up : tr_direction::Down;
     }
 
     [[nodiscard]] constexpr auto is_queued(tr_direction const dir) const noexcept
@@ -686,12 +686,12 @@ struct tr_torrent
 
     [[nodiscard]] constexpr bool client_can_download() const
     {
-        return this->is_piece_transfer_allowed(TR_PEER_TO_CLIENT);
+        return this->is_piece_transfer_allowed(tr_direction::PeerToClient);
     }
 
     [[nodiscard]] constexpr bool client_can_upload() const
     {
-        return this->is_piece_transfer_allowed(TR_CLIENT_TO_PEER);
+        return this->is_piece_transfer_allowed(tr_direction::ClientToPeer);
     }
 
     void set_download_dir(std::string_view path, bool is_new_torrent = false);
@@ -735,12 +735,12 @@ struct tr_torrent
             return is_done() ? TR_STATUS_SEED : TR_STATUS_DOWNLOAD;
         }
 
-        if (is_queued(TR_UP) && session->queueEnabled(TR_UP))
+        if (is_queued(tr_direction::Up) && session->queueEnabled(tr_direction::Up))
         {
             return TR_STATUS_SEED_WAIT;
         }
 
-        if (is_queued(TR_DOWN) && session->queueEnabled(TR_DOWN))
+        if (is_queued(tr_direction::Down) && session->queueEnabled(tr_direction::Down))
         {
             return TR_STATUS_DOWNLOAD_WAIT;
         }

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -465,12 +465,12 @@ enum tr_port_forwarding_state : uint8_t
 
 tr_port_forwarding_state tr_sessionGetPortForwarding(tr_session const* session);
 
-enum tr_direction : uint8_t
+enum class tr_direction : uint8_t
 {
-    TR_CLIENT_TO_PEER = 0,
-    TR_UP = 0,
-    TR_PEER_TO_CLIENT = 1,
-    TR_DOWN = 1
+    ClientToPeer = 0,
+    Up = 0,
+    PeerToClient = 1,
+    Down = 1,
 };
 
 // --- Session primary speed limits
@@ -554,7 +554,7 @@ void tr_torrentSetPriority(tr_torrent* tor, tr_priority_t priority);
 /**
  * Torrent Queueing
  *
- * There are independent queues for seeding (`TR_UP`) and leeching (`TR_DOWN`).
+ * There are independent queues for seeding (`tr_direction::Up`) and leeching (`tr_direction::Down`).
  *
  * If the session already has enough non-stalled seeds/leeches when
  * `tr_torrentStart()` is called, the torrent will be moved into the
@@ -594,16 +594,16 @@ void tr_torrentsQueueMoveBottom(tr_torrent* const* torrents, size_t torrent_coun
 
 // ---
 
-/** @brief Return the number of torrents allowed to download (if direction is `TR_DOWN`) or seed (if direction is `TR_UP`) at the same time */
+/** @brief Return the number of torrents allowed to download (if direction is `tr_direction::Down`) or seed (if direction is `tr_direction::Up`) at the same time */
 size_t tr_sessionGetQueueSize(tr_session const* session, tr_direction dir);
 
-/** @brief Set the number of torrents allowed to download (if direction is `TR_DOWN`) or seed (if direction is `TR_UP`) at the same time */
+/** @brief Set the number of torrents allowed to download (if direction is `tr_direction::Down`) or seed (if direction is `tr_direction::Up`) at the same time */
 void tr_sessionSetQueueSize(tr_session* session, tr_direction dir, size_t max_simultaneous_torrents);
 
-/** @brief Return true if we're limiting how many torrents can concurrently download (`TR_DOWN`) or seed (`TR_UP`) at the same time */
+/** @brief Return true if we're limiting how many torrents can concurrently download (`tr_direction::Down`) or seed (`tr_direction::Up`) at the same time */
 bool tr_sessionGetQueueEnabled(tr_session const* session, tr_direction dir);
 
-/** @brief Set whether or not to limit how many torrents can download (`TR_DOWN`) or seed (`TR_UP`) at the same time */
+/** @brief Set whether or not to limit how many torrents can download (`tr_direction::Down`) or seed (`tr_direction::Up`) at the same time */
 void tr_sessionSetQueueEnabled(tr_session* session, tr_direction dir, bool do_limit_simultaneous_torrents);
 
 // ---
@@ -1567,11 +1567,3 @@ tr_stat const* tr_torrentStat(tr_torrent* torrent);
 // Prefer calling this over calling the single-torrent version in a loop.
 // TODO(c++20) take a std::span argument
 std::vector<tr_stat const*> tr_torrentStat(tr_torrent* const* torrents, size_t n_torrents);
-
-/** @} */
-
-/** @brief Sanity checker to test that the direction is `TR_UP` or `TR_DOWN` */
-constexpr bool tr_isDirection(tr_direction d)
-{
-    return d == TR_UP || d == TR_DOWN;
-}

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -196,13 +196,13 @@ public:
 
     [[nodiscard]] Speed get_piece_speed(uint64_t now, tr_direction dir) const override
     {
-        return dir == TR_DOWN ? bandwidth_.get_piece_speed(now, dir) : Speed{};
+        return dir == tr_direction::Down ? bandwidth_.get_piece_speed(now, dir) : Speed{};
     }
 
     [[nodiscard]] tr_webseed_view get_view() const override
     {
         auto const is_downloading = !std::empty(tasks);
-        auto const speed = get_piece_speed(tr_time_msec(), TR_DOWN);
+        auto const speed = get_piece_speed(tr_time_msec(), tr_direction::Down);
         return {
             .url = base_url.c_str(),
             .is_downloading = is_downloading,
@@ -212,7 +212,7 @@ public:
 
     [[nodiscard]] TR_CONSTEXPR20 size_t active_req_count(tr_direction dir) const noexcept override
     {
-        if (dir == TR_CLIENT_TO_PEER) // blocks we've requested
+        if (dir == tr_direction::ClientToPeer) // blocks we've requested
         {
             return active_requests.count();
         }
@@ -254,8 +254,8 @@ public:
     void got_piece_data(uint32_t n_bytes)
     {
         auto const now = tr_time_msec();
-        bandwidth_.notify_bandwidth_consumed(TR_DOWN, n_bytes, false, now);
-        bandwidth_.notify_bandwidth_consumed(TR_DOWN, n_bytes, true, now);
+        bandwidth_.notify_bandwidth_consumed(tr_direction::Down, n_bytes, false, now);
+        bandwidth_.notify_bandwidth_consumed(tr_direction::Down, n_bytes, true, now);
         publish(tr_peer_event::GotPieceData(n_bytes));
         connection_limiter.got_data();
     }

--- a/macosx/GlobalOptionsPopoverViewController.mm
+++ b/macosx/GlobalOptionsPopoverViewController.mm
@@ -52,7 +52,7 @@
 
 - (IBAction)setDownSpeedSetting:(id)sender
 {
-    tr_sessionLimitSpeed(self.fHandle, TR_DOWN, [self.fDefaults boolForKey:@"CheckDownload"]);
+    tr_sessionLimitSpeed(self.fHandle, tr_direction::Down, [self.fDefaults boolForKey:@"CheckDownload"]);
 
     [NSNotificationCenter.defaultCenter postNotificationName:@"SpeedLimitUpdate" object:nil];
 }
@@ -61,7 +61,7 @@
 {
     NSInteger const limit = [sender integerValue];
     [self.fDefaults setInteger:limit forKey:@"DownloadLimit"];
-    tr_sessionSetSpeedLimit_KBps(self.fHandle, TR_DOWN, limit);
+    tr_sessionSetSpeedLimit_KBps(self.fHandle, tr_direction::Down, limit);
 
     [NSNotificationCenter.defaultCenter postNotificationName:@"UpdateSpeedLimitValuesOutsidePrefs" object:nil];
     [NSNotificationCenter.defaultCenter postNotificationName:@"SpeedLimitUpdate" object:nil];
@@ -69,7 +69,7 @@
 
 - (IBAction)setUpSpeedSetting:(id)sender
 {
-    tr_sessionLimitSpeed(self.fHandle, TR_UP, [self.fDefaults boolForKey:@"CheckUpload"]);
+    tr_sessionLimitSpeed(self.fHandle, tr_direction::Up, [self.fDefaults boolForKey:@"CheckUpload"]);
 
     [NSNotificationCenter.defaultCenter postNotificationName:@"UpdateSpeedLimitValuesOutsidePrefs" object:nil];
     [NSNotificationCenter.defaultCenter postNotificationName:@"SpeedLimitUpdate" object:nil];
@@ -79,7 +79,7 @@
 {
     NSInteger const limit = [sender integerValue];
     [self.fDefaults setInteger:limit forKey:@"UploadLimit"];
-    tr_sessionSetSpeedLimit_KBps(self.fHandle, TR_UP, limit);
+    tr_sessionSetSpeedLimit_KBps(self.fHandle, tr_direction::Up, limit);
 
     [NSNotificationCenter.defaultCenter postNotificationName:@"SpeedLimitUpdate" object:nil];
 }

--- a/macosx/PrefsController.mm
+++ b/macosx/PrefsController.mm
@@ -656,19 +656,19 @@ static NSString* const kWebUIURLFormat = @"http://localhost:%ld/";
 
 - (void)applySpeedSettings:(id)sender
 {
-    tr_sessionLimitSpeed(self.fHandle, TR_UP, [self.fDefaults boolForKey:@"CheckUpload"]);
-    tr_sessionSetSpeedLimit_KBps(self.fHandle, TR_UP, [self.fDefaults integerForKey:@"UploadLimit"]);
+    tr_sessionLimitSpeed(self.fHandle, tr_direction::Up, [self.fDefaults boolForKey:@"CheckUpload"]);
+    tr_sessionSetSpeedLimit_KBps(self.fHandle, tr_direction::Up, [self.fDefaults integerForKey:@"UploadLimit"]);
 
-    tr_sessionLimitSpeed(self.fHandle, TR_DOWN, [self.fDefaults boolForKey:@"CheckDownload"]);
-    tr_sessionSetSpeedLimit_KBps(self.fHandle, TR_DOWN, [self.fDefaults integerForKey:@"DownloadLimit"]);
+    tr_sessionLimitSpeed(self.fHandle, tr_direction::Down, [self.fDefaults boolForKey:@"CheckDownload"]);
+    tr_sessionSetSpeedLimit_KBps(self.fHandle, tr_direction::Down, [self.fDefaults integerForKey:@"DownloadLimit"]);
 
     [NSNotificationCenter.defaultCenter postNotificationName:@"SpeedLimitUpdate" object:nil];
 }
 
 - (void)applyAltSpeedSettings
 {
-    tr_sessionSetAltSpeed_KBps(self.fHandle, TR_UP, [self.fDefaults integerForKey:@"SpeedLimitUploadLimit"]);
-    tr_sessionSetAltSpeed_KBps(self.fHandle, TR_DOWN, [self.fDefaults integerForKey:@"SpeedLimitDownloadLimit"]);
+    tr_sessionSetAltSpeed_KBps(self.fHandle, tr_direction::Up, [self.fDefaults integerForKey:@"SpeedLimitUploadLimit"]);
+    tr_sessionSetAltSpeed_KBps(self.fHandle, tr_direction::Down, [self.fDefaults integerForKey:@"SpeedLimitDownloadLimit"]);
 
     [NSNotificationCenter.defaultCenter postNotificationName:@"SpeedLimitUpdate" object:nil];
 }
@@ -878,8 +878,8 @@ static NSString* const kWebUIURLFormat = @"http://localhost:%ld/";
 - (void)setQueue:(id)sender
 {
     //let's just do both - easier that way
-    tr_sessionSetQueueEnabled(self.fHandle, TR_DOWN, [self.fDefaults boolForKey:@"Queue"]);
-    tr_sessionSetQueueEnabled(self.fHandle, TR_UP, [self.fDefaults boolForKey:@"QueueSeed"]);
+    tr_sessionSetQueueEnabled(self.fHandle, tr_direction::Down, [self.fDefaults boolForKey:@"Queue"]);
+    tr_sessionSetQueueEnabled(self.fHandle, tr_direction::Up, [self.fDefaults boolForKey:@"QueueSeed"]);
 
     //handle if any transfers switch from queued to paused
     [NSNotificationCenter.defaultCenter postNotificationName:@"UpdateTorrentsState" object:nil];
@@ -892,7 +892,7 @@ static NSString* const kWebUIURLFormat = @"http://localhost:%ld/";
 
     [self.fDefaults setInteger:number forKey:seed ? @"QueueSeedNumber" : @"QueueDownloadNumber"];
 
-    tr_sessionSetQueueSize(self.fHandle, seed ? TR_UP : TR_DOWN, number);
+    tr_sessionSetQueueSize(self.fHandle, seed ? tr_direction::Up : tr_direction::Down, number);
 }
 
 - (void)setStalled:(id)sender
@@ -1375,17 +1375,17 @@ static NSString* const kWebUIURLFormat = @"http://localhost:%ld/";
     [self.fDefaults setBool:randomPort forKey:@"RandomPort"];
 
     //speed limit - down
-    BOOL const downLimitEnabled = tr_sessionIsSpeedLimited(self.fHandle, TR_DOWN);
+    BOOL const downLimitEnabled = tr_sessionIsSpeedLimited(self.fHandle, tr_direction::Down);
     [self.fDefaults setBool:downLimitEnabled forKey:@"CheckDownload"];
 
-    auto const downLimit = tr_sessionGetSpeedLimit_KBps(self.fHandle, TR_DOWN);
+    auto const downLimit = tr_sessionGetSpeedLimit_KBps(self.fHandle, tr_direction::Down);
     [self.fDefaults setInteger:downLimit forKey:@"DownloadLimit"];
 
     //speed limit - up
-    BOOL const upLimitEnabled = tr_sessionIsSpeedLimited(self.fHandle, TR_UP);
+    BOOL const upLimitEnabled = tr_sessionIsSpeedLimited(self.fHandle, tr_direction::Up);
     [self.fDefaults setBool:upLimitEnabled forKey:@"CheckUpload"];
 
-    auto const upLimit = tr_sessionGetSpeedLimit_KBps(self.fHandle, TR_UP);
+    auto const upLimit = tr_sessionGetSpeedLimit_KBps(self.fHandle, tr_direction::Up);
     [self.fDefaults setInteger:upLimit forKey:@"UploadLimit"];
 
     //alt speed limit enabled
@@ -1393,11 +1393,11 @@ static NSString* const kWebUIURLFormat = @"http://localhost:%ld/";
     [self.fDefaults setBool:useAltSpeed forKey:@"SpeedLimit"];
 
     //alt speed limit - down
-    auto const downLimitAlt = tr_sessionGetAltSpeed_KBps(self.fHandle, TR_DOWN);
+    auto const downLimitAlt = tr_sessionGetAltSpeed_KBps(self.fHandle, tr_direction::Down);
     [self.fDefaults setInteger:downLimitAlt forKey:@"SpeedLimitDownloadLimit"];
 
     //alt speed limit - up
-    auto const upLimitAlt = tr_sessionGetAltSpeed_KBps(self.fHandle, TR_UP);
+    auto const upLimitAlt = tr_sessionGetAltSpeed_KBps(self.fHandle, tr_direction::Up);
     [self.fDefaults setInteger:upLimitAlt forKey:@"SpeedLimitUploadLimit"];
 
     //alt speed limit schedule
@@ -1435,16 +1435,16 @@ static NSString* const kWebUIURLFormat = @"http://localhost:%ld/";
     [self.fDefaults setInteger:idleLimitMin forKey:@"IdleLimitMinutes"];
 
     //queue
-    BOOL const downloadQueue = tr_sessionGetQueueEnabled(self.fHandle, TR_DOWN);
+    BOOL const downloadQueue = tr_sessionGetQueueEnabled(self.fHandle, tr_direction::Down);
     [self.fDefaults setBool:downloadQueue forKey:@"Queue"];
 
-    size_t const downloadQueueNum = tr_sessionGetQueueSize(self.fHandle, TR_DOWN);
+    size_t const downloadQueueNum = tr_sessionGetQueueSize(self.fHandle, tr_direction::Down);
     [self.fDefaults setInteger:downloadQueueNum forKey:@"QueueDownloadNumber"];
 
-    BOOL const seedQueue = tr_sessionGetQueueEnabled(self.fHandle, TR_UP);
+    BOOL const seedQueue = tr_sessionGetQueueEnabled(self.fHandle, tr_direction::Up);
     [self.fDefaults setBool:seedQueue forKey:@"QueueSeed"];
 
-    size_t const seedQueueNum = tr_sessionGetQueueSize(self.fHandle, TR_UP);
+    size_t const seedQueueNum = tr_sessionGetQueueSize(self.fHandle, tr_direction::Up);
     [self.fDefaults setInteger:seedQueueNum forKey:@"QueueSeedNumber"];
 
     BOOL const checkStalled = tr_sessionGetQueueStalledEnabled(self.fHandle);

--- a/macosx/Torrent.mm
+++ b/macosx/Torrent.mm
@@ -448,22 +448,22 @@ bool trashDataFile(char const* filename, void* /*user_data*/, tr_error* error)
 
 - (BOOL)usesSpeedLimit:(BOOL)upload
 {
-    return tr_torrentUsesSpeedLimit(self.fHandle, upload ? TR_UP : TR_DOWN);
+    return tr_torrentUsesSpeedLimit(self.fHandle, upload ? tr_direction::Up : tr_direction::Down);
 }
 
 - (void)setUseSpeedLimit:(BOOL)use upload:(BOOL)upload
 {
-    tr_torrentUseSpeedLimit(self.fHandle, upload ? TR_UP : TR_DOWN, use);
+    tr_torrentUseSpeedLimit(self.fHandle, upload ? tr_direction::Up : tr_direction::Down, use);
 }
 
 - (NSUInteger)speedLimit:(BOOL)upload
 {
-    return tr_torrentGetSpeedLimit_KBps(self.fHandle, upload ? TR_UP : TR_DOWN);
+    return tr_torrentGetSpeedLimit_KBps(self.fHandle, upload ? tr_direction::Up : tr_direction::Down);
 }
 
 - (void)setSpeedLimit:(NSUInteger)limit upload:(BOOL)upload
 {
-    tr_torrentSetSpeedLimit_KBps(self.fHandle, upload ? TR_UP : TR_DOWN, limit);
+    tr_torrentSetSpeedLimit_KBps(self.fHandle, upload ? tr_direction::Up : tr_direction::Down, limit);
 }
 
 - (BOOL)usesGlobalSpeedLimit


### PR DESCRIPTION
Remove the need to manually check `tr_isDirection()` by converting `tr_direction` from an enum to enum class.

There should be no change in behaviour.