### PR TITLE
fix: periodically save queue position like other data files

### DIFF
--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -723,6 +723,7 @@ void tr_session::on_save_timer()
     }
 
     stats().save();
+    torrent_queue().to_file();
 }
 
 void tr_session::initImpl(init_data& data)

--- a/libtransmission/torrent-queue.cc
+++ b/libtransmission/torrent-queue.cc
@@ -25,6 +25,7 @@ using namespace std::literals;
 size_t tr_torrent_queue::add(tr_torrent_id_t const id)
 {
     queue_.push_back(id);
+    set_dirty();
     return std::size(queue_) - 1U;
 }
 
@@ -41,6 +42,7 @@ void tr_torrent_queue::remove(tr_torrent_id_t const id)
         auto const remove_it = std::remove(std::begin(queue_), std::end(queue_), id);
         queue_.erase(remove_it, std::end(queue_));
     }
+    set_dirty();
 }
 
 size_t tr_torrent_queue::get_pos(tr_torrent_id_t const id)
@@ -99,11 +101,18 @@ std::vector<tr_torrent_id_t> tr_torrent_queue::set_pos(tr_torrent_id_t const id,
         std::rotate(old_it, old_next_it, new_next_it);
     }
 
+    set_dirty();
     return ret;
 }
 
-bool tr_torrent_queue::to_file() const
+bool tr_torrent_queue::to_file()
 {
+    if (!is_dirty())
+    {
+        return false;
+    }
+    set_dirty(false);
+
     auto vec = tr_variant::Vector{};
     vec.reserve(std::size(queue_));
     for (auto const id : queue_)

--- a/libtransmission/torrent-queue.h
+++ b/libtransmission/torrent-queue.h
@@ -43,15 +43,27 @@ public:
     [[nodiscard]] size_t get_pos(tr_torrent_id_t id);
     [[nodiscard]] std::vector<tr_torrent_id_t> set_pos(tr_torrent_id_t id, size_t new_pos);
 
-    bool to_file() const; // NOLINT(modernize-use-nodiscard)
+    bool to_file(); // NOLINT(modernize-use-nodiscard)
     [[nodiscard]] std::vector<std::string> from_file();
 
     static auto constexpr MinQueuePosition = size_t{};
     static auto constexpr MaxQueuePosition = ~size_t{};
 
 private:
+    [[nodiscard]] constexpr auto is_dirty() const noexcept
+    {
+        return is_dirty_;
+    }
+
+    constexpr void set_dirty(bool is_dirty = true) noexcept
+    {
+        is_dirty_ = is_dirty;
+    }
+
     std::vector<tr_torrent_id_t> queue_;
     std::vector<size_t> pos_cache_;
+
+    bool is_dirty_ = false;
 
     Mediator const& mediator_;
 };


### PR DESCRIPTION
Cherry-pick #8299.

Notes: Fixed a `4.1.0` bug that caused torrents' queuing order to sometimes be lost between sessions.