### PR TITLE
fix: convert string to u8 before passing into `std::filesystem::space`

### DIFF
--- a/gtk/FreeSpaceLabel.cc
+++ b/gtk/FreeSpaceLabel.cc
@@ -54,7 +54,7 @@ bool FreeSpaceLabel::Impl::on_freespace_timer()
     }
 
     auto ec = std::error_code{};
-    auto const capacity = std::filesystem::space(dir_, ec);
+    auto const capacity = std::filesystem::space(std::filesystem::u8path(dir_), ec);
     auto const text = !ec ?
         fmt::format(fmt::runtime(_("{disk_space} free")), fmt::arg("disk_space", tr_strlsize(capacity.available))) :
         _("Error");

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -2232,7 +2232,7 @@ using SessionAccessors = std::pair<SessionGetter, SessionSetter>;
         [](tr_session const& src) -> tr_variant
         {
             auto ec = std::error_code{};
-            auto const space = std::filesystem::space(src.downloadDir(), ec);
+            auto const space = std::filesystem::space(std::filesystem::u8path(src.downloadDir()), ec);
             return !ec ? space.available : tr_variant{ -1 };
         },
         nullptr);
@@ -2737,7 +2737,7 @@ using SessionAccessors = std::pair<SessionGetter, SessionSetter>;
 
     // get the free space
     auto ec = std::error_code{};
-    auto const capacity = std::filesystem::space(*path, ec);
+    auto const capacity = std::filesystem::space(std::filesystem::u8path(*path), ec);
 
     // response
     args_out.try_emplace(TR_KEY_path, *path);


### PR DESCRIPTION
Between the 2 options listed at https://github.com/transmission/transmission/pull/8249#issuecomment-3815576989, I figured we don't need to reinstate `tr_sys_path_get_capacity()` since it's just 3 instances.

But we should probably pause migrating to `std::filesystem` before we sort out the strings.