### PR TITLE
Reduce decimal places in speed formatting

### DIFF
--- a/libtransmission/values.h
+++ b/libtransmission/values.h
@@ -218,13 +218,13 @@ public:
 
             if (val < 99.995) // 0.98 to 99.99
             {
-                *fmt::format_to_n(buf, buflen - 1, "{:.2Lf} {:s}", val, units_.display_name(idx)).out = '\0';
+                *fmt::format_to_n(buf, buflen - 1, "{:.1Lf} {:s}", val, units_.display_name(idx)).out = '\0';
                 return buf;
             }
 
             if (val < 999.95 || std::empty(units_.display_name(idx + 1))) // 100.0 to 999.9
             {
-                *fmt::format_to_n(buf, buflen - 1, "{:.1Lf} {:s}", val, units_.display_name(idx)).out = '\0';
+                *fmt::format_to_n(buf, buflen - 1, "{:.0Lf} {:s}", val, units_.display_name(idx)).out = '\0';
                 return buf;
             }
 

--- a/macosx/NSStringAdditions.mm
+++ b/macosx/NSStringAdditions.mm
@@ -184,23 +184,23 @@
 
     speed /= 1000.0;
 
-    if (speed < 99.995) // 1.00 MB/s to 99.99 MB/s
-    {
-        return [NSString localizedStringWithFormat:@"%.2f %@", speed, mb];
-    }
-    else if (speed < 999.95) // 100.0 MB/s to 999.9 MB/s
+    if (speed < 99.995) // 1.0 MB/s to 99.9 MB/s
     {
         return [NSString localizedStringWithFormat:@"%.1f %@", speed, mb];
+    }
+    else if (speed < 999.95) // 100 MB/s to 999 MB/s
+    {
+        return [NSString localizedStringWithFormat:@"%.0f %@", speed, mb];
     }
 
     speed /= 1000.0;
 
-    if (speed < 99.995) // 1.00 GB/s to 99.99 GB/s
+    if (speed < 99.995) // 1.0 GB/s to 99.9 GB/s
     {
-        return [NSString localizedStringWithFormat:@"%.2f %@", speed, gb];
+        return [NSString localizedStringWithFormat:@"%.1f %@", speed, gb];
     }
-    // 100.0 GB/s and above
-    return [NSString localizedStringWithFormat:@"%.1f %@", speed, gb];
+    // 100 GB/s and above
+    return [NSString localizedStringWithFormat:@"%.0f %@", speed, gb];
 }
 
 + (NSString*)stringForSpeedCompact:(CGFloat)speed kb:(NSString*)kb mb:(NSString*)mb gb:(NSString*)gb
@@ -216,13 +216,13 @@
 
     speed /= 1000.0;
 
-    if (speed < 9.995) // 1.00 MB/s to 9.99 MB/s
-    {
-        return [NSString localizedStringWithFormat:@"%.2f %@", speed, mb];
-    }
-    if (speed < 99.95) // 10.0 MB/s to 99.9 MB/s
+    if (speed < 9.995) // 1.0 MB/s to 9.9 MB/s
     {
         return [NSString localizedStringWithFormat:@"%.1f %@", speed, mb];
+    }
+    if (speed < 99.95) // 10 MB/s to 99 MB/s
+    {
+        return [NSString localizedStringWithFormat:@"%.0f %@", speed, mb];
     }
     if (speed < 999.5) // 100 MB/s to 999 MB/s
     {
@@ -231,13 +231,13 @@
 
     speed /= 1000.0;
 
-    if (speed < 9.995) // 1.00 GB/s to 9.99 GB/s
-    {
-        return [NSString localizedStringWithFormat:@"%.2f %@", speed, gb];
-    }
-    if (speed < 99.95) // 10.0 GB/s to 99.9 GB/s
+    if (speed < 9.995) // 1.0 GB/s to 9.9 GB/s
     {
         return [NSString localizedStringWithFormat:@"%.1f %@", speed, gb];
+    }
+    if (speed < 99.95) // 10 GB/s to 99 GB/s
+    {
+        return [NSString localizedStringWithFormat:@"%.0f %@", speed, gb];
     }
     // 100 GB/s and above
     return [NSString localizedStringWithFormat:@"%.0f %@", speed, gb];

--- a/tests/libtransmission/values-test.cc
+++ b/tests/libtransmission/values-test.cc
@@ -40,10 +40,10 @@ TEST_F(ValuesTest, toString)
     EXPECT_EQ("999 kB/s", val.to_string());
 
     val = Speed{ 99.22222, Speed::Units::KByps };
-    EXPECT_EQ("99.22 kB/s", val.to_string());
+    EXPECT_EQ("99.2 kB/s", val.to_string());
 
     val = Speed{ 999.22222, Speed::Units::KByps };
-    EXPECT_EQ("999.2 kB/s", val.to_string());
+    EXPECT_EQ("999 kB/s", val.to_string());
 }
 
 TEST_F(ValuesTest, isZero)

