### PR TITLE
fix: crash after failing to delete a torrent on macOS

### DIFF
--- a/macosx/Torrent.mm
+++ b/macosx/Torrent.mm
@@ -88,7 +88,10 @@ bool trashDataFile(char const* filename, void* /*user_data*/, tr_error* error)
         NSError* localError;
         if (![Torrent trashFile:@(filename) error:&localError])
         {
-            error->set(static_cast<int>(localError.code), localError.description.UTF8String);
+            if (error != nullptr)
+            {
+                error->set(static_cast<int>(localError.code), localError.description.UTF8String);
+            }
             return false;
         }
     }


### PR DESCRIPTION
Fixes #8267 for 4.1.x.

This is already fixed in `main` for 4.2.x as a side-effect of #8229.

This bug was introduced in #6198 and was first released in 4.1.0-beta.1.

Notes: Fixed a `4.1.0` crash that occurred if deleting a torrent's files on macOS  returned a system error.