### PR TITLE
refactor: remove unused code 

### DIFF
--- a/libtransmission/announcer.h
+++ b/libtransmission/announcer.h
@@ -83,8 +83,6 @@ public:
     virtual void upkeep() = 0;
 };
 
-std::unique_ptr<tr_announcer> tr_announcerCreate(tr_session* session);
-
 // --- For torrent customers
 
 void tr_announcerChangeMyPort(tr_torrent* tor);

--- a/libtransmission/benc.h
+++ b/libtransmission/benc.h
@@ -225,16 +225,6 @@ struct ParserStack
         return depth > 0 && stack[depth].parent_type == ParentType::Dict && (stack[depth].n_children_walked % 2) == 0;
     }
 
-    [[nodiscard]] constexpr std::optional<ParentType> parentType() const
-    {
-        if (depth == 0)
-        {
-            return {};
-        }
-
-        return stack[depth].parent_type;
-    }
-
     std::optional<ParentType> pop(tr_error& error)
     {
         if (depth == 0)

--- a/libtransmission/net.h
+++ b/libtransmission/net.h
@@ -101,11 +101,6 @@ public:
         hport_ = hport;
     }
 
-    void set_network(uint16_t nport) noexcept
-    {
-        hport_ = ntohs(nport);
-    }
-
     [[nodiscard]] static std::pair<tr_port, std::byte const*> from_compact(std::byte const* compact) noexcept;
 
     [[nodiscard]] constexpr auto operator<(tr_port const& that) const noexcept

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -746,11 +746,6 @@ public:
         return settings().peer_congestion_algorithm;
     }
 
-    void setPeerCongestionAlgorithm(std::string_view algorithm)
-    {
-        settings_.peer_congestion_algorithm = algorithm;
-    }
-
     void setSocketDiffServ(tr_socket_t sock, tr_address_type type) const
     {
         tr_netSetDiffServ(sock, settings_.peer_socket_diffserv, type);
@@ -806,11 +801,6 @@ public:
     [[nodiscard]] constexpr std::string const& announceIP() const noexcept
     {
         return settings().announce_ip;
-    }
-
-    void setAnnounceIP(std::string_view ip)
-    {
-        settings_.announce_ip = ip;
     }
 
     [[nodiscard]] constexpr bool useAnnounceIP() const noexcept

--- a/libtransmission/torrent-metainfo.cc
+++ b/libtransmission/torrent-metainfo.cc
@@ -369,7 +369,6 @@ struct MetainfoHandler final : public transmission::benc::BasicHandler<MaxBencDe
                 auto const n = std::size(value) / sizeof(tr_sha1_digest_t);
                 tm_.pieces_.resize(n);
                 std::copy_n(std::data(value), std::size(value), reinterpret_cast<char*>(std::data(tm_.pieces_)));
-                tm_.pieces_offset_ = context.tokenSpan().first;
             }
             else
             {

--- a/libtransmission/torrent-metainfo.h
+++ b/libtransmission/torrent-metainfo.h
@@ -164,11 +164,6 @@ public:
         return info_dict_offset_;
     }
 
-    [[nodiscard]] constexpr auto pieces_offset() const noexcept
-    {
-        return pieces_offset_;
-    }
-
     // UTILS
 
     [[nodiscard]] auto torrent_file(std::string_view torrent_dir = {}) const
@@ -238,10 +233,6 @@ private:
     // See https://www.bittorrent.org/beps/bep_0009.html
     uint64_t info_dict_size_ = 0;
     uint64_t info_dict_offset_ = 0;
-
-    // Offset of the bencoded 'pieces' checksums subset of the bencoded data.
-    // Used when loading piece checksums on demand.
-    uint64_t pieces_offset_ = 0;
 
     bool has_magnet_info_hash_ = false;
     bool is_private_ = false;

--- a/tests/libtransmission/torrent-metainfo-test.cc
+++ b/tests/libtransmission/torrent-metainfo-test.cc
@@ -128,7 +128,6 @@ TEST_F(TorrentMetainfoTest, AndroidTorrent)
     EXPECT_NE(nullptr, metainfo);
     EXPECT_EQ(336, metainfo->info_dict_offset());
     EXPECT_EQ(26583, metainfo->info_dict_size());
-    EXPECT_EQ(592, metainfo->pieces_offset());
     tr_ctorFree(ctor);
 }
 


### PR DESCRIPTION
* chore: remove unused tr_announcerCreate() declaration

added in d27c4c5 but never used

* chore: remove unused ParserStack::parentType()

added in 5efec26 but never used

* chore: remove tr_port::set_network()

added in 32f854a but never used

* chore: remove tr_torrent_metainfo::pieces_offset()

added in 52f6e80 but never used

* chore: remove unused `tr_session::setPeerCongestionAlgorithm()`

unused after 611d36a

chore: remove unused `tr_session::setAnnounceIP()`

unused after 611d36a