### PR TITLE
fix: encryption mode not displayed correctly in Preferences dialog

### DIFF
--- a/gtk/PrefsDialog.cc
+++ b/gtk/PrefsDialog.cc
@@ -315,7 +315,8 @@ Gtk::ComboBox* PageBase::init_encryption_combo(Glib::ustring const& name, tr_qua
             { _("Prefer encryption"), TR_ENCRYPTION_PREFERRED },
             { _("Require encryption"), TR_ENCRYPTION_REQUIRED },
         });
-    gtr_combo_box_set_active_enum(*combo, gtr_pref_int_get(key));
+    auto const mode = gtr_pref_get<tr_encryption_mode>(key).value_or(TR_ENCRYPTION_PREFERRED);
+    gtr_combo_box_set_active_enum(*combo, static_cast<int>(mode));
     combo->signal_changed().connect([this, combo, key]() { onIntComboChanged(*combo, key); });
     return combo;
 }


### PR DESCRIPTION
Fixes https://github.com/transmission/transmission/issues/8343.

No matter what encryption mode was actually in use, the GTK Preferences dialog still started up indicating "Allowed".

Notes: Fixed a `4.1.0` bug that showed the wrong encryption mode being shown in the Preferences dialog.
