### PR TITLE
refactor: move StatsMode to tr::app

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -170,7 +170,7 @@ jobs:
             -DUSE_SYSTEM_UTP=OFF `# Not packaged in Ubuntu` \
             -DUSE_SYSTEM_WIDE_INTEGER=OFF `# Not packaged in Ubuntu`
       - name: Make
-        run: cmake --build obj --config Debug --target libtransmission-test transmission-show
+        run: cmake --build obj --config Debug --target all-tests
       - name: Test with sanitizers
         uses: ./.github/actions/run-tests
         with:
@@ -221,7 +221,7 @@ jobs:
             -DUSE_SYSTEM_UTP=OFF `# Not packaged in Homebrew` \
             -DUSE_SYSTEM_WIDE_INTEGER=OFF `# Not packaged in Homebrew`
       - name: Make
-        run: cmake --build obj --config Debug --target libtransmission-test transmission-show
+        run: cmake --build obj --config Debug --target all-tests
       - name: Test with sanitizers
         uses: ./.github/actions/run-tests
         with:

--- a/cmake/TrMacros.cmake
+++ b/cmake/TrMacros.cmake
@@ -1,6 +1,34 @@
 include(CheckFunctionExists)
 include(CheckIncludeFile)
 
+macro(tr_setup_gtest_target TARGET_NAME TEST_PREFIX)
+    if(WIN32)
+        cmake_policy(PUSH)
+        cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+
+        add_custom_command(
+            TARGET ${TARGET_NAME} POST_BUILD
+            COMMAND
+                ${CMAKE_COMMAND}
+                -E copy_if_different
+                $<TARGET_RUNTIME_DLLS:${TARGET_NAME}>
+                $<TARGET_FILE_DIR:${TARGET_NAME}>
+            COMMAND_EXPAND_LISTS
+        )
+
+        cmake_policy(POP)
+    endif()
+
+    if(NOT CMAKE_CROSSCOMPILING OR CMAKE_CROSSCOMPILING_EMULATOR)
+        gtest_discover_tests(${TARGET_NAME}
+            TEST_PREFIX "${TEST_PREFIX}")
+    else()
+        add_test(
+            NAME ${TARGET_NAME}
+            COMMAND ${TARGET_NAME})
+    endif()
+endmacro()
+
 macro(tr_auto_option_changed NAME ACC VAL FIL STK)
     if(NOT ("${VAL}" STREQUAL "AUTO" OR "${VAL}" STREQUAL "ON" OR "${VAL}" STREQUAL "OFF"))
         if("${VAL}" STREQUAL "0" OR "${VAL}" STREQUAL "NO" OR "${VAL}" STREQUAL "FALSE" OR "${VAL}" STREQUAL "N")

--- a/gtk/Prefs.cc
+++ b/gtk/Prefs.cc
@@ -73,7 +73,7 @@ std::string gl_confdir;
     map.try_emplace(TR_KEY_show_tracker_scrapes, false);
     map.try_emplace(TR_KEY_sort_mode, to_variant(DefaultSortMode));
     map.try_emplace(TR_KEY_sort_reversed, false);
-    map.try_emplace(TR_KEY_statusbar_stats, "total-ratio"sv);
+    map.try_emplace(TR_KEY_statusbar_stats, to_variant(DefaultStatsMode));
     map.try_emplace(TR_KEY_torrent_added_notification_enabled, true);
     map.try_emplace(TR_KEY_torrent_complete_notification_enabled, true);
     map.try_emplace(TR_KEY_torrent_complete_sound_enabled, true);

--- a/gtk/Prefs.h
+++ b/gtk/Prefs.h
@@ -25,6 +25,14 @@ template<typename T>
     return iter != std::end(map) ? to_value<T>(iter->second) : std::nullopt;
 }
 
+template<typename T>
+void gtr_pref_set(tr_quark const key, T const& val)
+{
+    using namespace tr::serializer;
+    auto& map = gtr_pref_get_map();
+    map.insert_or_assign(key, to_variant(val));
+}
+
 void gtr_pref_init(std::string_view config_dir);
 
 int64_t gtr_pref_int_get(tr_quark key);

--- a/gtk/Session.cc
+++ b/gtk/Session.cc
@@ -1140,52 +1140,6 @@ void Session::Impl::maybe_inhibit_hibernation()
     set_hibernation_allowed(hibernation_allowed);
 }
 
