### PR TITLE
Rewrite file priority cell on stack view to increase layout performance.

### DIFF
--- a/macosx/FilePriorityCellView.mm
+++ b/macosx/FilePriorityCellView.mm
@@ -12,6 +12,10 @@ static CGFloat const kImageOverlap = 1.0;
 @interface FilePriorityCellView ()
 @property(nonatomic, weak) NSSegmentedControl* segmentedControl;
 @property(nonatomic, weak) NSView* iconsContainerView;
+@property(nonatomic, strong) NSStackView* stackView;
+@property(nonatomic, strong) NSImageView* lowPriorityView;
+@property(nonatomic, strong) NSImageView* mediumPriorityView;
+@property(nonatomic, strong) NSImageView* highPriorityView;
 @property(nonatomic, strong) NSTrackingArea* trackingArea;
 @end
 
@@ -62,9 +66,53 @@ static CGFloat const kImageOverlap = 1.0;
             [iconsContainerView.heightAnchor constraintLessThanOrEqualToAnchor:self.heightAnchor],
         ]];
 
+        [self updateIconsContainerView];
+
         _hovered = NO;
     }
     return self;
+}
+
+- (void)updateIconsContainerView
+{
+    NSImage* lowPriority = [NSImage imageNamed:@"PriorityLowTemplate"];
+    NSImage* mediumPriority = [NSImage imageNamed:@"PriorityNormalTemplate"];
+    NSImage* highPriority = [NSImage imageNamed:@"PriorityHighTemplate"];
+
+    NSImageView* lowPriorityView = [[NSImageView alloc] init];
+    lowPriorityView.image = lowPriority;
+    NSImageView* mediumPriorityView = [[NSImageView alloc] init];
+    mediumPriorityView.image = mediumPriority;
+    NSImageView* highPriorityView = [[NSImageView alloc] init];
+    highPriorityView.image = highPriority;
+
+    NSStackView* stackView = [[NSStackView alloc] init];
+    stackView.spacing = -kImageOverlap;
+
+    [stackView addArrangedSubview:lowPriorityView];
+    [stackView addArrangedSubview:mediumPriorityView];
+    [stackView addArrangedSubview:highPriorityView];
+
+    self.stackView = stackView;
+    self.lowPriorityView = lowPriorityView;
+    self.mediumPriorityView = mediumPriorityView;
+    self.highPriorityView = highPriorityView;
+
+    [self.iconsContainerView addSubview:stackView];
+
+    __auto_type view = stackView;
+    __auto_type superview = stackView.superview;
+    view.translatesAutoresizingMaskIntoConstraints = NO;
+
+    CGFloat height = lowPriority.size.height;
+
+    [NSLayoutConstraint activateConstraints:@[
+        [view.leadingAnchor constraintEqualToAnchor:superview.leadingAnchor],
+        [view.trailingAnchor constraintEqualToAnchor:superview.trailingAnchor],
+        [view.topAnchor constraintEqualToAnchor:superview.topAnchor],
+        [view.bottomAnchor constraintEqualToAnchor:superview.bottomAnchor],
+        [view.heightAnchor constraintEqualToConstant:height]
+    ]];
 }
 
 - (void)setNode:(FileListNode*)node
