### PR TITLE
Fix: torrent-metainfo unexpected: path

### DIFF
--- a/libtransmission/torrent-metainfo.cc
+++ b/libtransmission/torrent-metainfo.cc
@@ -251,6 +251,7 @@ struct MetainfoHandler final : public tr::benc::BasicHandler<MaxBencDepth>
             pathIs(InfoKey, UniqueKey) || //
             pathIs(ProfilesKey, HeightKey) || //
             pathIs(ProfilesKey, WidthKey) || //
+            pathIs(UidKey) || //
             pathIs(WidthKey) || //
             pathStartsWith(AzureusPropertiesKey) || //
             pathStartsWith(InfoKey, FileDurationKey) || //
@@ -312,6 +313,13 @@ struct MetainfoHandler final : public tr::benc::BasicHandler<MaxBencDepth>
                 // TODO https://github.com/transmission/transmission/issues/458
             }
             else if (
+                pathIs(InfoKey, FilesKey, std::optional<std::string_view>(), Crc32Key) || //
+                pathIs(InfoKey, FilesKey, std::optional<std::string_view>(), Ed2kKey) || //
+                pathIs(InfoKey, FilesKey, std::optional<std::string_view>(), FilehashKey) || //
+                pathIs(InfoKey, FilesKey, std::optional<std::string_view>(), Md5Key) || //
+                pathIs(InfoKey, FilesKey, std::optional<std::string_view>(), Md5sumKey) || //
+                pathIs(InfoKey, FilesKey, std::optional<std::string_view>(), MtimeKey) || // (why a string?)
+                pathIs(InfoKey, FilesKey, std::optional<std::string_view>(), Sha1Key) || //
                 pathIs(InfoKey, FilesKey, ""sv, Crc32Key) || //
                 pathIs(InfoKey, FilesKey, ""sv, Ed2kKey) || //
                 pathIs(InfoKey, FilesKey, ""sv, FilehashKey) || //
@@ -407,6 +415,7 @@ struct MetainfoHandler final : public tr::benc::BasicHandler<MaxBencDepth>
         else if (
             pathIs(ChecksumKey) || //
             pathIs(ErrCallbackKey) || //
+            pathIs(InfoKey, AttrKey) || //
             pathIs(InfoKey, CrossSeedEntryKey) || //
             pathIs(InfoKey, Ed2kKey) || //
             pathIs(InfoKey, EntropyKey) || //

--- a/libtransmission/torrent-metainfo.cc
+++ b/libtransmission/torrent-metainfo.cc
@@ -212,7 +212,7 @@ struct MetainfoHandler final : public tr::benc::BasicHandler<MaxBencDepth>
             {
                 file_length_ = value;
             }
-            else if (pathIs(InfoKey, FilesKey, ""sv, MtimeKey))
+            else if (pathIs(InfoKey, FilesKey, ArrayKey, MtimeKey))
             {
                 // unused by Transmission
             }
@@ -244,6 +244,7 @@ struct MetainfoHandler final : public tr::benc::BasicHandler<MaxBencDepth>
             tm_.is_v2_ = value == 2;
         }
         else if (
+            pathIs(CodepageKey) || //
             pathIs(DurationKey) || //
             pathIs(EncodedRateKey) || //
             pathIs(HeightKey) || //
@@ -313,20 +314,13 @@ struct MetainfoHandler final : public tr::benc::BasicHandler<MaxBencDepth>
                 // TODO https://github.com/transmission/transmission/issues/458
             }
             else if (
-                pathIs(InfoKey, FilesKey, std::optional<std::string_view>(), Crc32Key) || //
-                pathIs(InfoKey, FilesKey, std::optional<std::string_view>(), Ed2kKey) || //
-                pathIs(InfoKey, FilesKey, std::optional<std::string_view>(), FilehashKey) || //
-                pathIs(InfoKey, FilesKey, std::optional<std::string_view>(), Md5Key) || //
-                pathIs(InfoKey, FilesKey, std::optional<std::string_view>(), Md5sumKey) || //
-                pathIs(InfoKey, FilesKey, std::optional<std::string_view>(), MtimeKey) || // (why a string?)
-                pathIs(InfoKey, FilesKey, std::optional<std::string_view>(), Sha1Key) || //
-                pathIs(InfoKey, FilesKey, ""sv, Crc32Key) || //
-                pathIs(InfoKey, FilesKey, ""sv, Ed2kKey) || //
-                pathIs(InfoKey, FilesKey, ""sv, FilehashKey) || //
-                pathIs(InfoKey, FilesKey, ""sv, Md5Key) || //
-                pathIs(InfoKey, FilesKey, ""sv, Md5sumKey) || //
-                pathIs(InfoKey, FilesKey, ""sv, MtimeKey) || // (why a string?)
-                pathIs(InfoKey, FilesKey, ""sv, Sha1Key))
+                pathIs(InfoKey, FilesKey, ArrayKey, Crc32Key) || //
+                pathIs(InfoKey, FilesKey, ArrayKey, Ed2kKey) || //
+                pathIs(InfoKey, FilesKey, ArrayKey, FilehashKey) || //
+                pathIs(InfoKey, FilesKey, ArrayKey, Md5Key) || //
+                pathIs(InfoKey, FilesKey, ArrayKey, Md5sumKey) || //
+                pathIs(InfoKey, FilesKey, ArrayKey, MtimeKey) || // (why a string?)
+                pathIs(InfoKey, FilesKey, ArrayKey, Sha1Key))
             {
                 // unused by Transmission
             }
