### PR TITLE
refactor: use `std::filesystem` for `tr_sys_path_resolve()`

### DIFF
--- a/libtransmission/file-posix.cc
+++ b/libtransmission/file-posix.cc
@@ -226,24 +226,6 @@ bool tr_sys_path_is_same(std::string_view const path1, std::string_view const pa
     return ret;
 }
 
-std::string tr_sys_path_resolve(std::string_view path, tr_error* error)
-{
-    auto const szpath = tr_pathbuf{ path };
-    auto buf = std::array<char, PATH_MAX>{};
-
-    if (auto const* const ret = realpath(szpath, std::data(buf)); ret != nullptr)
-    {
-        return ret;
-    }
-
-    if (error != nullptr)
-    {
-        error->set_from_errno(errno);
-    }
-
-    return {};
-}
-
 std::string_view tr_sys_path_basename(std::string_view path, tr_error* /*error*/)
 {
     // As per the basename() manpage:

--- a/libtransmission/file.cc
+++ b/libtransmission/file.cc
@@ -3,6 +3,8 @@
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.
 
+#include <filesystem>
+#include <system_error>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -10,6 +12,25 @@
 #include "libtransmission/error.h"
 #include "libtransmission/file.h"
 #include "libtransmission/tr-assert.h"
+
+std::string tr_sys_path_resolve(std::string_view path, tr_error* error)
+{
+    auto ec = std::error_code{};
+    auto const canonical_path = std::filesystem::canonical(tr_u8path(path), ec);
+
+    if (ec)
+    {
+        if (error != nullptr)
+        {
+            error->set(ec.value(), ec.message());
+        }
+
+        return {};
+    }
+
+    auto const u8_path = canonical_path.u8string();
+    return { std::begin(u8_path), std::end(u8_path) };
+}
 
 std::vector<std::string> tr_sys_dir_get_files(
     std::string_view folder,


### PR DESCRIPTION
Use `std::filesystem` for `tr_sys_path_remove()` so that we have one implementation instead of two.

Notes: Moved from C++17 to C++20.