### PR TITLE
docs: add PR release notes guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,8 +62,6 @@ When submitting a pull request, please add a one-sentence paragraph that begins 
   - BAD: "address minor clang warning"
   - BAD: "Refactor: add libtransmission::Values."
 
-Notes: address minor clang warning
-
 ## Considerations
 
 - Prefer commonly-used tools over bespoke ones, e.g. use `std::list` instead of rolling your own list. This simplifies the code and makes it easier for other contributors to work with.


### PR DESCRIPTION
Add guidelines on what to include in release notes.

I put in some serious work to make the [4.1.0 release notes](https://github.com/transmission/transmission/releases/tag/4.1.0) readable and they were still a mess. :smile_cat:

I believe *all* of the @transmission/contributors -- myself included -- had some pretty terrible notes.  Some bad examples that stood out:

- I had these two: "Refactor: add libtransmission::Values. ([#6215](https://github.com/transmission/transmission/pull/6215)) and "fix: use URL base path ([#8078](https://github.com/transmission/transmission/pull/8078))"
- @nevack had this one: "Default initialize sleep callback duration in tr_verify_worker.  ([#6789](https://github.com/transmission/transmission/pull/6789))"
- @Coeur had this one: "remove TR_ASSERT(now >= latest) ([#7018](https://github.com/transmission/transmission/pull/7018))"