### PR TITLE
Revert "feat: inline delete prompt in remove dialog (#7000)"

### DIFF
--- a/web/src/action-manager.js
+++ b/web/src/action-manager.js
@@ -35,10 +35,7 @@ export class ActionManager extends EventTarget {
         enabled: false,
         text: 'Ask tracker for more peers',
       },
-      'remove-selected-torrents': {
-        enabled: false,
-        text: 'Remove selected torrents',
-      },
+      'remove-selected-torrents': { enabled: false, text: 'Remove from list…' },
       'resume-selected-torrents': {
         enabled: false,
         shortcut: 'R',
@@ -86,6 +83,10 @@ export class ActionManager extends EventTarget {
       'start-all-torrents': { enabled: false, text: 'Start all' },
       'toggle-compact-rows': { enabled: true, text: 'Compact rows' },
       'toggle-contrast': { enabled: true, text: 'High contrast UI' },
+      'trash-selected-torrents': {
+        enabled: false,
+        text: 'Trash data and remove from list…',
+      },
       'verify-selected-torrents': {
         enabled: false,
         shortcut: 'V',
@@ -202,6 +203,7 @@ export class ActionManager extends EventTarget {
       'show-inspector',
       'show-labels-dialog',
       'show-move-dialog',
+      'trash-selected-torrents',
       'verify-selected-torrents',
     ]);
 

--- a/web/src/context-menu.js
+++ b/web/src/context-menu.js
@@ -182,6 +182,7 @@ export class ContextMenu extends EventTarget {
         ),
         new_separator(),
         new_item('remove-selected-torrents', true),
+        new_item('trash-selected-torrents', true),
         new_separator(),
         new_item('verify-selected-torrents'),
         new_item('show-move-dialog'),

--- a/web/src/remove-dialog.js
+++ b/web/src/remove-dialog.js
@@ -9,9 +9,8 @@ export class RemoveDialog extends EventTarget {
   constructor(options) {
     super();
 
-    // options: remote, torrents
+    // options: remote, torrents, trash
     this.options = options;
-    this.options.trash = false;
     this.elements = RemoveDialog._create(options);
     this.elements.dismiss.addEventListener('click', () => this._onDismiss());
     this.elements.confirm.addEventListener('click', () => this._onConfirm());
@@ -44,50 +43,38 @@ export class RemoveDialog extends EventTarget {
   }
 
   static _create(options) {
-    const { torrents } = options;
+    const { trash } = options;
+    const { heading, message } = RemoveDialog._createMessage(options);
+
     const elements = createDialogContainer('remove-dialog');
-    const { confirm, heading, message, workarea } = elements;
-
-    heading.textContent =
-      torrents.length === 1
-        ? `Remove ${torrents[0].getName()}?`
-        : `Remove ${torrents.length} transfers?`;
-
-    const check = document.createElement('input');
-    check.id = 'delete-local-data-check';
-    check.type = 'checkbox';
-    check.checked = false;
-    message.append(check);
-
-    const label = document.createElement('label');
-    label.id = 'delete-local-data-label';
-    label.setAttribute('for', check.id);
-    label.textContent = 'Delete downloaded data';
-    message.append(label);
-
-    const body = document.createElement('div');
-    const rewrite = (checked) => {
-      if (checked && torrents.length === 1) {
-        body.textContent =
-          'All data downloaded for this torrent will be deleted. Are you sure you want to remove it?';
-      } else if (checked) {
-        body.textContent =
-          'All data downloaded for these torrents will be deleted. Are you sure you want to remove them?';
-      } else if (torrents.length === 1) {
-        body.textContent =
-          'Once removed, continuing the transfer will require the torrent file. Are you sure you want to remove it?';
-      } else {
-        body.textContent =
-          'Once removed, continuing the transfers will require the torrent files. Are you sure you want to remove them?';
-      }
-      confirm.textContent = checked ? 'Delete' : 'Remove';
-    };
-    rewrite(check.checked);
-    check.addEventListener('click', () => {
-      options.trash = check.checked;
-      rewrite(check.checked);
-    });
-    workarea.append(body);
+    elements.heading.textContent = heading;
+    elements.message.textContent = message;
+    elements.confirm.textContent = trash ? 'Trash' : 'Remove';
     return elements;
+  }
+
+  static _createMessage(options) {
+    let heading = null;
+    let message = null;
+    const { torrents, trash } = options;
+    const [torrent] = torrents;
+    if (trash && torrents.length === 1) {
+      heading = `Remove ${torrent.getName()} and delete data?`;
+      message =
+        'All data downloaded for this torrent will be deleted. Are you sure you want to remove it?';
+    } else if (trash) {
+      heading = `Remove ${torrents.length} transfers and delete data?`;
+      message =
+        'All data downloaded for these torrents will be deleted. Are you sure you want to remove them?';
+    } else if (torrents.length === 1) {
+      heading = `Remove ${torrent.getName()}?`;
+      message =
+        'Once removed, continuing the transfer will require the torrent file. Are you sure you want to remove it?';
+    } else {
+      heading = `Remove ${torrents.length} transfers?`;
+      message =
+        'Once removed, continuing the transfers will require the torrent files. Are you sure you want to remove them?';
+    }
+    return { heading, message };
   }
 }

--- a/web/src/transmission.js
+++ b/web/src/transmission.js
@@ -154,7 +154,7 @@ export class Transmission extends EventTarget {
           this._reannounceTorrents(this.getSelectedTorrents());
           break;
         case 'remove-selected-torrents':
-          this._removeSelectedTorrents();
+          this._removeSelectedTorrents(false);
           break;
         case 'resume-selected-torrents':
           this._startSelectedTorrents(false);
@@ -217,6 +217,9 @@ export class Transmission extends EventTarget {
             this.prefs.display_mode === Prefs.DisplayCompact
               ? Prefs.DisplayFull
               : Prefs.DisplayCompact;
+          break;
+        case 'trash-selected-torrents':
+          this._removeSelectedTorrents(true);
           break;
         case 'verify-selected-torrents':
           this._verifyTorrents(this.getSelectedTorrents());
@@ -946,10 +949,12 @@ TODO: fix this when notifications get fixed
     }
   }
 
-  _removeSelectedTorrents() {
+  _removeSelectedTorrents(trash) {
     const torrents = this.getSelectedTorrents();
     if (torrents.length > 0) {
-      this.setCurrentPopup(new RemoveDialog({ remote: this.remote, torrents }));
+      this.setCurrentPopup(
+        new RemoveDialog({ remote: this.remote, torrents, trash }),
+      );
     }
   }
 


### PR DESCRIPTION
Closes #8286.
Superscedes #8285.

As discussed, instead of adding a preference or some sort of persistence to remember the "Trash" checkbox, just revert #7000 for simplicity.