### PR TITLE
refactor: use `std::remove_cvref_t`

### DIFF
--- a/gtk/Notify.cc
+++ b/gtk/Notify.cc
@@ -53,8 +53,7 @@ template<typename... Ts>
 Glib::VariantContainerBase make_variant_tuple(Ts&&... args)
 {
     return Glib::VariantContainerBase::create_tuple(
-        // TODO(c++20): use std::remove_cvref_t (P0550R2) when GCC >= 9.1
-        { Glib::Variant<std::remove_cv_t<std::remove_reference_t<Ts>>>::create(std::forward<Ts>(args))... });
+        { Glib::Variant<std::remove_cvref_t<Ts>>::create(std::forward<Ts>(args))... });
 }
 
 void get_capabilities_callback(Glib::RefPtr<Gio::AsyncResult>& res)

--- a/libtransmission/api-compat.cc
+++ b/libtransmission/api-compat.cc
@@ -661,8 +661,7 @@ void convert_keys(tr_variant& var, State& state)
     var.visit(
         [&state](auto& val)
         {
-            // TODO(c++20): use std::remove_cvref_t (P0550R2) when GCC >= 9.1
-            using ValueType = std::decay_t<decltype(val)>;
+            using ValueType = std::remove_cvref_t<decltype(val)>;
 
             if constexpr (std::is_same_v<ValueType, std::string> || std::is_same_v<ValueType, std::string_view>)
             {

--- a/libtransmission/serializer.h
+++ b/libtransmission/serializer.h
@@ -31,10 +31,6 @@ namespace detail
 // NOLINTBEGIN(readability-identifier-naming)
 // use std-style naming for these traits
 
-// TODO(c++20): use std::remove_cvref_t (P0550R2) when GCC >= 9.1
-template<typename T>
-using remove_cvref_t = std::remove_cv_t<std::remove_reference_t<T>>;
-
 // Type trait: is C a container with push_back (but not a string)?
 template<typename C, typename = void>
 inline constexpr bool is_push_back_range_v = false;
@@ -303,7 +299,7 @@ void load(T& tgt, Fields const& fields, tr_variant const& src)
 template<typename T, typename Fields>
 [[nodiscard]] tr_variant::Map save(T const& src, Fields const& fields)
 {
-    auto map = tr_variant::Map{ std::tuple_size_v<detail::remove_cvref_t<Fields>> };
+    auto map = tr_variant::Map{ std::tuple_size_v<std::remove_cvref_t<Fields>> };
     std::apply([&src, &map](auto const&... field) { (field.save(&src, map), ...); }, fields);
     return map;
 }

--- a/libtransmission/variant.cc
+++ b/libtransmission/variant.cc
@@ -192,8 +192,7 @@ tr_variant& tr_variant::merge(tr_variant const& that)
     that.visit(
         [this](auto const& value)
         {
-            // TODO(c++20): use std::remove_cvref_t (P0550R2) when GCC >= 9.1
-            using ValueType = std::decay_t<decltype(value)>;
+            using ValueType = std::remove_cvref_t<decltype(value)>;
 
             if constexpr (
                 std::is_same_v<ValueType, std::monostate> || std::is_same_v<ValueType, std::nullptr_t> ||

--- a/libtransmission/variant.h
+++ b/libtransmission/variant.h
@@ -308,9 +308,9 @@ public:
     template<typename Val>
     [[nodiscard]] constexpr auto* get_if() noexcept
     {
-        // TODO(c++20): use std::remove_cvref_t (P0550R2) when GCC >= 9.1
         static_assert(
-            !std::is_same_v<std::decay_t<Val>, std::string> && !std::is_same_v<std::decay_t<Val>, std::string_view>,
+            !std::is_same_v<std::remove_cvref_t<Val>, std::string> &&
+                !std::is_same_v<std::remove_cvref_t<Val>, std::string_view>,
             "not supported -- use value_if<std::string_view>() instead.");
         return std::get_if<Val>(&val_);
     }
@@ -318,9 +318,9 @@ public:
     template<typename Val>
     [[nodiscard]] constexpr auto const* get_if() const noexcept
     {
-        // TODO(c++20): use std::remove_cvref_t (P0550R2) when GCC >= 9.1
         static_assert(
-            !std::is_same_v<std::decay_t<Val>, std::string> && !std::is_same_v<std::decay_t<Val>, std::string_view>,
+            !std::is_same_v<std::remove_cvref_t<Val>, std::string> &&
+                !std::is_same_v<std::remove_cvref_t<Val>, std::string_view>,
             "not supported -- use value_if<std::string_view>() instead.");
         return const_cast<tr_variant*>(this)->get_if<Val>();
     }

--- a/tests/libtransmission/variant-test.cc
+++ b/tests/libtransmission/variant-test.cc
@@ -735,8 +735,7 @@ TEST_F(VariantTest, visitsNodesDepthFirst)
         node.visit(
             [&](auto const& val)
             {
-                // TODO(c++20): use std::remove_cvref_t (P0550R2) when GCC >= 9.1
-                using ValueType = std::decay_t<decltype(val)>;
+                using ValueType = std::remove_cvref_t<decltype(val)>;
 
                 if constexpr (
                     std::is_same_v<ValueType, bool> || //


### PR DESCRIPTION
Use `std::remove_cvref_t` now that all the boxes in our CI chain have new enough compilers.

Notes: Moved from C++17 to C++20.