### PR TITLE
refactor: shuffle peers before pumping

### DIFF
--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -2514,12 +2514,17 @@ namespace bandwidth_helpers
 {
 void pumpAllPeers(tr_peerMgr* mgr)
 {
+    auto peers = std::vector<tr_peerMsgs*>{};
     for (auto* const tor : mgr->torrents_)
     {
-        for (auto const& peer : tor->swarm->peers)
-        {
-            peer->pulse();
-        }
+        std::ranges::transform(tor->swarm->peers, std::back_inserter(peers), [](auto const& p) { return p.get(); });
+    }
+
+    thread_local auto urbg = tr_urbg<size_t>{};
+    std::ranges::shuffle(peers, urbg);
+    for (auto const& peer : peers)
+    {
+        peer->pulse();
     }
 }
 } // namespace bandwidth_helpers

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -2514,7 +2514,7 @@ namespace bandwidth_helpers
 {
 void pumpAllPeers(tr_peerMgr* mgr)
 {
-    auto peers = std::vector<tr_peerMsgs*>{};
+    auto peers = small::vector<tr_peerMsgs*, TrDefaultPeerLimitGlobal>{};
     for (auto* const tor : mgr->torrents_)
     {
         std::ranges::transform(tor->swarm->peers, std::back_inserter(peers), [](auto const& p) { return p.get(); });


### PR DESCRIPTION
Partial fix for the symptoms described at https://github.com/transmission/transmission/issues/7919#issuecomment-3790214320.

- Spread BT traffic more evenly amongst peers. Right now, Transmission tends to prefer peers that happened to be at the front of the peer list.
- Avoid stalling downloads on a single peer that refuses to send data when there are other peers available.

Notes: Changed bandwidth allocation code to spread network traffic more evenly among peers.