@@ -118,73 +166,18 @@ static CGFloat const kImageOverlap = 1.0;
 
 - (void)updatePriorityIcons:(NSSet*)priorities
 {
-    // Remove all existing image views
-    for (NSView* subview in self.iconsContainerView.subviews)
-    {
-        [subview removeFromSuperview];
-    }
-
     NSUInteger const count = priorities.count;
-    NSMutableArray* images = [NSMutableArray arrayWithCapacity:MAX(count, 1u)];
-
     if (count == 0)
     {
-        NSImage* image = [[NSImage imageNamed:@"PriorityNormalTemplate"] imageWithColor:NSColor.lightGrayColor];
-        [images addObject:image];
+        self.lowPriorityView.hidden = YES;
+        self.mediumPriorityView.hidden = NO;
+        self.highPriorityView.hidden = YES;
     }
     else
     {
-        NSColor* priorityColor = self.backgroundStyle == NSBackgroundStyleEmphasized ? NSColor.whiteColor : NSColor.darkGrayColor;
-
-        if ([priorities containsObject:@(TR_PRI_LOW)])
-        {
-            NSImage* image = [[NSImage imageNamed:@"PriorityLowTemplate"] imageWithColor:priorityColor];
-            [images addObject:image];
-        }
-        if ([priorities containsObject:@(TR_PRI_NORMAL)])
-        {
-            NSImage* image = [[NSImage imageNamed:@"PriorityNormalTemplate"] imageWithColor:priorityColor];
-            [images addObject:image];
-        }
-        if ([priorities containsObject:@(TR_PRI_HIGH)])
-        {
-            NSImage* image = [[NSImage imageNamed:@"PriorityHighTemplate"] imageWithColor:priorityColor];
-            [images addObject:image];
-        }
-    }
-
-    NSView* previousView = nil;
-
-    for (NSImage* image in images)
-    {
-        NSImageView* imageView = [[NSImageView alloc] initWithFrame:NSZeroRect];
-        imageView.translatesAutoresizingMaskIntoConstraints = NO;
-        imageView.image = image;
-        [self.iconsContainerView addSubview:imageView];
-
-        NSSize const imageSize = image.size;
-
-        [NSLayoutConstraint activateConstraints:@[
-            [imageView.widthAnchor constraintEqualToConstant:imageSize.width],
-            [imageView.heightAnchor constraintEqualToConstant:imageSize.height],
-            [imageView.centerYAnchor constraintEqualToAnchor:self.iconsContainerView.centerYAnchor],
-        ]];
-
-        if (previousView == nil)
-        {
-            [imageView.leadingAnchor constraintEqualToAnchor:self.iconsContainerView.leadingAnchor].active = YES;
-        }
-        else
-        {
-            [imageView.leadingAnchor constraintEqualToAnchor:previousView.trailingAnchor constant:-kImageOverlap].active = YES;
-        }
-
-        previousView = imageView;
-    }
-
-    if (previousView)
-    {
-        [previousView.trailingAnchor constraintEqualToAnchor:self.iconsContainerView.trailingAnchor].active = YES;
+        self.lowPriorityView.hidden = [priorities containsObject:@(TR_PRI_LOW)] == NO;
+        self.mediumPriorityView.hidden = [priorities containsObject:@(TR_PRI_NORMAL)] == NO;
+        self.highPriorityView.hidden = [priorities containsObject:@(TR_PRI_HIGH)] == NO;
     }
 }
 
@@ -224,7 +217,11 @@ static CGFloat const kImageOverlap = 1.0;
 - (void)setBackgroundStyle:(NSBackgroundStyle)backgroundStyle
 {
     [super setBackgroundStyle:backgroundStyle];
-    [self updateDisplay];
+
+    NSColor* priorityColor = backgroundStyle == NSBackgroundStyleEmphasized ? NSColor.whiteColor : NSColor.darkGrayColor;
+    self.lowPriorityView.contentTintColor = priorityColor;
+    self.mediumPriorityView.contentTintColor = priorityColor;
+    self.highPriorityView.contentTintColor = priorityColor;
 }
 
 - (void)updateTrackingAreas


### PR DESCRIPTION
Rewriting `FilePriorityCellView` on stack view to increase layout performance.

Further improvements:

 - [ ] Cache or even remove NSSegmentedControl as very expensive in layout on old ( Intel ) machines.
 - [ ] Decrease manual ( or duplicate ) work in FileOutlineController.
 
 ### Snippet

I checked with this snippet:

```objective-c++
#import <mach/mach_time.h>

// Inside -(void)updateDisplay {
static uint64_t totalNanoseconds = 0;
static uint64_t callCount = 0;

uint64_t start = mach_absolute_time();

// --- body of updateDisplay... ---

uint64_t end = mach_absolute_time();

mach_timebase_info_data_t info;
mach_timebase_info(&info);
uint64_t elapsedNano = (end - start) * info.numer / info.denom;

totalNanoseconds += elapsedNano;
callCount++;

// Average time every 500 calls (scrolling).
if (callCount % 500 == 0) {
    NSLog(@"[PERF_TEST] Calls: %llu | Avg time per cell: %.3f ms", 
          callCount, (double)totalNanoseconds / callCount / 1000000.0);
}
// }
// [self updateColors];
// ...
// } // end of -(void)updateDisplay
```

### Results

| Total Rendered Cells | Before Optimization (main) | After Optimization (This PR) | Speedup / Improvement |
|---|---|---|---|
| 500 cells | 0.790 ms | 0.007 ms | -99.1% time spent |
| 1,000 cells | 0.818 ms | 0.005 ms | -99.4% time spent |
| 1,500 cells | 0.833 ms | 0.005 ms | -99.4% time spent |
| 2,000 cells | 0.839 ms | 0.005 ms | -99.4% time spent |
| 2,500 cells | 0.840 ms | 0.004 ms | -99.5% time spent |
| 3,000 cells | 0.845 ms | 0.004 ms | -99.5% time spent |
| 3,500 cells | 0.848 ms | 0.004 ms | -99.5% time spent |
| Average | 0.830 ms | 0.005 ms | ~171.0x Faster |


### Before Optimization

https://github.com/user-attachments/assets/2c08b3b2-523d-41d7-aca5-ee54bc1ee253

### After Optimization

https://github.com/user-attachments/assets/82519483-404c-4661-8e28-6acbab35236c