### PR TITLE
fix: FTBFS on MSVC Qt5

### DIFF
--- a/tests/qt/rpc-test-fixtures.h
+++ b/tests/qt/rpc-test-fixtures.h
@@ -22,7 +22,14 @@ template<typename String>
 [[nodiscard]] QByteArray toQBA(String const& str)
 {
     auto const sv = std::string_view{ str };
-    return { sv.data(), static_cast<qsizetype>(sv.size()) };
+    return { sv.data(),
+             static_cast<
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+                 int
+#else
+                 qsizetype
+#endif
+                 >(sv.size()) };
 }
 
 class FakeReply final : public QNetworkReply


### PR DESCRIPTION
```
[328/340] Building CXX object tests\qt\CMakeFiles\qt-test-rpcclient.dir\rpcclient-test.cc.obj
FAILED: [code=2] tests/qt/CMakeFiles/qt-test-rpcclient.dir/rpcclient-test.cc.obj 
ccache C:\PROGRA~1\MICROS~2\2022\COMMUN~1\VC\Tools\MSVC\1444~1.352\bin\Hostx64\x64\cl.exe  /nologo /TP -DFMT_EXCEPTIONS=0 -DFMT_HEADER_ONLY=1 -DFMT_USE_EXCEPTIONS=0 -DQAXSERVER -DQT_AXBASE_LIB -DQT_AXCONTAINER_LIB -DQT_AXSERVER_LIB -DQT_CORE_LIB -DQT_DBUS_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_NO_DEBUG -DQT_SVG_LIB -DQT_TESTCASE_BUILDDIR=\"C:/x64-project/.build\" -DQT_TESTLIB_LIB -DQT_WIDGETS_LIB -DQT_WINEXTRAS_LIB -DSMALL_DISABLE_EXCEPTIONS=1 -DWITH_OPENSSL -IC:\x64-project\.build\tests\qt\qt-test-rpcclient_autogen\include -IC:\x64-project\.build\qt\transmission-qt-lib_autogen\include -IC:\x64-project\qt -IC:\x64-project\libtransmission-app\.. -IC:\x64-project\.build\libtransmission-app\.. -IC:\x64-project\libtransmission\.. -IC:\x64-project\.build\libtransmission\.. -external:IC:\x64-project\third-party\fmt\include -external:IC:\x64-prefix\include -external:IC:\x64-project\third-party\small\include -external:IC:\x64-project\.build\third-party\libevent.bld\pfx\include -external:IC:\x64-prefix\include\QtCore -external:IC:\x64-prefix\.\mkspecs\win32-msvc -external:IC:\x64-prefix\include\QtGui -external:IC:\x64-prefix\include\QtWidgets -external:IC:\x64-prefix\include\QtNetwork -external:IC:\x64-prefix\include\QtSvg -external:IC:\x64-prefix\include\QtWinExtras -external:IC:\x64-prefix\include\QtDBus -external:IC:\x64-prefix\include\ActiveQt -external:IC:\x64-prefix\include\QtTest -external:W0 /FS  /DWIN32 /D_WINDOWS /GR /EHsc -DWIN32 -DWINVER=0x0600 -D_WIN32_WINNT=0x0600 -DUNICODE -D_UNICODE -D_CRT_SECURE_NO_DEPRECATE -D_CRT_NONSTDC_NO_DEPRECATE -D_SCL_SECURE_NO_WARNINGS -D_WINSOCK_DEPRECATED_NO_WARNINGS /utf-8 /wd4244 /wd4267 /Zc:__cplusplus -DWIN32_LEAN_AND_MEAN -DNOMINMAX -Z7 /O2 /Ob1 /DNDEBUG -std:c++20 -MD /W4 /utf-8 /showIncludes /Fotests\qt\CMakeFiles\qt-test-rpcclient.dir\rpcclient-test.cc.obj /Fdtests\qt\CMakeFiles\qt-test-rpcclient.dir\ /FS -c C:\x64-project\tests\qt\rpcclient-test.cc
C:\x64-project\tests\qt\rpc-test-fixtures.h(25): error C2398: Element '2': conversion from 'qsizetype' to 'int' requires a narrowing conversion
C:\x64-project\tests\qt\rpc-test-fixtures.h(25): note: the template instantiation context (the oldest one first) is
C:\x64-project\tests\qt\rpcclient-test.cc(124): note: see reference to function template instantiation 'void FakeReply::addRawHeader<std::string_view,char[16]>(const StringA &,const StringB (&))' being compiled
        with
        [
            StringA=std::string_view,
            StringB=char [16]
        ]
C:\x64-project\tests\qt\rpc-test-fixtures.h(66): note: see reference to function template instantiation 'QByteArray toQBA<StringA>(const String &)' being compiled
        with
        [
            StringA=std::string_view,
            String=std::string_view
        ]
```