-/**
-***  Prefs
-**/
-
-void Session::Impl::commit_prefs_change(tr_quark const key)
-{
-    signal_prefs_changed_.emit(key);
-    gtr_pref_save(session_);
-}
-
-void Session::set_pref(tr_quark const key, std::string const& newval)
-{
-    if (newval != gtr_pref_string_get(key))
-    {
-        gtr_pref_string_set(key, newval);
-        impl_->commit_prefs_change(key);
-    }
-}
-
-void Session::set_pref(tr_quark const key, bool newval)
-{
-    if (newval != gtr_pref_flag_get(key))
-    {
-        gtr_pref_flag_set(key, newval);
-        impl_->commit_prefs_change(key);
-    }
-}
-
-void Session::set_pref(tr_quark const key, int newval)
-{
-    if (newval != gtr_pref_int_get(key))
-    {
-        gtr_pref_int_set(key, newval);
-        impl_->commit_prefs_change(key);
-    }
-}
-
-void Session::set_pref(tr_quark const key, double newval)
-{
-    if (std::fabs(newval - gtr_pref_double_get(key)) >= 0.0001)
-    {
-        gtr_pref_double_set(key, newval);
-        impl_->commit_prefs_change(key);
-    }
-}
-
 /***
 ****
 ****  RPC Interface

--- a/gtk/Session.h
+++ b/gtk/Session.h
@@ -5,11 +5,13 @@
 #pragma once
 
 #include "GtkCompat.h"
+#include "Prefs.h"
 #include "Torrent.h"
 
 #include <libtransmission-app/favicon-cache.h>
 
 #include <libtransmission/transmission.h>
+#include <libtransmission/serializer.h>
 #include <libtransmission/variant.h>
 
 #include <gdkmm/pixbuf.h>
@@ -133,10 +135,16 @@ public:
     ***  Set a preference value, save the prefs file, and emit the "prefs-changed" signal
     **/
 
-    void set_pref(tr_quark key, std::string const& val);
-    void set_pref(tr_quark key, bool val);
-    void set_pref(tr_quark key, int val);
-    void set_pref(tr_quark key, double val);
+    template<typename T>
+    void set_pref(tr_quark const key, T const& val)
+    {
+        if (gtr_pref_get<T>(key) != val)
+        {
+            gtr_pref_set<T>(key, val);
+            signal_prefs_changed().emit(key);
+            gtr_pref_save(get_session());
+        }
+    }
 
     // ---
 

--- a/libtransmission-app/converters.cc
+++ b/libtransmission-app/converters.cc
@@ -116,6 +116,49 @@ tr_variant from_sort_mode(SortMode const& src)
 
     return from_sort_mode(DefaultSortMode);
 }
+
+// ---
+
+auto constexpr StatsKeys = std::array<std::pair<std::string_view, StatsMode>, StatsModeCount>{ {
+    { "session_ratio", StatsMode::SessionRatio },
+    { "session_transfer", StatsMode::SessionTransfer },
+    { "total_ratio", StatsMode::TotalRatio },
+    { "total_transfer", StatsMode::TotalTransfer },
+} };
+
+bool to_stats_mode(tr_variant const& src, StatsMode* tgt)
+{
+    static constexpr auto& Keys = StatsKeys;
+
+    if (auto const str = src.value_if<std::string_view>())
+    {
+        for (auto const& [key, val] : Keys)
+        {
+            if (str == key)
+            {
+                *tgt = val;
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
+tr_variant from_stats_mode(StatsMode const& src)
+{
+    static constexpr auto& Keys = StatsKeys;
+
+    for (auto const& [key, val] : Keys)
+    {
+        if (src == val)
+        {
+            return tr_variant::unmanaged_string(key);
+        }
+    }
+
+    return from_stats_mode(DefaultStatsMode);
+}
 } // unnamed namespace
 
 void register_app_converters()
@@ -128,6 +171,7 @@ void register_app_converters()
             using Converters = tr::serializer::Converters;
             Converters::add(to_show_mode, from_show_mode);
             Converters::add(to_sort_mode, from_sort_mode);
+            Converters::add(to_stats_mode, from_stats_mode);
         });
 }
 

--- a/libtransmission-app/display-modes.h
+++ b/libtransmission-app/display-modes.h
@@ -37,4 +37,14 @@ enum class SortMode
 inline auto constexpr SortModeCount = 10U;
 inline auto constexpr DefaultSortMode = SortMode::SortByName;
 
