### PR TITLE
fix: race condition when removing torrents in GTK client

### DIFF
--- a/gtk/Session.cc
+++ b/gtk/Session.cc
@@ -930,10 +930,7 @@ void Session::Impl::remove_torrent(tr_torrent_id_t const id, bool const delete_f
     {
         get_raw_model()->remove(position);
 
-        tr_torrentRemove(
-            &torrent->get_underlying(),
-            delete_files,
-            gtr_file_trash_or_remove);
+        tr_torrentRemove(&torrent->get_underlying(), delete_files, gtr_file_trash_or_remove);
     }
 }
 

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -1046,16 +1046,8 @@ private:
     friend tr_torrent* tr_torrentNew(tr_ctor* ctor, tr_torrent** setme_duplicate_of);
     friend uint64_t tr_torrentGetBytesLeftToAllocate(tr_torrent const* tor);
     friend void tr_torrentFreeInSessionThread(tr_torrent* tor);
-    friend void tr_torrentRemoveInSessionThread(
-        tr_torrent* tor,
-        bool delete_flag,
-        tr_torrent_remove_func remove_func,
-        tr_torrent_remove_done_func on_remove_done);
-    friend void tr_torrentRemove(
-        tr_torrent* tor,
-        bool delete_flag,
-        tr_torrent_remove_func remove_func,
-        tr_torrent_remove_done_func on_remove_done);
+    friend void tr_torrentRemoveInSessionThread(tr_torrent* tor, bool delete_flag, tr_torrent_remove_func remove_func);
+    friend void tr_torrentRemove(tr_torrent* tor, bool delete_flag, tr_torrent_remove_func remove_func);
     friend void tr_torrentSetDownloadDir(tr_torrent* tor, std::string_view path);
     friend void tr_torrentSetPriority(tr_torrent* tor, tr_priority_t priority);
     friend void tr_torrentStart(tr_torrent* tor);

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -810,7 +810,6 @@ tr_torrent* tr_torrentNew(tr_ctor* ctor, tr_torrent** setme_duplicate_of);
     @{ */
 
 using tr_torrent_remove_func = std::function<bool(std::string_view filename, tr_error* error)>;
-using tr_torrent_remove_done_func = std::function<void(tr_torrent_id_t, bool success)>;
 
 /**
  * @brief Removes our torrent and .resume files for this torrent
@@ -820,13 +819,8 @@ using tr_torrent_remove_done_func = std::function<void(tr_torrent_id_t, bool suc
  *                    to move to a recycle bin instead of deleting.
  *                    The callback is invoked in the session thread and the filename view
  *                    is only valid for the duration of the call.
- * @param on_remove_done A callback to invoke in the session thread when removal is done.
  */
-void tr_torrentRemove(
-    tr_torrent* tor,
-    bool delete_flag,
-    tr_torrent_remove_func remove_func = {},
-    tr_torrent_remove_done_func on_remove_done = {});
+void tr_torrentRemove(tr_torrent* tor, bool delete_flag, tr_torrent_remove_func remove_func = {});
 
 /** @brief Start a torrent */
 void tr_torrentStart(tr_torrent* torrent);


### PR DESCRIPTION
Cherry-pick https://github.com/transmission/transmission/pull/8340 for `main`.

Since this removes the last use of `tr_torrentRemove()`'s `on_remove_done` arg, this PR also removes the arg.