### PR TITLE
perf: faster arrow key navigation in torrent list

### DIFF
--- a/macosx/TorrentTableView.mm
+++ b/macosx/TorrentTableView.mm
@@ -28,14 +28,19 @@ static CGFloat const kErrorImageSize = 20.0;
 
 static NSTimeInterval const kToggleProgressSeconds = 0.175;
 
-// return the indexes that are in either lhs or rhs, but not both
-static NSIndexSet* SymmetricDifference(NSIndexSet* lhs, NSIndexSet* rhs)
-{
-    NSMutableIndexSet* result = [lhs mutableCopy];
-    [result addIndexes:rhs];
+@interface NSIndexSet (Transmission)
+- (NSIndexSet*)symmetricDifference:(NSIndexSet*)otherSet;
+@end
 
-    [lhs enumerateIndexesUsingBlock:^(NSUInteger idx, BOOL*) {
-        if ([rhs containsIndex:idx])
+@implementation NSIndexSet (Transmission)
+
+- (NSIndexSet*)symmetricDifference:(NSIndexSet*)otherSet
+{
+    NSMutableIndexSet* result = [self mutableCopy];
+    [result addIndexes:otherSet];
+
+    [self enumerateIndexesUsingBlock:^(NSUInteger idx, BOOL*) {
+        if ([otherSet containsIndex:idx])
         {
             [result removeIndex:idx];
         }
@@ -43,6 +48,8 @@ static NSIndexSet* SymmetricDifference(NSIndexSet* lhs, NSIndexSet* rhs)
 
     return [result copy];
 }
+
+@end
 
 @interface TorrentTableView ()
 
@@ -452,7 +459,7 @@ static NSIndexSet* SymmetricDifference(NSIndexSet* lhs, NSIndexSet* rhs)
     NSIndexSet* newSelection = self.selectedRowIndexes;
     self.fSelectedRowIndexes = newSelection;
 
-    NSIndexSet* changedRows = SymmetricDifference(oldSelection, newSelection);
+    NSIndexSet* changedRows = [oldSelection symmetricDifference:newSelection];
     if (changedRows.count > 0)
     {
         if (!self.fPendingSelectionReloadRows)

--- a/macosx/TorrentTableView.mm
+++ b/macosx/TorrentTableView.mm
@@ -29,7 +29,7 @@ static CGFloat const kErrorImageSize = 20.0;
 static NSTimeInterval const kToggleProgressSeconds = 0.175;
 
 // return the indexes that are in either lhs or rhs, but not both
-static NSMutableIndexSet* SymmetricDifference(NSIndexSet* lhs, NSIndexSet* rhs)
+static NSIndexSet* SymmetricDifference(NSIndexSet* lhs, NSIndexSet* rhs)
 {
     NSMutableIndexSet* result = [lhs mutableCopy];
     [result addIndexes:rhs];
@@ -41,7 +41,7 @@ static NSMutableIndexSet* SymmetricDifference(NSIndexSet* lhs, NSIndexSet* rhs)
         }
     }];
 
-    return result;
+    return [result copy];
 }
 
 @interface TorrentTableView ()

--- a/macosx/TorrentTableView.mm
+++ b/macosx/TorrentTableView.mm
@@ -452,7 +452,8 @@ static NSIndexSet* SymmetricDifference(NSIndexSet* lhs, NSIndexSet* rhs)
     NSIndexSet* newSelection = self.selectedRowIndexes;
     self.fSelectedRowIndexes = newSelection;
 
-    if (NSMutableIndexSet* changedRows = SymmetricDifference(oldSelection, newSelection); changedRows.count > 0)
+    NSIndexSet* changedRows = SymmetricDifference(oldSelection, newSelection);
+    if (changedRows.count > 0)
     {
         if (!self.fPendingSelectionReloadRows)
         {


### PR DESCRIPTION
Fixes #8307.

Needs macOS review from @transmission/contributors 

Notes: Fixed slow keyboard navigation in the main window's torrent list.

This PR addresses two hotspots revealed in the logs provided by @lolgear in 8307:

1. All visible rows were rebuilt when selection changed in `TorrentTableView`. In practice, we only need to update the ones whose selection changed.
2. The update happened immediately, forcing redundant recalculations of the same torrents over and over. This PR coalesces any redundant selection changes that happen during the same run-loop iteration.

Notes: Improved UI code to use less CPU.