### PR TITLE
docs: update references in rpc-spec.md

### DIFF
--- a/docs/rpc-spec.md
+++ b/docs/rpc-spec.md
@@ -120,7 +120,7 @@ matches it to one of the whitelisted names. Regardless of host whitelist
 content, `localhost` and `localhost.` domain names as well as all the IP
 addresses are always implicitly allowed.
 
-For more information on configuration, see settings.json documentation for
+For more information on configuration, see [Editing Configuration Files](Editing-Configuration-Files.md#rpc) documentation for
 `rpc_host_whitelist_enabled` and `rpc_host_whitelist` keys.
 
 #### 2.2.3 Authentication
@@ -591,7 +591,7 @@ Response parameters: `path`, `name`, and `id`, holding the torrent ID integer
 | `peer_port` | number | port number
 | `pex_enabled` | boolean | true means allow PEX in public torrents
 | `port_forwarding_enabled` | boolean | true means ask upstream router to forward the configured peer port to transmission using UPnP or NAT-PMP
-| `preferred_transports` | string[] | preference of transport protocols, see `settings.json` for details
+| `preferred_transports` | string[] | preference of transport protocols, see [Editing Configuration Files](Editing-Configuration-Files.md#misc) for details
 | `queue_stalled_enabled` | boolean | whether or not to consider idle torrents as stalled
 | `queue_stalled_minutes` | number | torrents that are idle for N minuets aren't counted toward `seed_queue_size` or `download_queue_size`
 | `rename_partial_files` | boolean | true means append `.part` to incomplete files


### PR DESCRIPTION
This updates references (links) in the RPC spec to refer to the appropriate information in `Editing-Configuration-Files.md`, per [#8304](https://github.com/transmission/transmission/issues/8304).

Fixes #8304