### PR TITLE
refactor: convert `tr_sys_path_capacity` members to unsigned

### DIFF
--- a/libtransmission/file.h
+++ b/libtransmission/file.h
@@ -102,8 +102,8 @@ struct tr_sys_path_info
 
 struct tr_sys_path_capacity
 {
-    int64_t free = -1;
-    int64_t total = -1;
+    uint64_t free = {};
+    uint64_t total = {};
 };
 
 /**


### PR DESCRIPTION
Fixes some `bugprone-narrowing-conversions` warnings.

P.S. With our new shiny compiler in the DragonflyBSD CI, we can *finally* start moving to `std::filesystem`, and do away with all this mess.

Edit: Actually, how about I just go ahead and try it out. If that fails then we merge this PR.