### PR TITLE
fix: crash on fail to update blocklist on GTK when assertions are enabled

### DIFF
--- a/gtk/Session.cc
+++ b/gtk/Session.cc
@@ -1360,7 +1360,7 @@ void Session::blocklist_update()
                 gtr_pref_int_set(TR_KEY_blocklist_date, tr_time());
             }
 
-            impl_->signal_blocklist_updated().emit(*n_rules >= 0);
+            impl_->signal_blocklist_updated().emit(n_rules >= 0);
         });
 }
 


### PR DESCRIPTION
Fixes #8272.

Cherry-picked for 4.1.x by #8273.

The bug was introduced in #7938 and was first released in 4.1.0-beta.5.