+enum class StatsMode
+{
+    TotalRatio,
+    TotalTransfer,
+    SessionRatio,
+    SessionTransfer,
+};
+inline auto constexpr StatsModeCount = 4U;
+inline auto constexpr DefaultStatsMode = StatsMode::TotalRatio;
+
 } // namespace tr::app

--- a/libtransmission/api-compat.cc
+++ b/libtransmission/api-compat.cc
@@ -639,6 +639,23 @@ struct State
         }
     }
 
+    if (state.is_settings && state.current_key_is_any_of({ TR_KEY_statusbar_stats, TR_KEY_statusbar_stats_kebab_APICOMPAT }))
+    {
+        static auto constexpr Strings = std::array<std::pair<std::string_view, std::string_view>, 4U>{ {
+            { "total_ratio", "total-ratio" },
+            { "total_transfer", "total-transfer" },
+            { "session_ratio", "session-ratio" },
+            { "session_transfer", "session-transfer" },
+        } };
+        for (auto const& [current, legacy] : Strings)
+        {
+            if (src == current || src == legacy)
+            {
+                return state.style == Style::Tr5 ? current : legacy;
+            }
+        }
+    }
+
     // TODO(ckerr): replace `new_key == TR_KEY_TORRENTS` here to turn on convert
     // if it's an array inside an array val whose key was `torrents`.
     // This is for the edge case of table mode: `torrents : [ [ 'key1', 'key2' ], [ ... ] ]`

--- a/qt/MainWindow.h
+++ b/qt/MainWindow.h
@@ -113,7 +113,7 @@ private slots:
     void openStats();
     void openTorrent();
     void openURL();
-    void refreshPref(int key);
+    void refreshPref(int idx);
     void removeTorrents(bool const delete_files);
     void setLocation();
     void setSortAscendingPref(bool);
@@ -179,10 +179,6 @@ private:
     bool auto_add_clipboard_links_ = {};
     QStringList clipboard_processed_keys_ = {};
 
-    QString const total_ratio_stats_mode_name_ = QStringLiteral("total-ratio");
-    QString const total_transfer_stats_mode_name_ = QStringLiteral("total-transfer");
-    QString const session_ratio_stats_mode_name_ = QStringLiteral("session-ratio");
-    QString const session_transfer_stats_mode_name_ = QStringLiteral("session-transfer");
     QString const show_options_checkbox_name_ = QStringLiteral("show-options-checkbox");
 
     struct TransferStats

--- a/qt/Prefs.cc
+++ b/qt/Prefs.cc
@@ -49,6 +49,9 @@ template<typename T>
     case UserMetaType::SortModeType:
         return qvarFromOptional(ser::to_value<SortMode>(var));
 
+    case UserMetaType::StatsModeType:
+        return qvarFromOptional(ser::to_value<StatsMode>(var));
+
     case UserMetaType::ShowModeType:
         return qvarFromOptional(ser::to_value<ShowMode>(var));
 
@@ -88,6 +91,9 @@ template<typename T>
 
     case UserMetaType::ShowModeType:
         return ser::to_variant(var.value<ShowMode>());
+
+    case UserMetaType::StatsModeType:
+        return ser::to_variant(var.value<StatsMode>());
 
     case QMetaType::QString:
         return ser::to_variant(var.value<QString>());

--- a/qt/Prefs.h
+++ b/qt/Prefs.h
@@ -199,7 +199,7 @@ private:
         { COMPACT_VIEW, TR_KEY_compact_view, QMetaType::Bool },
         { FILTERBAR, TR_KEY_show_filterbar, QMetaType::Bool },
         { STATUSBAR, TR_KEY_show_statusbar, QMetaType::Bool },
-        { STATUSBAR_STATS, TR_KEY_statusbar_stats, QMetaType::QString },
+        { STATUSBAR_STATS, TR_KEY_statusbar_stats, UserMetaType::StatsModeType },
         { SHOW_TRACKER_SCRAPES, TR_KEY_show_tracker_scrapes, QMetaType::Bool },
         { SHOW_BACKUP_TRACKERS, TR_KEY_show_backup_trackers, QMetaType::Bool },
         { TOOLBAR, TR_KEY_show_toolbar, QMetaType::Bool },

--- a/qt/UserMetaType.h
+++ b/qt/UserMetaType.h
@@ -18,6 +18,7 @@ public:
     {
         ShowModeType = QMetaType::User,
         SortModeType,
+        StatsModeType,
         EncryptionModeType,
     };
 };