@@ -562,6 +556,7 @@ private:
     static constexpr std::string_view AzureusPrivatePropertiesKey = "azureus_private_properties"sv;
     static constexpr std::string_view AzureusPropertiesKey = "azureus_properties"sv;
     static constexpr std::string_view ChecksumKey = "checksum"sv;
+    static constexpr std::string_view CodepageKey = "codepage"sv;
     static constexpr std::string_view CollectionsKey = "collections"sv;
     static constexpr std::string_view CommentKey = "comment"sv;
     static constexpr std::string_view CommentUtf8Key = "comment.utf-8"sv;


### PR DESCRIPTION
At Transmission startup, I get those warnings, coming from different torrents.
```
2026-02-01 18:23:07 +0000 torrent-metainfo.cc:448 [Avertissement] torrent-metainfo.cc:448: unexpected: path '[][info][files][][ed2k]', str '้+“ว@Qื
กป$ฆ'
2026-02-01 18:23:08 +0000 torrent-metainfo.cc:448 [Avertissement] torrent-metainfo.cc:448: unexpected: path '[][info][files][][filehash]', str '9lฝฏSปนทห‘Uื@3K+C'
2026-02-01 18:23:10 +0000 torrent-metainfo.cc:448 [Avertissement] torrent-metainfo.cc:448: unexpected: path '[][info][files][][ed2k]', str '¿§QA†8ˆ�„ª”,Š¾˜Û'
2026-02-01 18:23:11 +0000 torrent-metainfo.cc:448 [Avertissement] torrent-metainfo.cc:448: unexpected: path '[][info][files][][filehash]', str 'Ęu“ą7Łź\„¶×Tń¸“ęØ'
2026-02-01 18:23:17 +0000 torrent-metainfo.cc:448 [Avertissement] torrent-metainfo.cc:448: unexpected: path '[][info][attr]', str 'x'
2026-02-01 18:23:17 +0000 torrent-metainfo.cc:271 [Avertissement] torrent-metainfo.cc:271: unexpected: path '[][uid]', int '56789'
2026-02-01 18:23:17 +0000 torrent-metainfo.cc:271 [Avertissement] torrent-metainfo.cc:271: unexpected: path '[][uid]', int '56788'
```

To address the warnings, I add the paths to the unhandled list.

Notes: Silenced some unnecessary warnings when parsing unexpected torrent metainfo.