--- a/tests/utils/assets/Inner_Sanctum_movie_archive.show
+++ b/tests/utils/assets/Inner_Sanctum_movie_archive.show
@@ -15,7 +15,7 @@ Note: many Internet Archive torrents contain a 'pad file' directory. This direct
 Note: the file Inner_Sanctum_movie_meta.xml contains metadata about this torrent's contents.
   Piece Count: 1090
   Piece Size: 2 MiB
-  Total Size: 2.29 GB
+  Total Size: 2.3 GB
   Privacy: Public torrent
 
 TRACKERS

--- a/tests/utils/assets/Thor_and_the_Amazon_Women.avi.show
+++ b/tests/utils/assets/Thor_and_the_Amazon_Women.avi.show
@@ -10,7 +10,7 @@ GENERAL
 
   Piece Count: 1493
   Piece Size: 512 KiB
-  Total Size: 782.3 MB
+  Total Size: 782 MB
   Privacy: Public torrent
 
 TRACKERS
@@ -20,5 +20,5 @@ TRACKERS
 
 FILES
 
-  Thor_and_the_Amazon_Women.avi (782.3 MB)
+  Thor_and_the_Amazon_Women.avi (782 MB)
 

--- a/tests/utils/assets/bittorrent-v2-hybrid-test.show
+++ b/tests/utils/assets/bittorrent-v2-hybrid-test.show
@@ -11,7 +11,7 @@ GENERAL
 
   Piece Count: 1715
   Piece Size: 512 KiB
-  Total Size: 898.6 MB
+  Total Size: 899 MB
   Privacy: Public torrent
 
 TRACKERS
@@ -33,6 +33,6 @@ FILES
   bittorrent-v1-v2-hybrid-test/fairlight_cncd-agenda_circling_forth-1080p30lq.mp4 (277.9 MB)
   bittorrent-v1-v2-hybrid-test/meet the deadline - Still _ Evoke 2014.mp4 (44.58 MB)
   bittorrent-v1-v2-hybrid-test/readme.txt (61 B)
-  bittorrent-v1-v2-hybrid-test/tbl-goa.avi (26.30 MB)
+  bittorrent-v1-v2-hybrid-test/tbl-goa.avi (26.3 MB)
   bittorrent-v1-v2-hybrid-test/tbl-tint.mpg (115.9 MB)
 

--- a/tests/utils/assets/hybrid-single-ubuntu-20.04.3-desktop-amd64.iso.show
+++ b/tests/utils/assets/hybrid-single-ubuntu-20.04.3-desktop-amd64.iso.show
@@ -11,7 +11,7 @@ GENERAL
 
   Piece Count: 11719
   Piece Size: 256 KiB
-  Total Size: 3.07 GB
+  Total Size: 3.1 GB
   Privacy: Public torrent
 
 TRACKERS
@@ -21,5 +21,5 @@ TRACKERS
 
 FILES
 
-  ubuntu-20.04.3-desktop-amd64.iso (3.07 GB)
+  ubuntu-20.04.3-desktop-amd64.iso (3.1 GB)
 

--- a/tests/utils/assets/ubuntu-20.04.3-desktop-amd64.iso.show
+++ b/tests/utils/assets/ubuntu-20.04.3-desktop-amd64.iso.show
@@ -11,7 +11,7 @@ GENERAL
   Comment: Ubuntu CD releases.ubuntu.com
   Piece Count: 11719
   Piece Size: 256 KiB
-  Total Size: 3.07 GB
+  Total Size: 3.1 GB
   Privacy: Public torrent
 
 TRACKERS
@@ -24,5 +24,5 @@ TRACKERS
 
 FILES
 
-  ubuntu-20.04.3-desktop-amd64.iso (3.07 GB)
+  ubuntu-20.04.3-desktop-amd64.iso (3.1 GB)
 


### PR DESCRIPTION
Reduce decimal places in speed formatting for better readability.

- Values < 99.995: 2 decimals → 1 decimal
- Values < 999.95: 1 decimal → 0 decimals