@@ -32,3 +33,8 @@ inline auto constexpr ShowModeCount = tr::app::ShowModeCount;
 using SortMode = tr::app::SortMode;
 Q_DECLARE_METATYPE(SortMode)
 inline auto constexpr DefaultSortMode = tr::app::DefaultSortMode;
+
+using StatsMode = tr::app::StatsMode;
+Q_DECLARE_METATYPE(StatsMode)
+inline auto constexpr DefaultStatsMode = tr::app::DefaultStatsMode;
+inline auto constexpr StatsModeCount = tr::app::StatsModeCount;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,7 @@
 include(TrGTest)
 
 add_subdirectory(libtransmission)
+add_subdirectory(libtransmission-app)
 if(ENABLE_UTILS)
     add_subdirectory(utils)
 endif()
@@ -18,6 +19,8 @@ set_property(
 if(TARGET libtransmission-test)
     add_dependencies(all-tests libtransmission-test)
 endif()
+
+add_dependencies(all-tests libtransmission-app-test)
 
 if(TARGET qt-tests)
     add_dependencies(all-tests qt-tests)

--- a/tests/libtransmission-app/CMakeLists.txt
+++ b/tests/libtransmission-app/CMakeLists.txt
@@ -1,0 +1,27 @@
+include(GoogleTest)
+
+add_executable(libtransmission-app-test)
+
+target_sources(libtransmission-app-test
+	PRIVATE
+		display-mode-tests.cc
+		test-fixtures.h)
+
+set_property(
+	TARGET libtransmission-app-test
+	PROPERTY FOLDER "tests")
+
+target_link_libraries(libtransmission-app-test
+	PRIVATE
+		${TR_NAME}-app
+		${TR_NAME}
+		GTest::gtest_main)
+
+if(NOT CMAKE_CROSSCOMPILING OR CMAKE_CROSSCOMPILING_EMULATOR)
+	gtest_discover_tests(libtransmission-app-test
+		TEST_PREFIX "LTA.")
+else()
+	add_test(
+		NAME libtransmission-app-test
+		COMMAND libtransmission-app-test)
+endif()

--- a/tests/libtransmission-app/CMakeLists.txt
+++ b/tests/libtransmission-app/CMakeLists.txt
@@ -17,11 +17,4 @@ target_link_libraries(libtransmission-app-test
 		${TR_NAME}
 		GTest::gtest_main)
 
-if(NOT CMAKE_CROSSCOMPILING OR CMAKE_CROSSCOMPILING_EMULATOR)
-	gtest_discover_tests(libtransmission-app-test
-		TEST_PREFIX "LTA.")
-else()
-	add_test(
-		NAME libtransmission-app-test
-		COMMAND libtransmission-app-test)
-endif()
+tr_setup_gtest_target(libtransmission-app-test "LTA.")

--- a/tests/libtransmission-app/display-mode-tests.cc
+++ b/tests/libtransmission-app/display-mode-tests.cc
@@ -1,0 +1,86 @@
+// This file Copyright © Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
+
+#include <array>
+#include <string_view>
+
+#include <gtest/gtest.h>
+
+#include <libtransmission/serializer.h>
+#include <libtransmission/variant.h>
+
+#include "libtransmission-app/display-modes.h"
+
+#include "test-fixtures.h"
+
+using DisplayModeTest = TransmissionTest;
+using namespace std::literals;
+using tr::serializer::Converters;
+
+namespace
+{
+
+template<typename T, size_t N>
+void testModeRoundtrip(std::array<std::pair<std::string_view, T>, N> const& items)
+{
+    for (auto const& [key, mode] : items)
+    {
+        auto const var = Converters::serialize(mode);
+        EXPECT_TRUE(var.template holds_alternative<std::string_view>());
+        EXPECT_EQ(var.template value_if<std::string_view>().value_or(""sv), key);
+
+        auto out = T{};
+        EXPECT_TRUE(Converters::deserialize(tr_variant{ key }, &out));
+        EXPECT_EQ(out, mode);
+    }
+}
+
+} // namespace
+
+TEST_F(DisplayModeTest, showModeStringsRoundtrip)
+{
+    auto constexpr Items = std::array<std::pair<std::string_view, tr::app::ShowMode>, tr::app::ShowModeCount>{ {
+        { "show_active", tr::app::ShowMode::ShowActive },
+        { "show_all", tr::app::ShowMode::ShowAll },
+        { "show_downloading", tr::app::ShowMode::ShowDownloading },
+        { "show_error", tr::app::ShowMode::ShowError },
+        { "show_finished", tr::app::ShowMode::ShowFinished },
+        { "show_paused", tr::app::ShowMode::ShowPaused },
+        { "show_seeding", tr::app::ShowMode::ShowSeeding },
+        { "show_verifying", tr::app::ShowMode::ShowVerifying },
+    } };
+
+    testModeRoundtrip(Items);
+}
+
+TEST_F(DisplayModeTest, sortModeStringsRoundtrip)
+{
+    auto constexpr Items = std::array<std::pair<std::string_view, tr::app::SortMode>, tr::app::SortModeCount>{ {
+        { "sort_by_activity", tr::app::SortMode::SortByActivity },
+        { "sort_by_age", tr::app::SortMode::SortByAge },
+        { "sort_by_eta", tr::app::SortMode::SortByEta },
+        { "sort_by_id", tr::app::SortMode::SortById },
+        { "sort_by_name", tr::app::SortMode::SortByName },
+        { "sort_by_progress", tr::app::SortMode::SortByProgress },
+        { "sort_by_queue", tr::app::SortMode::SortByQueue },
+        { "sort_by_ratio", tr::app::SortMode::SortByRatio },
+        { "sort_by_size", tr::app::SortMode::SortBySize },
+        { "sort_by_state", tr::app::SortMode::SortByState },
+    } };
+
+    testModeRoundtrip(Items);
+}
+
+TEST_F(DisplayModeTest, statsModeStringsRoundtrip)
+{
+    auto constexpr Items = std::array<std::pair<std::string_view, tr::app::StatsMode>, tr::app::StatsModeCount>{ {
+        { "total_ratio", tr::app::StatsMode::TotalRatio },
+        { "total_transfer", tr::app::StatsMode::TotalTransfer },
+        { "session_ratio", tr::app::StatsMode::SessionRatio },
+        { "session_transfer", tr::app::StatsMode::SessionTransfer },
+    } };
+
+    testModeRoundtrip(Items);
+}

--- a/tests/libtransmission-app/test-fixtures.h
+++ b/tests/libtransmission-app/test-fixtures.h
@@ -1,0 +1,19 @@
+// This file Copyright © Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
+
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include "libtransmission-app/app.h"
+
+class TransmissionTest : public ::testing::Test
+{
+protected:
+    static void SetUpTestSuite()
+    {
+        tr::app::init();
+    }
+};

--- a/tests/libtransmission/CMakeLists.txt
+++ b/tests/libtransmission/CMakeLists.txt
@@ -87,31 +87,7 @@ target_link_libraries(libtransmission-test
         libevent::event
         WideInteger::WideInteger)
 
-if (WIN32)
-    cmake_policy(PUSH)
-    cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
-
-    add_custom_command(
-        TARGET libtransmission-test POST_BUILD
-        COMMAND
-            ${CMAKE_COMMAND}
-            -E copy_if_different
-            $<TARGET_RUNTIME_DLLS:libtransmission-test>
-            $<TARGET_FILE_DIR:libtransmission-test>
-        COMMAND_EXPAND_LISTS
-    )
-
-    cmake_policy(POP)
-endif ()
-
-if(NOT CMAKE_CROSSCOMPILING OR CMAKE_CROSSCOMPILING_EMULATOR)
-    gtest_discover_tests(libtransmission-test
-        TEST_PREFIX "LT.")
-else()
-    add_test(
-        NAME libtransmission-test
-        COMMAND libtransmission-test)
-endif()
+tr_setup_gtest_target(libtransmission-test "LT.")
 
 add_custom_command(
     TARGET libtransmission-test

--- a/tests/libtransmission/api-compat-test.cc
+++ b/tests/libtransmission/api-compat-test.cc
@@ -747,7 +747,7 @@ constexpr std::string_view CurrentSettingsJson = R"json({
     "speed_limit_up_enabled": false,
     "start_added_torrents": true,
     "start_minimized": false,
-    "statusbar_stats": "total-ratio",
+    "statusbar_stats": "total_ratio",
     "torrent_added_notification_enabled": true,
     "torrent_complete_notification_enabled": true,
     "torrent_complete_sound_command": [


### PR DESCRIPTION
Added StatsMode to the tr::app namespace, added tests, and refactored the Qt and GTK clients to use it.

Notes: Improved code sharing between the Qt and GTK user interfaces.