### PR TITLE
fix: assertion failed no timezone in fmt::chrono

### DIFF
--- a/libtransmission/log.cc
+++ b/libtransmission/log.cc
@@ -38,7 +38,7 @@ using namespace std::literals;
 namespace
 {
 template<typename T>
-inline constexpr bool HasTmTzV = requires { T::tm_gmtoff; } || requires { T::tm_zone; };
+inline constexpr bool HasTmGmtoffV = requires(T t) { t.tm_gmtoff; };
 
 class tr_log_state
 {
@@ -205,8 +205,8 @@ std::string_view tr_logGetTimeStr(std::chrono::system_clock::time_point const no
     auto* walk = buf;
     auto const now_time_t = std::chrono::system_clock::to_time_t(now);
     auto const now_tm = *std::localtime(&now_time_t);
-    static auto constexpr HasTz = HasTmTzV<std::tm>;
-    static auto constexpr Fmt = HasTz ? "{0:%FT%R:}{1:%S}{0:%z}"sv : "{0:%FT%R:}{1:%S}"sv;
+    static bool constexpr HasTmGmtoff = HasTmGmtoffV<std::tm>;
+    static auto constexpr Fmt = HasTmGmtoff ? "{0:%FT%R:}{1:%S}{0:%z}"sv : "{0:%FT%R:}{1:%S}"sv;
     walk = fmt::format_to_n(walk, buflen, Fmt, now_tm, std::chrono::time_point_cast<std::chrono::milliseconds>(now)).out;
 #ifdef _WIN32
     if (auto tz_info = TIME_ZONE_INFORMATION{}; GetTimeZoneInformation(&tz_info) != TIME_ZONE_ID_INVALID)


### PR DESCRIPTION
Fixes #8337.

OmniOS lacks timezone fields `tm_gmtoff` and `tm_zone` in the `std::tm` struct, so check first before using them.

There is a related fix for Windows by @tearfur in fb25228f from #7612.

Once this PR is merged, I'll cherry-pick it for `4.1.x` with release notes.