### PR TITLE
refactor: make `tr_web` use `std::chrono` for deadline computation

### DIFF
--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -361,9 +361,9 @@ void tr_session::WebMediator::run(tr_web::FetchDoneFunc&& func, tr_web::FetchRes
     session_->run_in_session_thread(std::move(func), std::move(response));
 }
 
-time_t tr_session::WebMediator::now() const
+std::chrono::steady_clock::time_point tr_session::WebMediator::now() const
 {
-    return tr_time();
+    return std::chrono::steady_clock::now();
 }
 
 void tr_sessionFetch(tr_session* session, tr_web::FetchOptions&& options)

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -266,7 +266,7 @@ private:
         [[nodiscard]] std::optional<std::string_view> userAgent() const override;
         [[nodiscard]] size_t clamp(int torrent_id, size_t byte_count) const override;
         [[nodiscard]] std::optional<std::string> proxyUrl() const override;
-        [[nodiscard]] time_t now() const override;
+        [[nodiscard]] std::chrono::steady_clock::time_point now() const override;
         // runs the tr_web::fetch response callback in the libtransmission thread
         void run(tr_web::FetchDoneFunc&& func, tr_web::FetchResponse&& response) const override;
 

--- a/libtransmission/web.cc
+++ b/libtransmission/web.cc
@@ -226,14 +226,14 @@ public:
 
     ~Impl()
     {
-        deadline_ = mediator.now();
+        deadline_ns_ = to_ns(mediator.now());
         queued_tasks_cv_.notify_one();
         curl_thread->join();
     }
 
     void startShutdown(std::chrono::milliseconds deadline)
     {
-        deadline_ = mediator.now() + std::chrono::duration_cast<std::chrono::seconds>(deadline).count();
+        deadline_ns_ = to_ns(mediator.now() + deadline);
         queued_tasks_cv_.notify_one();
     }
 
@@ -455,21 +455,29 @@ public:
     // if unset: steady-state, all is good
     // if set: do not accept new tasks
     // if set and deadline reached: kill all remaining tasks
-    std::atomic<time_t> deadline_ = {}; // NOLINT(readability-redundant-member-init)
+    using Clock = std::chrono::steady_clock;
+    static auto constexpr NoDeadline = int64_t{ 0 };
 
-    [[nodiscard]] auto deadline() const
+    std::atomic<int64_t> deadline_ns_ = {}; // NOLINT(readability-redundant-member-init)
+
+    [[nodiscard]] static int64_t to_ns(Clock::time_point tp)
     {
-        return deadline_.load();
+        return std::chrono::duration_cast<std::chrono::nanoseconds>(tp.time_since_epoch()).count();
+    }
+
+    [[nodiscard]] auto deadline_ns() const
+    {
+        return deadline_ns_.load();
     }
 
     [[nodiscard]] bool deadline_exists() const
     {
-        return deadline() != time_t{};
+        return deadline_ns() != NoDeadline;
     }
 
     [[nodiscard]] bool deadline_reached() const
     {
-        return deadline_exists() && deadline() <= mediator.now();
+        return deadline_exists() && deadline_ns() <= to_ns(mediator.now());
     }
 
     [[nodiscard]] CURL* get_easy(std::string_view host)
@@ -767,7 +775,7 @@ public:
             // But during startup, wake up 10x more often. This is so tests
             // that should take a few msec don't block for a full second
             // while tr_session waits for this thread to finish.
-            static auto constexpr StartupSecs = 15;
+            static auto constexpr StartupSecs = std::chrono::seconds{ 15 };
             auto const timeout_ms = mediator.now() - start_time < StartupSecs ? 50 : 1000;
 
             // Adapted from https://curl.se/libcurl/c/curl_multi_wait.html docs.

--- a/libtransmission/web.h
+++ b/libtransmission/web.h
@@ -166,9 +166,9 @@ public:
             func(response);
         }
 
-        [[nodiscard]] virtual time_t now() const
+        [[nodiscard]] virtual std::chrono::steady_clock::time_point now() const
         {
-            return time(nullptr);
+            return std::chrono::steady_clock::now();
         }
     };
 

--- a/utils/show.cc
+++ b/utils/show.cc
@@ -316,9 +316,9 @@ void doScrape(tr_torrent_metainfo const& metainfo)
 {
     class Mediator final : public tr_web::Mediator
     {
-        [[nodiscard]] time_t now() const override
+        [[nodiscard]] std::chrono::steady_clock::time_point now() const override
         {
-            return time(nullptr);
+            return std::chrono::steady_clock::now();
         }
     };
 


### PR DESCRIPTION
Fixes #8155.