### PR TITLE
fix: put torrent in "recently active" set after changing queue position

### DIFF
--- a/libtransmission/torrent-queue.cc
+++ b/libtransmission/torrent-queue.cc
@@ -63,20 +63,20 @@ size_t tr_torrent_queue::get_pos(tr_torrent_id_t const id)
     return pos_cache_[uid];
 }
 
-void tr_torrent_queue::set_pos(tr_torrent_id_t const id, size_t new_pos)
+bool tr_torrent_queue::set_pos(tr_torrent_id_t const id, size_t new_pos)
 {
     auto const old_pos = get_pos(id);
     auto const n_queue = std::size(queue_);
     if (old_pos >= n_queue || queue_[old_pos] != id)
     {
-        return;
+        return false;
     }
 
     new_pos = std::min(new_pos, n_queue - 1U);
 
     if (old_pos == new_pos)
     {
-        return;
+        return false;
     }
 
     auto const begin = std::begin(queue_);
@@ -91,6 +91,7 @@ void tr_torrent_queue::set_pos(tr_torrent_id_t const id, size_t new_pos)
     {
         std::rotate(old_it, next_it, std::next(new_it));
     }
+    return true;
 }
 
 bool tr_torrent_queue::to_file() const

--- a/libtransmission/torrent-queue.h
+++ b/libtransmission/torrent-queue.h
@@ -41,7 +41,7 @@ public:
     void remove(tr_torrent_id_t id);
 
     [[nodiscard]] size_t get_pos(tr_torrent_id_t id);
-    void set_pos(tr_torrent_id_t id, size_t new_pos);
+    bool set_pos(tr_torrent_id_t id, size_t new_pos);
 
     bool to_file() const; // NOLINT(modernize-use-nodiscard)
     [[nodiscard]] std::vector<std::string> from_file();

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -991,9 +991,14 @@ struct tr_torrent
         return session->torrent_queue().get_pos(id());
     }
 
-    void set_queue_position(size_t new_pos) // NOLINT(readability-make-member-function-const)
+    bool set_queue_position(size_t new_pos) // NOLINT(readability-make-member-function-const)
     {
-        session->torrent_queue().set_pos(id(), new_pos);
+        if (!session->torrent_queue().set_pos(id(), new_pos))
+        {
+            return false;
+        }
+        mark_changed();
+        return true;
     }
 
     static constexpr struct


### PR DESCRIPTION
~Fixes #8279.~ This fix is not correct, will be reverted.
Regression from #7332.