### PR TITLE
fix use different icon filenames per-client

### DIFF
--- a/gtk/CMakeLists.txt
+++ b/gtk/CMakeLists.txt
@@ -226,6 +226,7 @@ set(ICON_NAME_REGEX "^([^_]+)_([^_]+)_([^_]+)_(.+)$")
 foreach(ICON ${PUBLIC_ICONS})
     string(REGEX REPLACE ${ICON_NAME_REGEX} "\\1/\\3/\\2" ICON_DIR ${ICON})
     string(REGEX REPLACE ${ICON_NAME_REGEX} "\\4" ICON_NAME ${ICON})
+    string(REGEX REPLACE "^transmission" "transmission-gtk" ICON_NAME ${ICON_NAME})
     install(
         FILES ${SOURCE_ICONS_DIR}/${ICON}
         DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/${ICON_DIR}/

--- a/gtk/transmission-gtk.desktop.in
+++ b/gtk/transmission-gtk.desktop.in
@@ -5,7 +5,7 @@ Comment=Download and share files over BitTorrent
 # Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 Keywords=torrents;downloading;uploading;share;sharing;
 Exec=transmission-gtk %U
-Icon=transmission
+Icon=transmission-gtk
 Terminal=false
 TryExec=transmission-gtk
 Type=Application

--- a/qt/CMakeLists.txt
+++ b/qt/CMakeLists.txt
@@ -271,6 +271,7 @@ set(ICON_NAME_REGEX "^([^_]+)_([^_]+)_([^_]+)_(.+)$")
 foreach(ICON ${PUBLIC_ICONS})
     string(REGEX REPLACE ${ICON_NAME_REGEX} "\\1/\\3/\\2" ICON_DIR ${ICON})
     string(REGEX REPLACE ${ICON_NAME_REGEX} "\\4" ICON_NAME ${ICON})
+    string(REGEX REPLACE "^transmission" "transmission-qt" ICON_NAME ${ICON_NAME})
     install(
         FILES ${SOURCE_ICONS_DIR}/${ICON}
         DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/${ICON_DIR}/

--- a/qt/transmission-qt.desktop
+++ b/qt/transmission-qt.desktop
@@ -5,7 +5,7 @@ Comment=Download and share files over BitTorrent
 # Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 Keywords=torrents;downloading;uploading;share;sharing;
 Exec=transmission-qt %U
-Icon=transmission
+Icon=transmission-qt
 Terminal=false
 Type=Application
 MimeType=application/x-bittorrent;x-scheme-handler/magnet;


### PR DESCRIPTION
Fixes #8254.

This bug was introduced in #6683 and first release in 4.1.0-beta.1.

Notes: Fixed a `4.1.0` packaging error that prevented the Qt and GTK clients from being installed side-by-side on Arch.