### PR TITLE
fix: mark strings for translation

### DIFF
--- a/gtk/transmission-ui.xml
+++ b/gtk/transmission-ui.xml
@@ -4,7 +4,7 @@
 
   <menu id="main-window-menu">
     <submenu>
-      <attribute name="label" translatable="true">_File</attribute>
+      <attribute name="label" translatable="yes">_File</attribute>
       <section>
         <item>
           <attribute name="action">win.open-torrent</attribute>
@@ -51,7 +51,7 @@
       </section>
     </submenu>
     <submenu>
-      <attribute name="label" translatable="true">_Edit</attribute>
+      <attribute name="label" translatable="yes">_Edit</attribute>
       <section>
         <item>
           <attribute name="action">win.select-all</attribute>
@@ -74,7 +74,7 @@
       </section>
     </submenu>
     <submenu>
-      <attribute name="label" translatable="true">_Torrent</attribute>
+      <attribute name="label" translatable="yes">_Torrent</attribute>
       <section>
         <item>
           <attribute name="action">win.show-torrent-properties</attribute>
@@ -111,7 +111,7 @@
           <attribute name="label" translatable="yes">Ask Tracker for _More Peers</attribute>
         </item>
         <submenu>
-          <attribute name="label" translatable="true">_Queue</attribute>
+          <attribute name="label" translatable="yes">_Queue</attribute>
           <section>
             <item>
               <attribute name="action">win.queue-move-top</attribute>
@@ -175,7 +175,7 @@
       </section>
     </submenu>
     <submenu>
-      <attribute name="label" translatable="true">_View</attribute>
+      <attribute name="label" translatable="yes">_View</attribute>
       <section>
         <item>
           <attribute name="action">win.compact-view</attribute>
@@ -252,7 +252,7 @@
       </section>
     </submenu>
     <submenu>
-      <attribute name="label" translatable="true">_Help</attribute>
+      <attribute name="label" translatable="yes">_Help</attribute>
       <section>
         <item>
           <attribute name="action">win.toggle-message-log</attribute>
@@ -303,7 +303,7 @@
     </section>
     <section>
       <submenu>
-        <attribute name="label" translatable="true">_Sort Torrents By</attribute>
+        <attribute name="label" translatable="yes">_Sort Torrents By</attribute>
         <section>
           <item>
             <attribute name="action">win.sort-torrents</attribute>
@@ -380,7 +380,7 @@
         <attribute name="label" translatable="yes">Ask Tracker for _More Peers</attribute>
       </item>
       <submenu>
-        <attribute name="label" translatable="true">_Queue</attribute>
+        <attribute name="label" translatable="yes">_Queue</attribute>
         <section>
           <item>
             <attribute name="action">win.queue-move-top</attribute>

--- a/gtk/ui/gtk4/AddTrackerDialog.ui
+++ b/gtk/ui/gtk4/AddTrackerDialog.ui
@@ -17,7 +17,7 @@
               <object class="GtkFrame">
                 <child type="label">
                   <object class="GtkLabel" id="url_section_label">
-                    <property name="label" translatable="1">Tracker</property>
+                    <property name="label" translatable="yes">Tracker</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
                     </attributes>
@@ -29,7 +29,7 @@
                     <property name="column-spacing">12</property>
                     <child>
                       <object class="GtkLabel" id="url_label">
-                        <property name="label" translatable="1">_Announce URL:</property>
+                        <property name="label" translatable="yes">_Announce URL:</property>
                         <property name="use-underline">1</property>
                         <property name="mnemonic-widget">url_entry</property>
                         <layout>
@@ -64,7 +64,7 @@
         <property name="spacing">6</property>
         <child>
           <object class="GtkButton" id="cancel_button">
-            <property name="label" translatable="1">_Cancel</property>
+            <property name="label" translatable="yes">_Cancel</property>
             <property name="focusable">1</property>
             <property name="receives-default">1</property>
             <property name="use-underline">1</property>
@@ -72,7 +72,7 @@
         </child>
         <child>
           <object class="GtkButton" id="open_button">
-            <property name="label" translatable="1">_Add</property>
+            <property name="label" translatable="yes">_Add</property>
             <property name="focusable">1</property>
             <property name="receives-default">1</property>
             <property name="use-underline">1</property>

--- a/gtk/ui/gtk4/DetailsDialog.ui
+++ b/gtk/ui/gtk4/DetailsDialog.ui
@@ -23,7 +23,7 @@
                       <object class="GtkFrame">
                         <child type="label">
                           <object class="GtkLabel" id="activity_section_label">
-                            <property name="label" translatable="1">Activity</property>
+                            <property name="label" translatable="yes">Activity</property>
                             <attributes>
                               <attribute name="weight" value="bold"/>
                             </attributes>
@@ -35,7 +35,7 @@
                             <property name="column-spacing">12</property>
                             <child>
                               <object class="GtkLabel" id="torrent_size_label">
-                                <property name="label" translatable="1">Torrent size:</property>
+                                <property name="label" translatable="yes">Torrent size:</property>
                                 <property name="xalign">0</property>
                                 <layout>
                                   <property name="column">0</property>
@@ -45,7 +45,7 @@
                             </child>
                             <child>
                               <object class="GtkLabel" id="have_label">
-                                <property name="label" translatable="1">Have:</property>
+                                <property name="label" translatable="yes">Have:</property>
                                 <property name="xalign">0</property>
                                 <layout>
                                   <property name="column">0</property>
@@ -55,7 +55,7 @@
                             </child>
                             <child>
                               <object class="GtkLabel" id="uploaded_label">
-                                <property name="label" translatable="1">Uploaded:</property>
+                                <property name="label" translatable="yes">Uploaded:</property>
                                 <property name="xalign">0</property>
                                 <layout>
                                   <property name="column">0</property>
@@ -65,7 +65,7 @@
                             </child>
                             <child>
                               <object class="GtkLabel" id="downloaded_label">
-                                <property name="label" translatable="1">Downloaded:</property>
+                                <property name="label" translatable="yes">Downloaded:</property>
                                 <property name="xalign">0</property>
                                 <layout>
                                   <property name="column">0</property>
@@ -75,7 +75,7 @@
                             </child>
                             <child>
                               <object class="GtkLabel" id="state_label">
-                                <property name="label" translatable="1">State:</property>
+                                <property name="label" translatable="yes">State:</property>
                                 <property name="xalign">0</property>
                                 <layout>
                                   <property name="column">0</property>
@@ -85,7 +85,7 @@
                             </child>
                             <child>
                               <object class="GtkLabel" id="running_time_label">
-                                <property name="label" translatable="1">Running time:</property>
+                                <property name="label" translatable="yes">Running time:</property>
                                 <property name="xalign">0</property>
                                 <layout>
                                   <property name="column">0</property>
@@ -95,7 +95,7 @@
                             </child>
                             <child>
                               <object class="GtkLabel" id="remaining_time_label">
-                                <property name="label" translatable="1">Remaining time:</property>
+                                <property name="label" translatable="yes">Remaining time:</property>
                                 <property name="xalign">0</property>
                                 <layout>
                                   <property name="column">0</property>
@@ -105,7 +105,7 @@
                             </child>
                             <child>
                               <object class="GtkLabel" id="last_activity_label">
-                                <property name="label" translatable="1">Last activity:</property>
+                                <property name="label" translatable="yes">Last activity:</property>
                                 <property name="xalign">0</property>
                                 <layout>
                                   <property name="column">0</property>
@@ -115,7 +115,7 @@
                             </child>
                             <child>
                               <object class="GtkLabel" id="error_label">
-                                <property name="label" translatable="1">Error:</property>
+                                <property name="label" translatable="yes">Error:</property>
                                 <property name="xalign">0</property>
                                 <property name="yalign">0</property>
                                 <layout>
@@ -271,7 +271,7 @@
                       <object class="GtkFrame">
                         <child type="label">
                           <object class="GtkLabel" id="details_section_label">
-                            <property name="label" translatable="1">Details</property>
+                            <property name="label" translatable="yes">Details</property>
                             <attributes>
                               <attribute name="weight" value="bold"/>
                             </attributes>
@@ -283,7 +283,7 @@
                             <property name="column-spacing">12</property>
                             <child>
                               <object class="GtkLabel" id="location_label">
-                                <property name="label" translatable="1">Location:</property>
+                                <property name="label" translatable="yes">Location:</property>
                                 <property name="xalign">0</property>
                                 <layout>
                                   <property name="column">0</property>
@@ -293,7 +293,7 @@
                             </child>
                             <child>
                               <object class="GtkLabel" id="hash_label">
-                                <property name="label" translatable="1">Hash:</property>
+                                <property name="label" translatable="yes">Hash:</property>
                                 <property name="xalign">0</property>
                                 <layout>
                                   <property name="column">0</property>
@@ -303,7 +303,7 @@
                             </child>
                             <child>
                               <object class="GtkLabel" id="privacy_label">
-                                <property name="label" translatable="1">Privacy:</property>
+                                <property name="label" translatable="yes">Privacy:</property>
                                 <property name="xalign">0</property>
                                 <layout>
                                   <property name="column">0</property>
@@ -313,7 +313,7 @@
                             </child>
                             <child>
                               <object class="GtkLabel" id="origin_label">
-                                <property name="label" translatable="1">Origin:</property>
+                                <property name="label" translatable="yes">Origin:</property>
                                 <property name="xalign">0</property>
                                 <layout>
                                   <property name="column">0</property>
@@ -323,7 +323,7 @@
                             </child>
                             <child>
                               <object class="GtkLabel" id="added_label">
-                                <property name="label" translatable="1">Added:</property>
+                                <property name="label" translatable="yes">Added:</property>
                                 <property name="xalign">0</property>
                                 <layout>
                                   <property name="column">0</property>
@@ -335,7 +335,7 @@
                               <object class="GtkLabel" id="comment_label">
                                 <property name="margin-top">6</property>
                                 <property name="margin-bottom">6</property>
-                                <property name="label" translatable="1">Comment:</property>
+                                <property name="label" translatable="yes">Comment:</property>
                                 <property name="use-underline">1</property>
                                 <property name="mnemonic-widget">comment_value_view</property>
                                 <property name="xalign">0</property>
@@ -448,7 +448,7 @@
                 </property>
                 <property name="tab">
                   <object class="GtkLabel" id="info_page_label">
-                    <property name="label" translatable="1">Information</property>
+                    <property name="label" translatable="yes">Information</property>
                   </object>
                 </property>
               </object>
@@ -499,7 +499,7 @@
                     </child>
                     <child>
                       <object class="GtkCheckButton" id="more_peer_details_check">
-                        <property name="label" translatable="1">Show _more details</property>
+                        <property name="label" translatable="yes">Show _more details</property>
                         <property name="focusable">1</property>
                         <property name="valign">center</property>
                         <property name="use-underline">1</property>
@@ -509,7 +509,7 @@
                 </property>
                 <property name="tab">
                   <object class="GtkLabel" id="peers_page_label">
-                    <property name="label" translatable="1">Peers</property>
+                    <property name="label" translatable="yes">Peers</property>
                   </object>
                 </property>
               </object>
@@ -548,7 +548,7 @@
                             <property name="spacing">6</property>
                             <child>
                               <object class="GtkButton" id="add_tracker_button">
-                                <property name="label" translatable="1">_Add</property>
+                                <property name="label" translatable="yes">_Add</property>
                                 <property name="focusable">1</property>
                                 <property name="receives-default">1</property>
                                 <property name="use-underline">1</property>
@@ -556,7 +556,7 @@
                             </child>
                             <child>
                               <object class="GtkButton" id="edit_tracker_button">
-                                <property name="label" translatable="1">_Edit</property>
+                                <property name="label" translatable="yes">_Edit</property>
                                 <property name="focusable">1</property>
                                 <property name="receives-default">1</property>
                                 <property name="use-underline">1</property>
@@ -564,7 +564,7 @@
                             </child>
                             <child>
                               <object class="GtkButton" id="remove_tracker_button">
-                                <property name="label" translatable="1">_Remove</property>
+                                <property name="label" translatable="yes">_Remove</property>
                                 <property name="focusable">1</property>
                                 <property name="receives-default">1</property>
                                 <property name="use-underline">1</property>
@@ -576,7 +576,7 @@
                     </child>
                     <child>
                       <object class="GtkCheckButton" id="more_tracker_details_check">
-                        <property name="label" translatable="1">Show _more details</property>
+                        <property name="label" translatable="yes">Show _more details</property>
                         <property name="focusable">1</property>
                         <property name="valign">center</property>
                         <property name="use-underline">1</property>
@@ -584,7 +584,7 @@
                     </child>
                     <child>
                       <object class="GtkCheckButton" id="backup_trackers_check">
-                        <property name="label" translatable="1">Show _backup trackers</property>
+                        <property name="label" translatable="yes">Show _backup trackers</property>
                         <property name="focusable">1</property>
                         <property name="valign">center</property>
                         <property name="use-underline">1</property>
@@ -594,7 +594,7 @@
                 </property>
                 <property name="tab">
                   <object class="GtkLabel" id="trackers_page_label">
-                    <property name="label" translatable="1">Trackers</property>
+                    <property name="label" translatable="yes">Trackers</property>
                   </object>
                 </property>
               </object>
@@ -624,14 +624,14 @@
                     <child>
                       <object class="GtkLabel" id="files_label">
                         <property name="vexpand">1</property>
-                        <property name="label" translatable="1">File listing not available for combined torrent properties</property>
+                        <property name="label" translatable="yes">File listing not available for combined torrent properties</property>
                       </object>
                     </child>
                   </object>
                 </property>
                 <property name="tab">
                   <object class="GtkLabel" id="files_page_label">
-                    <property name="label" translatable="1">Files</property>
+                    <property name="label" translatable="yes">Files</property>
                   </object>
                 </property>
               </object>
@@ -648,7 +648,7 @@
                       <object class="GtkFrame">
                         <child type="label">
                           <object class="GtkLabel" id="speed_section_label">
-                            <property name="label" translatable="1">Speed</property>
+                            <property name="label" translatable="yes">Speed</property>
                             <attributes>
                               <attribute name="weight" value="bold"/>
                             </attributes>
@@ -660,7 +660,7 @@
                             <property name="column-spacing">12</property>
                             <child>
                               <object class="GtkCheckButton" id="honor_limits_check">
-                                <property name="label" translatable="1">Honor global _limits</property>
+                                <property name="label" translatable="yes">Honor global _limits</property>
                                 <property name="focusable">1</property>
                                 <property name="valign">center</property>
                                 <property name="use-underline">1</property>
@@ -673,7 +673,7 @@
                             </child>
                             <child>
                               <object class="GtkCheckButton" id="download_limit_check">
-                                <property name="label" translatable="1">Limit _download speed ({speed_units}):</property>
+                                <property name="label" translatable="yes">Limit _download speed ({speed_units}):</property>
                                 <property name="focusable">1</property>
                                 <property name="valign">center</property>
                                 <property name="use-underline">1</property>
@@ -685,7 +685,7 @@
                             </child>
                             <child>
                               <object class="GtkCheckButton" id="upload_limit_check">
-                                <property name="label" translatable="1">Limit _upload speed ({speed_units}):</property>
+                                <property name="label" translatable="yes">Limit _upload speed ({speed_units}):</property>
                                 <property name="focusable">1</property>
                                 <property name="valign">center</property>
                                 <property name="use-underline">1</property>
@@ -697,7 +697,7 @@
                             </child>
                             <child>
                               <object class="GtkLabel" id="priority_label">
-                                <property name="label" translatable="1">Torrent _priority:</property>
+                                <property name="label" translatable="yes">Torrent _priority:</property>
                                 <property name="use-underline">1</property>
                                 <property name="mnemonic-widget">priority_combo</property>
                                 <property name="xalign">0</property>
@@ -746,7 +746,7 @@
                       <object class="GtkFrame">
                         <child type="label">
                           <object class="GtkLabel" id="seeding_limits_section_label">
-                            <property name="label" translatable="1">Seeding Limits</property>
+                            <property name="label" translatable="yes">Seeding Limits</property>
                             <attributes>
                               <attribute name="weight" value="bold"/>
                             </attributes>
@@ -758,7 +758,7 @@
                             <property name="column-spacing">12</property>
                             <child>
                               <object class="GtkLabel" id="ratio_limit_label">
-                                <property name="label" translatable="1">_Ratio:</property>
+                                <property name="label" translatable="yes">_Ratio:</property>
                                 <property name="use-underline">1</property>
                                 <property name="mnemonic-widget">ratio_limit_combo</property>
                                 <property name="xalign">0</property>
@@ -770,7 +770,7 @@
                             </child>
                             <child>
                               <object class="GtkLabel" id="idle_limit_label">
-                                <property name="label" translatable="1">_Idle:</property>
+                                <property name="label" translatable="yes">_Idle:</property>
                                 <property name="use-underline">1</property>
                                 <property name="mnemonic-widget">idle_limit_combo</property>
                                 <property name="xalign">0</property>
@@ -828,7 +828,7 @@
                       <object class="GtkFrame">
                         <child type="label">
                           <object class="GtkLabel" id="peer_connections_section_label">
-                            <property name="label" translatable="1">Peer Connections</property>
+                            <property name="label" translatable="yes">Peer Connections</property>
                             <attributes>
                               <attribute name="weight" value="bold"/>
                             </attributes>
@@ -840,7 +840,7 @@
                             <property name="column-spacing">12</property>
                             <child>
                               <object class="GtkLabel" id="max_peers_label">
-                                <property name="label" translatable="1">_Maximum peers:</property>
+                                <property name="label" translatable="yes">_Maximum peers:</property>
                                 <property name="use-underline">1</property>
                                 <property name="mnemonic-widget">max_peers_spin</property>
                                 <property name="xalign">0</property>
@@ -868,7 +868,7 @@
                 </property>
                 <property name="tab">
                   <object class="GtkLabel" id="options_page_label">
-                    <property name="label" translatable="1">Options</property>
+                    <property name="label" translatable="yes">Options</property>
                   </object>
                 </property>
               </object>
@@ -883,7 +883,7 @@
         <property name="spacing">6</property>
         <child>
           <object class="GtkButton" id="close_button">
-            <property name="label" translatable="1">_Close</property>
+            <property name="label" translatable="yes">_Close</property>
             <property name="focusable">1</property>
             <property name="receives-default">1</property>
             <property name="use-underline">1</property>

--- a/gtk/ui/gtk4/EditTrackersDialog.ui
+++ b/gtk/ui/gtk4/EditTrackersDialog.ui
@@ -17,7 +17,7 @@
               <object class="GtkFrame">
                 <child type="label">
                   <object class="GtkLabel" id="urls_section_title">
-                    <property name="label" translatable="1">Tracker Announce URLs</property>
+                    <property name="label" translatable="yes">Tracker Announce URLs</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
                     </attributes>
@@ -29,7 +29,7 @@
                     <property name="column-spacing">12</property>
                     <child>
                       <object class="GtkLabel" id="urls_section_top_comment_label">
-                        <property name="label" translatable="1"><![CDATA[To add a backup URL, add it on the next line after a primary URL.
+                        <property name="label" translatable="yes"><![CDATA[To add a backup URL, add it on the next line after a primary URL.
 To add a new primary URL, add it after a blank line.]]></property>
                         <property name="xalign">0</property>
                         <layout>
@@ -60,7 +60,7 @@ To add a new primary URL, add it after a blank line.]]></property>
                     </child>
                     <child>
                       <object class="GtkLabel" id="urls_section_bottom_comment_label">
-                        <property name="label" translatable="1">Also see Default Public Trackers in Edit &gt; Preferences &gt; Network</property>
+                        <property name="label" translatable="yes">Also see Default Public Trackers in Edit &gt; Preferences &gt; Network</property>
                         <property name="xalign">0</property>
                         <layout>
                           <property name="column">0</property>
@@ -83,7 +83,7 @@ To add a new primary URL, add it after a blank line.]]></property>
         <property name="spacing">6</property>
         <child>
           <object class="GtkButton" id="cancel_button">
-            <property name="label" translatable="1">_Cancel</property>
+            <property name="label" translatable="yes">_Cancel</property>
             <property name="focusable">1</property>
             <property name="receives-default">1</property>
             <property name="use-underline">1</property>
@@ -91,7 +91,7 @@ To add a new primary URL, add it after a blank line.]]></property>
         </child>
         <child>
           <object class="GtkButton" id="save_button">
-            <property name="label" translatable="1">_Save</property>
+            <property name="label" translatable="yes">_Save</property>
             <property name="focusable">1</property>
             <property name="receives-default">1</property>
             <property name="use-underline">1</property>

--- a/gtk/ui/gtk4/FilterBar.ui
+++ b/gtk/ui/gtk4/FilterBar.ui
@@ -5,7 +5,7 @@
     <property name="spacing">3</property>
     <child>
       <object class="GtkLabel" id="show_label">
-        <property name="label" translatable="1">_Show:</property>
+        <property name="label" translatable="yes">_Show:</property>
         <property name="use-underline">1</property>
         <property name="mnemonic-widget">show_mode_combo</property>
       </object>

--- a/gtk/ui/gtk4/MainWindow.ui
+++ b/gtk/ui/gtk4/MainWindow.ui
@@ -13,7 +13,7 @@ horizontal]]></property>
             <child>
               <object class="GtkButton" id="open_file_button">
                 <property name="focusable">1</property>
-                <property name="tooltip-text" translatable="1">Open a torrent</property>
+                <property name="tooltip-text" translatable="yes">Open a torrent</property>
                 <property name="action-name">win.open-torrent</property>
                 <child>
                   <object class="GtkBox">
@@ -27,7 +27,7 @@ horizontal]]></property>
                     </child>
                     <child>
                       <object class="GtkLabel">
-                        <property name="label" translatable="1">_Open</property>
+                        <property name="label" translatable="yes">_Open</property>
                         <property name="single-line-mode">1</property>
                         <property name="use-underline">1</property>
                       </object>
@@ -39,9 +39,9 @@ horizontal]]></property>
             <child>
               <object class="GtkButton" id="start_torrent_button">
                 <property name="focusable">1</property>
-                <property name="tooltip-text" translatable="1">Start torrent</property>
+                <property name="tooltip-text" translatable="yes">Start torrent</property>
                 <property name="action-name">win.torrent-start</property>
-                <property name="label" translatable="1">_Start</property>
+                <property name="label" translatable="yes">_Start</property>
                 <property name="use-underline">1</property>
                 <property name="icon-name">media-playback-start</property>
               </object>
@@ -49,9 +49,9 @@ horizontal]]></property>
             <child>
               <object class="GtkButton" id="pause_torrent_button">
                 <property name="focusable">1</property>
-                <property name="tooltip-text" translatable="1">Pause torrent</property>
+                <property name="tooltip-text" translatable="yes">Pause torrent</property>
                 <property name="action-name">win.torrent-stop</property>
-                <property name="label" translatable="1">_Pause</property>
+                <property name="label" translatable="yes">_Pause</property>
                 <property name="use-underline">1</property>
                 <property name="icon-name">media-playback-pause</property>
               </object>
@@ -61,7 +61,7 @@ horizontal]]></property>
                 <property name="focusable">1</property>
                 <property name="tooltip-text" translatable="yes">Remove torrent</property>
                 <property name="action-name">win.remove-torrent</property>
-                <property name="label" translatable="1">Remove torrent</property>
+                <property name="label" translatable="yes">Remove torrent</property>
                 <property name="use-underline">1</property>
                 <property name="icon-name">list-remove</property>
               </object>
@@ -75,7 +75,7 @@ horizontal]]></property>
             <child>
               <object class="GtkButton" id="torrent_properties_button">
                 <property name="focusable">1</property>
-                <property name="tooltip-text" translatable="1">Torrent properties</property>
+                <property name="tooltip-text" translatable="yes">Torrent properties</property>
                 <property name="action-name">win.show-torrent-properties</property>
                 <child>
                   <object class="GtkBox">
@@ -89,7 +89,7 @@ horizontal]]></property>
                     </child>
                     <child>
                       <object class="GtkLabel">
-                        <property name="label" translatable="1">_Properties</property>
+                        <property name="label" translatable="yes">_Properties</property>
                         <property name="single-line-mode">1</property>
                         <property name="use-underline">1</property>
                       </object>
@@ -133,7 +133,7 @@ horizontal]]></property>
                 <property name="focusable">1</property>
                 <property name="has-frame">0</property>
                 <property name="receives-default">1</property>
-                <property name="tooltip-text" translatable="1">Options</property>
+                <property name="tooltip-text" translatable="yes">Options</property>
                 <child>
                   <object class="GtkImage" id="gear_button_image">
                     <property name="icon-name">options-symbolic</property>
@@ -187,7 +187,7 @@ horizontal]]></property>
                 <property name="focusable">1</property>
                 <property name="has-frame">0</property>
                 <property name="receives-default">1</property>
-                <property name="tooltip-text" translatable="1">Statistics</property>
+                <property name="tooltip-text" translatable="yes">Statistics</property>
                 <child>
                   <object class="GtkImage" id="ratio_button_image">
                     <property name="icon-name">ratio-symbolic</property>

--- a/gtk/ui/gtk4/MakeDialog.ui
+++ b/gtk/ui/gtk4/MakeDialog.ui
@@ -2,7 +2,7 @@
 <interface domain="transmission-gtk">
   <requires lib="gtk" version="4.0"/>
   <object class="GtkDialog" id="MakeDialog">
-    <property name="title" translatable="1">New Torrent</property>
+    <property name="title" translatable="yes">New Torrent</property>
     <child internal-child="content_area">
       <object class="GtkBox" id="dialog_layout">
         <property name="orientation">vertical</property>
@@ -17,7 +17,7 @@
               <object class="GtkFrame">
                 <child type="label">
                   <object class="GtkLabel" id="files_section_label">
-                    <property name="label" translatable="1">Files</property>
+                    <property name="label" translatable="yes">Files</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
                     </attributes>
@@ -29,7 +29,7 @@
                     <property name="column-spacing">12</property>
                     <child>
                       <object class="GtkLabel" id="destination_label">
-                        <property name="label" translatable="1">Sa_ve to:</property>
+                        <property name="label" translatable="yes">Sa_ve to:</property>
                         <property name="use-underline">1</property>
                         <property name="mnemonic-widget">destination_button</property>
                         <property name="xalign">0</property>
@@ -51,7 +51,7 @@
                     </child>
                     <child>
                       <object class="GtkCheckButton" id="source_folder_radio">
-                        <property name="label" translatable="1">Source F_older:</property>
+                        <property name="label" translatable="yes">Source F_older:</property>
                         <property name="valign">center</property>
                         <property name="use-underline">1</property>
                         <property name="active">1</property>
@@ -74,7 +74,7 @@
                     </child>
                     <child>
                       <object class="GtkCheckButton" id="source_file_radio">
-                        <property name="label" translatable="1">Source _File:</property>
+                        <property name="label" translatable="yes">Source _File:</property>
                         <property name="valign">center</property>
                         <property name="use-underline">1</property>
                         <property name="group">source_folder_radio</property>
@@ -97,7 +97,7 @@
                     <child>
                       <object class="GtkLabel" id="source_size_label">
                         <property name="hexpand">1</property>
-                        <property name="label" translatable="1">No source selected</property>
+                        <property name="label" translatable="yes">No source selected</property>
                         <property name="xalign">0</property>
                         <attributes>
                           <attribute name="style" value="italic"/>
@@ -110,7 +110,7 @@
                     </child>
                     <child>
                       <object class="GtkLabel" id="piece_size_label">
-                        <property name="label" translatable="1">Piece size:</property>
+                        <property name="label" translatable="yes">Piece size:</property>
                         <property name="use-underline">1</property>
                         <property name="mnemonic-widget">piece_size_scale</property>
                         <property name="xalign">0</property>
@@ -143,7 +143,7 @@
               <object class="GtkFrame">
                 <child type="label">
                   <object class="GtkLabel" id="properties_section_label">
-                    <property name="label" translatable="1">Properties</property>
+                    <property name="label" translatable="yes">Properties</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
                     </attributes>
@@ -156,7 +156,7 @@
                     <child>
                       <object class="GtkLabel" id="trackers_label">
                         <property name="valign">start</property>
-                        <property name="label" translatable="1">_Trackers:</property>
+                        <property name="label" translatable="yes">_Trackers:</property>
                         <property name="use-underline">1</property>
                         <property name="mnemonic-widget">trackers_view</property>
                         <property name="xalign">0</property>
@@ -190,7 +190,7 @@
                         <child>
                           <object class="GtkLabel" id="trackers_description_label">
                             <property name="hexpand">1</property>
-                            <property name="label" translatable="1"><![CDATA[To add a backup URL, add it on the next line after a primary URL.
+                            <property name="label" translatable="yes"><![CDATA[To add a backup URL, add it on the next line after a primary URL.
 To add a new primary URL, add it after a blank line.]]></property>
                             <property name="xalign">0</property>
                           </object>
@@ -203,7 +203,7 @@ To add a new primary URL, add it after a blank line.]]></property>
                     </child>
                     <child>
                       <object class="GtkCheckButton" id="comment_check">
-                        <property name="label" translatable="1">Co_mment:</property>
+                        <property name="label" translatable="yes">Co_mment:</property>
                         <property name="focusable">1</property>
                         <property name="valign">center</property>
                         <property name="use-underline">1</property>
@@ -226,7 +226,7 @@ To add a new primary URL, add it after a blank line.]]></property>
                     </child>
                     <child>
                       <object class="GtkCheckButton" id="source_check">
-                        <property name="label" translatable="1">_Source:</property>
+                        <property name="label" translatable="yes">_Source:</property>
                         <property name="focusable">1</property>
                         <property name="valign">center</property>
                         <property name="use-underline">1</property>
@@ -249,7 +249,7 @@ To add a new primary URL, add it after a blank line.]]></property>
                     </child>
                     <child>
                       <object class="GtkCheckButton" id="private_check">
-                        <property name="label" translatable="1">_Private torrent</property>
+                        <property name="label" translatable="yes">_Private torrent</property>
                         <property name="focusable">1</property>
                         <property name="valign">center</property>
                         <property name="use-underline">1</property>
@@ -274,7 +274,7 @@ To add a new primary URL, add it after a blank line.]]></property>
         <property name="spacing">6</property>
         <child>
           <object class="GtkButton" id="close_button">
-            <property name="label" translatable="1">_Close</property>
+            <property name="label" translatable="yes">_Close</property>
             <property name="focusable">1</property>
             <property name="receives-default">1</property>
             <property name="use-underline">1</property>
@@ -282,7 +282,7 @@ To add a new primary URL, add it after a blank line.]]></property>
         </child>
         <child>
           <object class="GtkButton" id="new_button">
-            <property name="label" translatable="1">_New</property>
+            <property name="label" translatable="yes">_New</property>
             <property name="focusable">1</property>
             <property name="receives-default">1</property>
             <property name="use-underline">1</property>

--- a/gtk/ui/gtk4/MakeProgressDialog.ui
+++ b/gtk/ui/gtk4/MakeProgressDialog.ui
@@ -2,7 +2,7 @@
 <interface domain="transmission-gtk">
   <requires lib="gtk" version="4.0"/>
   <object class="GtkDialog" id="MakeProgressDialog">
-    <property name="title" translatable="1">New Torrent</property>
+    <property name="title" translatable="yes">New Torrent</property>
     <property name="modal">1</property>
     <child internal-child="content_area">
       <object class="GtkBox" id="dialog_layout">
@@ -16,7 +16,7 @@
             <property name="spacing">6</property>
             <child>
               <object class="GtkLabel" id="progress_label">
-                <property name="label" translatable="1">Creating torrent…</property>
+                <property name="label" translatable="yes">Creating torrent…</property>
                 <property name="xalign">0</property>
               </object>
             </child>
@@ -33,7 +33,7 @@
         <property name="spacing">6</property>
         <child>
           <object class="GtkButton" id="cancel_button">
-            <property name="label" translatable="1">_Cancel</property>
+            <property name="label" translatable="yes">_Cancel</property>
             <property name="focusable">1</property>
             <property name="receives-default">1</property>
             <property name="use-underline">1</property>
@@ -41,7 +41,7 @@
         </child>
         <child>
           <object class="GtkButton" id="close_button">
-            <property name="label" translatable="1">_Close</property>
+            <property name="label" translatable="yes">_Close</property>
             <property name="focusable">1</property>
             <property name="receives-default">1</property>
             <property name="use-underline">1</property>
@@ -49,7 +49,7 @@
         </child>
         <child>
           <object class="GtkButton" id="add_button">
-            <property name="label" translatable="1">_Add</property>
+            <property name="label" translatable="yes">_Add</property>
             <property name="focusable">1</property>
             <property name="receives-default">1</property>
             <property name="use-underline">1</property>

--- a/gtk/ui/gtk4/MessageLogWindow.ui
+++ b/gtk/ui/gtk4/MessageLogWindow.ui
@@ -2,7 +2,7 @@
 <interface domain="transmission-gtk">
   <requires lib="gtk" version="4.0"/>
   <object class="GtkWindow" id="MessageLogWindow">
-    <property name="title" translatable="1">Message Log</property>
+    <property name="title" translatable="yes">Message Log</property>
     <property name="default-width">750</property>
     <property name="default-height">350</property>
     <property name="child">
@@ -28,7 +28,7 @@ horizontal]]></property>
                     </child>
                     <child>
                       <object class="GtkLabel">
-                        <property name="label" translatable="1">Save _As</property>
+                        <property name="label" translatable="yes">Save _As</property>
                         <property name="single-line-mode">1</property>
                         <property name="use-underline">1</property>
                       </object>
@@ -52,7 +52,7 @@ horizontal]]></property>
                     </child>
                     <child>
                       <object class="GtkLabel">
-                        <property name="label" translatable="1">Clear</property>
+                        <property name="label" translatable="yes">Clear</property>
                         <property name="single-line-mode">1</property>
                         <property name="use-underline">1</property>
                       </object>
@@ -81,7 +81,7 @@ horizontal]]></property>
                     </child>
                     <child>
                       <object class="GtkLabel">
-                        <property name="label" translatable="1">P_ause</property>
+                        <property name="label" translatable="yes">P_ause</property>
                         <property name="single-line-mode">1</property>
                         <property name="use-underline">1</property>
                       </object>
@@ -97,7 +97,7 @@ horizontal]]></property>
             </child>
             <child>
               <object class="GtkLabel" id="level_label">
-                <property name="label" translatable="1">Level</property>
+                <property name="label" translatable="yes">Level</property>
                 <property name="use-underline">1</property>
                 <property name="mnemonic-widget">level_combo</property>
                 <property name="css-classes">tr-pad-normal</property>

--- a/gtk/ui/gtk4/OptionsDialog.ui
+++ b/gtk/ui/gtk4/OptionsDialog.ui
@@ -2,7 +2,7 @@
 <interface domain="transmission-gtk">
   <requires lib="gtk" version="4.0"/>
   <object class="GtkDialog" id="OptionsDialog">
-    <property name="title" translatable="1">Torrent Options</property>
+    <property name="title" translatable="yes">Torrent Options</property>
     <child internal-child="content_area">
       <object class="GtkBox" id="dialog_layout">
         <property name="orientation">vertical</property>
@@ -16,7 +16,7 @@
             <property name="column-spacing">12</property>
             <child>
               <object class="GtkLabel" id="source_label">
-                <property name="label" translatable="1">_Torrent file:</property>
+                <property name="label" translatable="yes">_Torrent file:</property>
                 <property name="use-underline">1</property>
                 <property name="mnemonic-widget">source_button</property>
                 <property name="xalign">0</property>
@@ -29,7 +29,7 @@
             <child>
               <object class="gtkmm__CustomObject_10PathButton" id="source_button">
                 <property name="hexpand">1</property>
-                <property name="title" translatable="1">Select Source File</property>
+                <property name="title" translatable="yes">Select Source File</property>
                 <layout>
                   <property name="column">1</property>
                   <property name="row">0</property>
@@ -38,7 +38,7 @@
             </child>
             <child>
               <object class="GtkLabel" id="destination_label">
-                <property name="label" translatable="1">_Destination folder:</property>
+                <property name="label" translatable="yes">_Destination folder:</property>
                 <property name="use-underline">1</property>
                 <property name="mnemonic-widget">destination_button</property>
                 <property name="xalign">0</property>
@@ -52,7 +52,7 @@
               <object class="gtkmm__CustomObject_10PathButton" id="destination_button">
                 <property name="hexpand">1</property>
                 <property name="action">select-folder</property>
-                <property name="title" translatable="1">Select Destination Folder</property>
+                <property name="title" translatable="yes">Select Destination Folder</property>
                 <layout>
                   <property name="column">1</property>
                   <property name="row">1</property>
@@ -84,7 +84,7 @@
             </child>
             <child>
               <object class="GtkLabel" id="priority_label">
-                <property name="label" translatable="1">Torrent _priority:</property>
+                <property name="label" translatable="yes">Torrent _priority:</property>
                 <property name="use-underline">1</property>
                 <property name="mnemonic-widget">priority_combo</property>
                 <property name="xalign">0</property>
@@ -105,7 +105,7 @@
             </child>
             <child>
               <object class="GtkCheckButton" id="start_check">
-                <property name="label" translatable="1">_Start when added</property>
+                <property name="label" translatable="yes">_Start when added</property>
                 <property name="focusable">1</property>
                 <property name="valign">center</property>
                 <property name="use-underline">1</property>
@@ -118,7 +118,7 @@
             </child>
             <child>
               <object class="GtkCheckButton" id="trash_check">
-                <property name="label" translatable="1">Mo_ve torrent file to the trash</property>
+                <property name="label" translatable="yes">Mo_ve torrent file to the trash</property>
                 <property name="focusable">1</property>
                 <property name="valign">center</property>
                 <property name="use-underline">1</property>
@@ -173,7 +173,7 @@
         <property name="spacing">6</property>
         <child>
           <object class="GtkButton" id="cancel_button">
-            <property name="label" translatable="1">_Cancel</property>
+            <property name="label" translatable="yes">_Cancel</property>
             <property name="focusable">1</property>
             <property name="receives-default">1</property>
             <property name="use-underline">1</property>
@@ -181,7 +181,7 @@
         </child>
         <child>
           <object class="GtkButton" id="open_button">
-            <property name="label" translatable="1">_Open</property>
+            <property name="label" translatable="yes">_Open</property>
             <property name="focusable">1</property>
             <property name="receives-default">1</property>
             <property name="use-underline">1</property>

--- a/gtk/ui/gtk4/PrefsDialog.ui
+++ b/gtk/ui/gtk4/PrefsDialog.ui
@@ -2,7 +2,7 @@
 <interface domain="transmission-gtk">
   <requires lib="gtk" version="4.0"/>
   <object class="GtkDialog" id="PrefsDialog">
-    <property name="title" translatable="1">Transmission Preferences</property>
+    <property name="title" translatable="yes">Transmission Preferences</property>
     <property name="modal">0</property>
     <child internal-child="content_area">
       <object class="GtkBox" id="dialog_layout">
@@ -26,7 +26,7 @@
                       <object class="GtkFrame">
                         <child type="label">
                           <object class="GtkLabel" id="speed_limits_section_label">
-                            <property name="label" translatable="1">Speed Limits</property>
+                            <property name="label" translatable="yes">Speed Limits</property>
                             <attributes>
                               <attribute name="weight" value="bold"/>
                             </attributes>
@@ -38,7 +38,7 @@
                             <property name="column-spacing">12</property>
                             <child>
                               <object class="GtkCheckButton" id="upload_limit_check">
-                                <property name="label" translatable="1" comments="Checkbox to limit upload speed">_Upload ({speed_units}):</property>
+                                <property name="label" translatable="yes" comments="Checkbox to limit upload speed">_Upload ({speed_units}):</property>
                                 <property name="focusable">1</property>
                                 <property name="valign">center</property>
                                 <property name="use-underline">1</property>
@@ -50,7 +50,7 @@
                             </child>
                             <child>
                               <object class="GtkCheckButton" id="download_limit_check">
-                                <property name="label" translatable="1" comments="Checkbox to limit download speed">_Download ({speed_units}):</property>
+                                <property name="label" translatable="yes" comments="Checkbox to limit download speed">_Download ({speed_units}):</property>
                                 <property name="focusable">1</property>
                                 <property name="valign">center</property>
                                 <property name="use-underline">1</property>
@@ -90,7 +90,7 @@
                       <object class="GtkFrame">
                         <child type="label">
                           <object class="GtkLabel" id="alt_speed_limits_section_label">
-                            <property name="label" translatable="1">Alternative Speed Limits</property>
+                            <property name="label" translatable="yes">Alternative Speed Limits</property>
                             <attributes>
                               <attribute name="weight" value="bold"/>
                             </attributes>
@@ -111,7 +111,7 @@
                                 </child>
                                 <child>
                                   <object class="GtkLabel" id="alt_speed_limits_section_comment_label">
-                                    <property name="label" translatable="1">Override normal speed limits manually or at scheduled times</property>
+                                    <property name="label" translatable="yes">Override normal speed limits manually or at scheduled times</property>
                                     <property name="xalign">0</property>
                                     <style>
                                       <class name="tr-small"/>
@@ -127,7 +127,7 @@
                             </child>
                             <child>
                               <object class="GtkLabel" id="alt_upload_limit_label">
-                                <property name="label" translatable="1" comments="Labels a spinbutton for alternate upload speed limits">U_pload ({speed_units}):</property>
+                                <property name="label" translatable="yes" comments="Labels a spinbutton for alternate upload speed limits">U_pload ({speed_units}):</property>
                                 <property name="use-underline">1</property>
                                 <property name="mnemonic-widget">alt_upload_limit_spin</property>
                                 <property name="xalign">0</property>
@@ -139,7 +139,7 @@
                             </child>
                             <child>
                               <object class="GtkLabel" id="alt_download_limit_label">
-                                <property name="label" translatable="1" comments="Labels a spinbutton for alternate download speed limits">Do_wnload ({speed_units}):</property>
+                                <property name="label" translatable="yes" comments="Labels a spinbutton for alternate download speed limits">Do_wnload ({speed_units}):</property>
                                 <property name="use-underline">1</property>
                                 <property name="mnemonic-widget">alt_download_limit_spin</property>
                                 <property name="xalign">0</property>
@@ -151,7 +151,7 @@
                             </child>
                             <child>
                               <object class="GtkCheckButton" id="alt_schedule_time_check">
-                                <property name="label" translatable="1">_Scheduled times:</property>
+                                <property name="label" translatable="yes">_Scheduled times:</property>
                                 <property name="focusable">1</property>
                                 <property name="valign">center</property>
                                 <property name="use-underline">1</property>
@@ -164,7 +164,7 @@
                             <child>
                               <object class="GtkLabel" id="alt_speed_days_label">
                                 <property name="sensitive" bind-source="alt_schedule_time_check" bind-property="active" bind-flags="sync-create">0</property>
-                                <property name="label" translatable="1">_On days:</property>
+                                <property name="label" translatable="yes">_On days:</property>
                                 <property name="use-underline">1</property>
                                 <property name="mnemonic-widget">alt_speed_days_combo</property>
                                 <property name="xalign">0</property>
@@ -207,7 +207,7 @@
                                 <child>
                                   <object class="GtkLabel" id="alt_speed_to_label">
                                     <property name="sensitive" bind-source="alt_schedule_time_check" bind-property="active" bind-flags="sync-create">0</property>
-                                    <property name="label" translatable="1" comments="Label goes between two time selectors, e.g. &quot;limit speeds from [time] to [time]&quot;">_to</property>
+                                    <property name="label" translatable="yes" comments="Label goes between two time selectors, e.g. &quot;limit speeds from [time] to [time]&quot;">_to</property>
                                     <property name="use-underline">1</property>
                                     <property name="mnemonic-widget">alt_speed_end_time_combo</property>
                                   </object>
@@ -242,7 +242,7 @@
                 </property>
                 <property name="tab">
                   <object class="GtkLabel" id="speed_page_label">
-                    <property name="label" translatable="1">Speed</property>
+                    <property name="label" translatable="yes">Speed</property>
                   </object>
                 </property>
               </object>
@@ -259,7 +259,7 @@
                       <object class="GtkFrame">
                         <child type="label">
                           <object class="GtkLabel" id="adding_section_label">
-                            <property name="label" translatable="1" context="Gerund">Adding</property>
+                            <property name="label" translatable="yes" context="Gerund">Adding</property>
                             <attributes>
                               <attribute name="weight" value="bold"/>
                             </attributes>
@@ -271,7 +271,7 @@
                             <property name="column-spacing">12</property>
                             <child>
                               <object class="GtkCheckButton" id="watch_dir_check">
-                                <property name="label" translatable="1">Automatically add torrent files _from:</property>
+                                <property name="label" translatable="yes">Automatically add torrent files _from:</property>
                                 <property name="focusable">1</property>
                                 <property name="valign">center</property>
                                 <property name="use-underline">1</property>
@@ -283,7 +283,7 @@
                             </child>
                             <child>
                               <object class="GtkCheckButton" id="show_options_dialog_check">
-                                <property name="label" translatable="1">Show the Torrent Options _dialog</property>
+                                <property name="label" translatable="yes">Show the Torrent Options _dialog</property>
                                 <property name="focusable">1</property>
                                 <property name="valign">center</property>
                                 <property name="hexpand">1</property>
@@ -297,7 +297,7 @@
                             </child>
                             <child>
                               <object class="GtkCheckButton" id="start_on_add_check">
-                                <property name="label" translatable="1">_Start added torrents</property>
+                                <property name="label" translatable="yes">_Start added torrents</property>
                                 <property name="focusable">1</property>
                                 <property name="valign">center</property>
                                 <property name="hexpand">1</property>
@@ -311,7 +311,7 @@
                             </child>
                             <child>
                               <object class="GtkCheckButton" id="trash_on_add_check">
-                                <property name="label" translatable="1">Mo_ve torrent file to the trash</property>
+                                <property name="label" translatable="yes">Mo_ve torrent file to the trash</property>
                                 <property name="focusable">1</property>
                                 <property name="valign">center</property>
                                 <property name="hexpand">1</property>
@@ -325,7 +325,7 @@
                             </child>
                             <child>
                               <object class="GtkLabel" id="download_dir_label">
-                                <property name="label" translatable="1">Save to _Location:</property>
+                                <property name="label" translatable="yes">Save to _Location:</property>
                                 <property name="use-underline">1</property>
                                 <property name="mnemonic-widget">download_dir_chooser</property>
                                 <property name="xalign">0</property>
@@ -386,7 +386,7 @@
                       <object class="GtkFrame">
                         <child type="label">
                           <object class="GtkLabel" id="download_queue_section_label">
-                            <property name="label" translatable="1">Download Queue</property>
+                            <property name="label" translatable="yes">Download Queue</property>
                             <attributes>
                               <attribute name="weight" value="bold"/>
                             </attributes>
@@ -398,7 +398,7 @@
                             <property name="column-spacing">12</property>
                             <child>
                               <object class="GtkLabel" id="max_active_downloads_label">
-                                <property name="label" translatable="1">Ma_ximum active downloads:</property>
+                                <property name="label" translatable="yes">Ma_ximum active downloads:</property>
                                 <property name="use-underline">1</property>
                                 <property name="mnemonic-widget">max_active_downloads_spin</property>
                                 <property name="xalign">0</property>
@@ -410,7 +410,7 @@
                             </child>
                             <child>
                               <object class="GtkLabel" id="max_inactive_time_label">
-                                <property name="label" translatable="1">Downloads sharing data in the last _N minutes are active:</property>
+                                <property name="label" translatable="yes">Downloads sharing data in the last _N minutes are active:</property>
                                 <property name="use-underline">1</property>
                                 <property name="mnemonic-widget">max_inactive_time_spin</property>
                                 <property name="xalign">0</property>
@@ -448,7 +448,7 @@
                       <object class="GtkFrame">
                         <child type="label">
                           <object class="GtkLabel" id="incomplete_section_label">
-                            <property name="label" translatable="1">Incomplete</property>
+                            <property name="label" translatable="yes">Incomplete</property>
                             <attributes>
                               <attribute name="weight" value="bold"/>
                             </attributes>
@@ -460,7 +460,7 @@
                             <property name="column-spacing">12</property>
                             <child>
                               <object class="GtkCheckButton" id="append_suffix_to_incomplete_check">
-                                <property name="label" translatable="1">Append &quot;._part&quot; to incomplete files&apos; names</property>
+                                <property name="label" translatable="yes">Append &quot;._part&quot; to incomplete files&apos; names</property>
                                 <property name="focusable">1</property>
                                 <property name="valign">center</property>
                                 <property name="hexpand">1</property>
@@ -474,7 +474,7 @@
                             </child>
                             <child>
                               <object class="GtkCheckButton" id="incomplete_dir_check">
-                                <property name="label" translatable="1">Keep _incomplete torrents in:</property>
+                                <property name="label" translatable="yes">Keep _incomplete torrents in:</property>
                                 <property name="focusable">1</property>
                                 <property name="valign">center</property>
                                 <property name="use-underline">1</property>
@@ -486,7 +486,7 @@
                             </child>
                             <child>
                               <object class="GtkCheckButton" id="download_done_script_check">
-                                <property name="label" translatable="1">Call scrip_t when done downloading:</property>
+                                <property name="label" translatable="yes">Call scrip_t when done downloading:</property>
                                 <property name="focusable">1</property>
                                 <property name="valign">center</property>
                                 <property name="use-underline">1</property>
@@ -525,7 +525,7 @@
                 </property>
                 <property name="tab">
                   <object class="GtkLabel" id="downloading_page_label">
-                    <property name="label" translatable="1" context="Gerund">Downloading</property>
+                    <property name="label" translatable="yes" context="Gerund">Downloading</property>
                   </object>
                 </property>
               </object>
@@ -542,7 +542,7 @@
                       <object class="GtkFrame">
                         <child type="label">
                           <object class="GtkLabel" id="limits_section_label">
-                            <property name="label" translatable="1">Limits</property>
+                            <property name="label" translatable="yes">Limits</property>
                             <attributes>
                               <attribute name="weight" value="bold"/>
                             </attributes>
@@ -554,7 +554,7 @@
                             <property name="column-spacing">12</property>
                             <child>
                               <object class="GtkCheckButton" id="stop_seeding_ratio_check">
-                                <property name="label" translatable="1">Stop seeding at _ratio:</property>
+                                <property name="label" translatable="yes">Stop seeding at _ratio:</property>
                                 <property name="focusable">1</property>
                                 <property name="valign">center</property>
                                 <property name="use-underline">1</property>
@@ -566,7 +566,7 @@
                             </child>
                             <child>
                               <object class="GtkCheckButton" id="stop_seeding_timeout_check">
-                                <property name="label" translatable="1">Stop seeding if idle for _N minutes:</property>
+                                <property name="label" translatable="yes">Stop seeding if idle for _N minutes:</property>
                                 <property name="focusable">1</property>
                                 <property name="valign">center</property>
                                 <property name="use-underline">1</property>
@@ -578,7 +578,7 @@
                             </child>
                             <child>
                               <object class="GtkCheckButton" id="seeding_done_script_check">
-                                <property name="label" translatable="1">Call scrip_t when done seeding:</property>
+                                <property name="label" translatable="yes">Call scrip_t when done seeding:</property>
                                 <property name="focusable">1</property>
                                 <property name="valign">center</property>
                                 <property name="use-underline">1</property>
@@ -628,7 +628,7 @@
                 </property>
                 <property name="tab">
                   <object class="GtkLabel" id="seeding_page_label">
-                    <property name="label" translatable="1" context="Gerund">Seeding</property>
+                    <property name="label" translatable="yes" context="Gerund">Seeding</property>
                   </object>
                 </property>
               </object>
@@ -645,7 +645,7 @@
                       <object class="GtkFrame">
                         <child type="label">
                           <object class="GtkLabel" id="privacy_section_label">
-                            <property name="label" translatable="1">Privacy</property>
+                            <property name="label" translatable="yes">Privacy</property>
                             <attributes>
                               <attribute name="weight" value="bold"/>
                             </attributes>
@@ -657,7 +657,7 @@
                             <property name="column-spacing">12</property>
                             <child>
                               <object class="GtkLabel" id="encryption_mode_label">
-                                <property name="label" translatable="1">_Encryption mode:</property>
+                                <property name="label" translatable="yes">_Encryption mode:</property>
                                 <property name="use-underline">1</property>
                                 <property name="mnemonic-widget">encryption_mode_combo</property>
                                 <property name="xalign">0</property>
@@ -684,7 +684,7 @@
                       <object class="GtkFrame">
                         <child type="label">
                           <object class="GtkLabel" id="blocklist_section_label">
-                            <property name="label" translatable="1">Blocklist</property>
+                            <property name="label" translatable="yes">Blocklist</property>
                             <attributes>
                               <attribute name="weight" value="bold"/>
                             </attributes>
@@ -696,7 +696,7 @@
                             <property name="column-spacing">12</property>
                             <child>
                               <object class="GtkCheckButton" id="blocklist_check">
-                                <property name="label" translatable="1">Enable _blocklist:</property>
+                                <property name="label" translatable="yes">Enable _blocklist:</property>
                                 <property name="focusable">1</property>
                                 <property name="valign">center</property>
                                 <property name="use-underline">1</property>
@@ -709,7 +709,7 @@
                             <child>
                               <object class="GtkCheckButton" id="blocklist_autoupdate_check">
                                 <property name="sensitive" bind-source="blocklist_check" bind-property="active" bind-flags="sync-create">0</property>
-                                <property name="label" translatable="1">Enable _automatic updates</property>
+                                <property name="label" translatable="yes">Enable _automatic updates</property>
                                 <property name="focusable">1</property>
                                 <property name="valign">center</property>
                                 <property name="hexpand">1</property>
@@ -750,7 +750,7 @@
                                 </child>
                                 <child>
                                   <object class="GtkButton" id="update_blocklist_button">
-                                    <property name="label" translatable="1">_Update</property>
+                                    <property name="label" translatable="yes">_Update</property>
                                     <property name="focusable">1</property>
                                     <property name="receives-default">1</property>
                                     <property name="use-underline">1</property>
@@ -780,7 +780,7 @@
                 </property>
                 <property name="tab">
                   <object class="GtkLabel" id="privacy_page_label">
-                    <property name="label" translatable="1">Privacy</property>
+                    <property name="label" translatable="yes">Privacy</property>
                   </object>
                 </property>
               </object>
@@ -798,7 +798,7 @@
                       <object class="GtkFrame">
                         <child type="label">
                           <object class="GtkLabel" id="listening_port_section_label">
-                            <property name="label" translatable="1">Listening Port</property>
+                            <property name="label" translatable="yes">Listening Port</property>
                             <attributes>
                               <attribute name="weight" value="bold"/>
                             </attributes>
@@ -810,7 +810,7 @@
                             <property name="column-spacing">12</property>
                             <child>
                               <object class="GtkLabel" id="listening_port_label">
-                                <property name="label" translatable="1">_Port used for incoming connections:</property>
+                                <property name="label" translatable="yes">_Port used for incoming connections:</property>
                                 <property name="use-underline">1</property>
                                 <property name="mnemonic-widget">listening_port_spin</property>
                                 <property name="xalign">0</property>
@@ -822,7 +822,7 @@
                             </child>
                             <child>
                               <object class="GtkCheckButton" id="pick_random_listening_port_at_start_check">
-                                <property name="label" translatable="1">Pick a _random port every time Transmission is started</property>
+                                <property name="label" translatable="yes">Pick a _random port every time Transmission is started</property>
                                 <property name="focusable">1</property>
                                 <property name="valign">center</property>
                                 <property name="hexpand">1</property>
@@ -836,7 +836,7 @@
                             </child>
                             <child>
                               <object class="GtkCheckButton" id="enable_listening_port_forwarding_check">
-                                <property name="label" translatable="1">Use UPnP or NAT-PMP port _forwarding from my router</property>
+                                <property name="label" translatable="yes">Use UPnP or NAT-PMP port _forwarding from my router</property>
                                 <property name="focusable">1</property>
                                 <property name="valign">center</property>
                                 <property name="hexpand">1</property>
@@ -888,7 +888,7 @@
                                 </child>
                                 <child>
                                   <object class="GtkButton" id="test_listening_port_button">
-                                    <property name="label" translatable="1">Te_st Port</property>
+                                    <property name="label" translatable="yes">Te_st Port</property>
                                     <property name="focusable">1</property>
                                     <property name="receives-default">1</property>
                                     <property name="use-underline">1</property>
@@ -908,7 +908,7 @@
                       <object class="GtkFrame">
                         <child type="label">
                           <object class="GtkLabel" id="peer_limits_section_label">
-                            <property name="label" translatable="1">Peer Limits</property>
+                            <property name="label" translatable="yes">Peer Limits</property>
                             <attributes>
                               <attribute name="weight" value="bold"/>
                             </attributes>
@@ -920,7 +920,7 @@
                             <property name="column-spacing">12</property>
                             <child>
                               <object class="GtkLabel" id="max_torrent_peers_label">
-                                <property name="label" translatable="1">Maximum peers per _torrent:</property>
+                                <property name="label" translatable="yes">Maximum peers per _torrent:</property>
                                 <property name="use-underline">1</property>
                                 <property name="mnemonic-widget">max_torrent_peers_spin</property>
                                 <property name="xalign">0</property>
@@ -932,7 +932,7 @@
                             </child>
                             <child>
                               <object class="GtkLabel" id="max_total_peers_label">
-                                <property name="label" translatable="1">Maximum peers _overall:</property>
+                                <property name="label" translatable="yes">Maximum peers _overall:</property>
                                 <property name="use-underline">1</property>
                                 <property name="mnemonic-widget">max_total_peers_spin</property>
                                 <property name="xalign">0</property>
@@ -970,7 +970,7 @@
                       <object class="GtkFrame">
                         <child type="label">
                           <object class="GtkLabel" id="network_options_section_label">
-                            <property name="label" translatable="1">Options</property>
+                            <property name="label" translatable="yes">Options</property>
                             <attributes>
                               <attribute name="weight" value="bold"/>
                             </attributes>
@@ -982,9 +982,9 @@
                             <property name="column-spacing">12</property>
                             <child>
                               <object class="GtkCheckButton" id="enable_utp_check">
-                                <property name="label" translatable="1">Enable µ_TP for peer communication</property>
+                                <property name="label" translatable="yes">Enable µ_TP for peer communication</property>
                                 <property name="focusable">1</property>
-                                <property name="tooltip-text" translatable="1">µTP is a tool for reducing network congestion.</property>
+                                <property name="tooltip-text" translatable="yes">µTP is a tool for reducing network congestion.</property>
                                 <property name="valign">center</property>
                                 <property name="hexpand">1</property>
                                 <property name="use-underline">1</property>
@@ -997,9 +997,9 @@
                             </child>
                             <child>
                               <object class="GtkCheckButton" id="enable_pex_check">
-                                <property name="label" translatable="1">Use PE_X to find more peers</property>
+                                <property name="label" translatable="yes">Use PE_X to find more peers</property>
                                 <property name="focusable">1</property>
-                                <property name="tooltip-text" translatable="1">PEX is a tool for exchanging peer lists with the peers you&apos;re connected to.</property>
+                                <property name="tooltip-text" translatable="yes">PEX is a tool for exchanging peer lists with the peers you&apos;re connected to.</property>
                                 <property name="valign">center</property>
                                 <property name="hexpand">1</property>
                                 <property name="use-underline">1</property>
@@ -1012,9 +1012,9 @@
                             </child>
                             <child>
                               <object class="GtkCheckButton" id="enable_dht_check">
-                                <property name="label" translatable="1">Use _DHT to find more peers</property>
+                                <property name="label" translatable="yes">Use _DHT to find more peers</property>
                                 <property name="focusable">1</property>
-                                <property name="tooltip-text" translatable="1">DHT is a tool for finding peers without a tracker.</property>
+                                <property name="tooltip-text" translatable="yes">DHT is a tool for finding peers without a tracker.</property>
                                 <property name="valign">center</property>
                                 <property name="hexpand">1</property>
                                 <property name="use-underline">1</property>
@@ -1027,9 +1027,9 @@
                             </child>
                             <child>
                               <object class="GtkCheckButton" id="enable_lpd_check">
-                                <property name="label" translatable="1">Use _Local Peer Discovery to find more peers</property>
+                                <property name="label" translatable="yes">Use _Local Peer Discovery to find more peers</property>
                                 <property name="focusable">1</property>
-                                <property name="tooltip-text" translatable="1">LPD is a tool for finding peers on your local network.</property>
+                                <property name="tooltip-text" translatable="yes">LPD is a tool for finding peers on your local network.</property>
                                 <property name="valign">center</property>
                                 <property name="hexpand">1</property>
                                 <property name="use-underline">1</property>
@@ -1048,7 +1048,7 @@
                       <object class="GtkFrame">
                         <child type="label">
                           <object class="GtkLabel" id="default_trackers_section_label">
-                            <property name="label" translatable="1">Default Public Trackers</property>
+                            <property name="label" translatable="yes">Default Public Trackers</property>
                             <attributes>
                               <attribute name="weight" value="bold"/>
                             </attributes>
@@ -1070,7 +1070,7 @@
                                   <object class="GtkTextView" id="default_trackers_view">
                                     <property name="focusable">1</property>
                                     <property name="accepts-tab">0</property>
-                                    <property name="tooltip-text" translatable="1"><![CDATA[Trackers to use on all public torrents.
+                                    <property name="tooltip-text" translatable="yes"><![CDATA[Trackers to use on all public torrents.
 
 To add a backup URL, add it on the next line after a primary URL.
 To add a new primary URL, add it after a blank line.]]></property>
@@ -1092,7 +1092,7 @@ To add a new primary URL, add it after a blank line.]]></property>
                 </property>
                 <property name="tab">
                   <object class="GtkLabel" id="network_page_label">
-                    <property name="label" translatable="1">Network</property>
+                    <property name="label" translatable="yes">Network</property>
                   </object>
                 </property>
               </object>
@@ -1109,7 +1109,7 @@ To add a new primary URL, add it after a blank line.]]></property>
                       <object class="GtkFrame">
                         <child type="label">
                           <object class="GtkLabel" id="desktop_section_label">
-                            <property name="label" translatable="1">Desktop</property>
+                            <property name="label" translatable="yes">Desktop</property>
                             <attributes>
                               <attribute name="weight" value="bold"/>
                             </attributes>
@@ -1121,7 +1121,7 @@ To add a new primary URL, add it after a blank line.]]></property>
                             <property name="column-spacing">12</property>
                             <child>
                               <object class="GtkCheckButton" id="inhibit_hibernation_check">
-                                <property name="label" translatable="1">_Inhibit hibernation when torrents are active</property>
+                                <property name="label" translatable="yes">_Inhibit hibernation when torrents are active</property>
                                 <property name="focusable">1</property>
                                 <property name="valign">center</property>
                                 <property name="hexpand">1</property>
@@ -1135,7 +1135,7 @@ To add a new primary URL, add it after a blank line.]]></property>
                             </child>
                             <child>
                               <object class="GtkCheckButton" id="show_systray_icon_check">
-                                <property name="label" translatable="1">Show Transmission icon in the _notification area</property>
+                                <property name="label" translatable="yes">Show Transmission icon in the _notification area</property>
                                 <property name="focusable">1</property>
                                 <property name="valign">center</property>
                                 <property name="hexpand">1</property>
@@ -1155,7 +1155,7 @@ To add a new primary URL, add it after a blank line.]]></property>
                       <object class="GtkFrame">
                         <child type="label">
                           <object class="GtkLabel" id="notification_section_label">
-                            <property name="label" translatable="1">Notification</property>
+                            <property name="label" translatable="yes">Notification</property>
                             <attributes>
                               <attribute name="weight" value="bold"/>
                             </attributes>
@@ -1167,7 +1167,7 @@ To add a new primary URL, add it after a blank line.]]></property>
                             <property name="column-spacing">12</property>
                             <child>
                               <object class="GtkCheckButton" id="notify_on_torrent_add_check">
-                                <property name="label" translatable="1">Show a notification when torrents are a_dded</property>
+                                <property name="label" translatable="yes">Show a notification when torrents are a_dded</property>
                                 <property name="focusable">1</property>
                                 <property name="valign">center</property>
                                 <property name="hexpand">1</property>
@@ -1181,7 +1181,7 @@ To add a new primary URL, add it after a blank line.]]></property>
                             </child>
                             <child>
                               <object class="GtkCheckButton" id="notify_on_torrent_finish_check">
-                                <property name="label" translatable="1">Show a notification when torrents _finish</property>
+                                <property name="label" translatable="yes">Show a notification when torrents _finish</property>
                                 <property name="focusable">1</property>
                                 <property name="valign">center</property>
                                 <property name="hexpand">1</property>
@@ -1195,7 +1195,7 @@ To add a new primary URL, add it after a blank line.]]></property>
                             </child>
                             <child>
                               <object class="GtkCheckButton" id="ding_no_torrent_finish_check">
-                                <property name="label" translatable="1">Play a _sound when torrents finish</property>
+                                <property name="label" translatable="yes">Play a _sound when torrents finish</property>
                                 <property name="focusable">1</property>
                                 <property name="valign">center</property>
                                 <property name="hexpand">1</property>
@@ -1215,7 +1215,7 @@ To add a new primary URL, add it after a blank line.]]></property>
                 </property>
                 <property name="tab">
                   <object class="GtkLabel" id="desktop_page_label">
-                    <property name="label" translatable="1">Desktop</property>
+                    <property name="label" translatable="yes">Desktop</property>
                   </object>
                 </property>
               </object>
@@ -1232,7 +1232,7 @@ To add a new primary URL, add it after a blank line.]]></property>
                       <object class="GtkFrame">
                         <child type="label">
                           <object class="GtkLabel" id="remote_control_section_label">
-                            <property name="label" translatable="1">Remote Control</property>
+                            <property name="label" translatable="yes">Remote Control</property>
                             <attributes>
                               <attribute name="weight" value="bold"/>
                             </attributes>
@@ -1249,7 +1249,7 @@ To add a new primary URL, add it after a blank line.]]></property>
                                 <child>
                                   <object class="GtkCheckButton" id="enable_rpc_check">
                                     <property name="hexpand">1</property>
-                                    <property name="label" translatable="1">Allow _remote access</property>
+                                    <property name="label" translatable="yes">Allow _remote access</property>
                                     <property name="focusable">1</property>
                                     <property name="valign">center</property>
                                     <property name="use-underline">1</property>
@@ -1258,7 +1258,7 @@ To add a new primary URL, add it after a blank line.]]></property>
                                 <child>
                                   <object class="GtkButton" id="open_web_client_button">
                                     <property name="sensitive" bind-source="enable_rpc_check" bind-property="active" bind-flags="sync-create">0</property>
-                                    <property name="label" translatable="1">_Open web client</property>
+                                    <property name="label" translatable="yes">_Open web client</property>
                                     <property name="focusable">1</property>
                                     <property name="receives-default">1</property>
                                     <property name="use-underline">1</property>
@@ -1274,7 +1274,7 @@ To add a new primary URL, add it after a blank line.]]></property>
                             <child>
                               <object class="GtkLabel" id="rpc_port_label">
                                 <property name="sensitive" bind-source="enable_rpc_check" bind-property="active" bind-flags="sync-create">0</property>
-                                <property name="label" translatable="1">HTTP _port:</property>
+                                <property name="label" translatable="yes">HTTP _port:</property>
                                 <property name="use-underline">1</property>
                                 <property name="mnemonic-widget">rpc_port_spin</property>
                                 <property name="xalign">0</property>
@@ -1287,7 +1287,7 @@ To add a new primary URL, add it after a blank line.]]></property>
                             <child>
                               <object class="GtkCheckButton" id="enable_rpc_auth_check">
                                 <property name="sensitive" bind-source="enable_rpc_check" bind-property="active" bind-flags="sync-create">0</property>
-                                <property name="label" translatable="1">Use _authentication</property>
+                                <property name="label" translatable="yes">Use _authentication</property>
                                 <property name="focusable">1</property>
                                 <property name="valign">center</property>
                                 <property name="hexpand">1</property>
@@ -1301,7 +1301,7 @@ To add a new primary URL, add it after a blank line.]]></property>
                             </child>
                             <child>
                               <object class="GtkLabel" id="rpc_username_label">
-                                <property name="label" translatable="1">_Username:</property>
+                                <property name="label" translatable="yes">_Username:</property>
                                 <property name="use-underline">1</property>
                                 <property name="mnemonic-widget">rpc_username_entry</property>
                                 <property name="xalign">0</property>
@@ -1313,7 +1313,7 @@ To add a new primary URL, add it after a blank line.]]></property>
                             </child>
                             <child>
                               <object class="GtkLabel" id="rpc_password_label">
-                                <property name="label" translatable="1">Pass_word:</property>
+                                <property name="label" translatable="yes">Pass_word:</property>
                                 <property name="use-underline">1</property>
                                 <property name="mnemonic-widget">rpc_password_entry</property>
                                 <property name="xalign">0</property>
@@ -1326,7 +1326,7 @@ To add a new primary URL, add it after a blank line.]]></property>
                             <child>
                               <object class="GtkCheckButton" id="rpc_whitelist_check">
                                 <property name="sensitive" bind-source="enable_rpc_check" bind-property="active" bind-flags="sync-create">0</property>
-                                <property name="label" translatable="1">Only allow these IP a_ddresses:</property>
+                                <property name="label" translatable="yes">Only allow these IP a_ddresses:</property>
                                 <property name="focusable">1</property>
                                 <property name="valign">center</property>
                                 <property name="hexpand">1</property>
@@ -1342,7 +1342,7 @@ To add a new primary URL, add it after a blank line.]]></property>
                               <object class="GtkLabel" id="rpc_whitelist_label">
                                 <property name="margin-top">6</property>
                                 <property name="margin-bottom">6</property>
-                                <property name="label" translatable="1">Addresses:</property>
+                                <property name="label" translatable="yes">Addresses:</property>
                                 <property name="use-underline">1</property>
                                 <property name="mnemonic-widget">rpc_whitelist_view</property>
                                 <property name="xalign">0</property>
@@ -1400,7 +1400,7 @@ To add a new primary URL, add it after a blank line.]]></property>
                                 <property name="spacing">6</property>
                                 <child>
                                   <object class="GtkButton" id="add_to_rpc_whitelist_button">
-                                    <property name="label" translatable="1">_Add</property>
+                                    <property name="label" translatable="yes">_Add</property>
                                     <property name="focusable">1</property>
                                     <property name="receives-default">1</property>
                                     <property name="use-underline">1</property>
@@ -1408,7 +1408,7 @@ To add a new primary URL, add it after a blank line.]]></property>
                                 </child>
                                 <child>
                                   <object class="GtkButton" id="remove_from_rpc_whistlist_button">
-                                    <property name="label" translatable="1">_Remove</property>
+                                    <property name="label" translatable="yes">_Remove</property>
                                     <property name="focusable">1</property>
                                     <property name="receives-default">1</property>
                                     <property name="use-underline">1</property>
@@ -1430,7 +1430,7 @@ To add a new primary URL, add it after a blank line.]]></property>
                                 <property name="child">
                                   <object class="GtkTreeView" id="rpc_whitelist_view">
                                     <property name="focusable">1</property>
-                                    <property name="tooltip-text" translatable="1">IP addresses may use wildcards, such as 192.168.*.*</property>
+                                    <property name="tooltip-text" translatable="yes">IP addresses may use wildcards, such as 192.168.*.*</property>
                                     <property name="headers-visible">0</property>
                                     <child internal-child="selection">
                                       <object class="GtkTreeSelection" id="rpc_whitelist_view_selection"/>
@@ -1451,7 +1451,7 @@ To add a new primary URL, add it after a blank line.]]></property>
                 </property>
                 <property name="tab">
                   <object class="GtkLabel" id="remote_page_label">
-                    <property name="label" translatable="1">Remote</property>
+                    <property name="label" translatable="yes">Remote</property>
                   </object>
                 </property>
               </object>
@@ -1468,7 +1468,7 @@ To add a new primary URL, add it after a blank line.]]></property>
         <property name="halign">0</property>
         <child>
           <object class="GtkButton" id="help_button">
-            <property name="label" translatable="1">_Help</property>
+            <property name="label" translatable="yes">_Help</property>
             <property name="focusable">1</property>
             <property name="receives-default">1</property>
             <property name="use-underline">1</property>
@@ -1481,7 +1481,7 @@ To add a new primary URL, add it after a blank line.]]></property>
         </child>
         <child>
           <object class="GtkButton" id="close_button">
-            <property name="label" translatable="1">_Close</property>
+            <property name="label" translatable="yes">_Close</property>
             <property name="focusable">1</property>
             <property name="receives-default">1</property>
             <property name="use-underline">1</property>

--- a/gtk/ui/gtk4/RelocateDialog.ui
+++ b/gtk/ui/gtk4/RelocateDialog.ui
@@ -2,7 +2,7 @@
 <interface domain="transmission-gtk">
   <requires lib="gtk" version="4.0"/>
   <object class="GtkDialog" id="RelocateDialog">
-    <property name="title" translatable="1">Set Torrent Location</property>
+    <property name="title" translatable="yes">Set Torrent Location</property>
     <child internal-child="content_area">
       <object class="GtkBox" id="dialog_layout">
         <property name="orientation">vertical</property>
@@ -17,7 +17,7 @@
               <object class="GtkFrame">
                 <child type="label">
                   <object class="GtkLabel" id="set_location_section_label">
-                    <property name="label" translatable="1">Location</property>
+                    <property name="label" translatable="yes">Location</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
                     </attributes>
@@ -30,7 +30,7 @@
                     <child>
                       <object class="GtkLabel" id="new_location_label">
                         <property name="halign">start</property>
-                        <property name="label" translatable="1">Torrent _location:</property>
+                        <property name="label" translatable="yes">Torrent _location:</property>
                         <property name="use-underline">1</property>
                         <property name="mnemonic-widget">new_location_button</property>
                         <property name="xalign">0</property>
@@ -52,7 +52,7 @@
                     </child>
                     <child>
                       <object class="GtkCheckButton" id="move_data_radio">
-                        <property name="label" translatable="1">_Move from the current folder</property>
+                        <property name="label" translatable="yes">_Move from the current folder</property>
                         <property name="valign">center</property>
                         <property name="use-underline">1</property>
                         <property name="active">1</property>
@@ -65,7 +65,7 @@
                     </child>
                     <child>
                       <object class="GtkCheckButton" id="find_data_radio">
-                        <property name="label" translatable="1">Local data is _already there</property>
+                        <property name="label" translatable="yes">Local data is _already there</property>
                         <property name="valign">center</property>
                         <property name="use-underline">1</property>
                         <property name="group">move_data_radio</property>
@@ -90,7 +90,7 @@
         <property name="spacing">6</property>
         <child>
           <object class="GtkButton" id="cancel_button">
-            <property name="label" translatable="1">_Cancel</property>
+            <property name="label" translatable="yes">_Cancel</property>
             <property name="focusable">1</property>
             <property name="receives-default">1</property>
             <property name="use-underline">1</property>
@@ -98,7 +98,7 @@
         </child>
         <child>
           <object class="GtkButton" id="apply_button">
-            <property name="label" translatable="1">_Apply</property>
+            <property name="label" translatable="yes">_Apply</property>
             <property name="focusable">1</property>
             <property name="receives-default">1</property>
             <property name="use-underline">1</property>

--- a/gtk/ui/gtk4/StatsDialog.ui
+++ b/gtk/ui/gtk4/StatsDialog.ui
@@ -2,7 +2,7 @@
 <interface domain="transmission-gtk">
   <requires lib="gtk" version="4.0"/>
   <object class="GtkDialog" id="StatsDialog">
-    <property name="title" translatable="1">Statistics</property>
+    <property name="title" translatable="yes">Statistics</property>
     <child internal-child="content_area">
       <object class="GtkBox" id="dialog_layout">
         <property name="orientation">vertical</property>
@@ -17,7 +17,7 @@
               <object class="GtkFrame">
                 <child type="label">
                   <object class="GtkLabel" id="current_session_section_label">
-                    <property name="label" translatable="1">Current Session</property>
+                    <property name="label" translatable="yes">Current Session</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
                     </attributes>
@@ -29,7 +29,7 @@
                     <property name="column-spacing">12</property>
                     <child>
                       <object class="GtkLabel" id="current_uploaded_label">
-                        <property name="label" translatable="1">Uploaded:</property>
+                        <property name="label" translatable="yes">Uploaded:</property>
                         <property name="xalign">0</property>
                         <layout>
                           <property name="column">0</property>
@@ -54,7 +54,7 @@
                     </child>
                     <child>
                       <object class="GtkLabel" id="current_downloaded_label">
-                        <property name="label" translatable="1">Downloaded:</property>
+                        <property name="label" translatable="yes">Downloaded:</property>
                         <property name="xalign">0</property>
                         <layout>
                           <property name="column">0</property>
@@ -79,7 +79,7 @@
                     </child>
                     <child>
                       <object class="GtkLabel" id="current_ratio_label">
-                        <property name="label" translatable="1">Ratio:</property>
+                        <property name="label" translatable="yes">Ratio:</property>
                         <property name="xalign">0</property>
                         <layout>
                           <property name="column">0</property>
@@ -104,7 +104,7 @@
                     </child>
                     <child>
                       <object class="GtkLabel" id="current_duration_label">
-                        <property name="label" translatable="1">Duration:</property>
+                        <property name="label" translatable="yes">Duration:</property>
                         <property name="xalign">0</property>
                         <layout>
                           <property name="column">0</property>
@@ -135,7 +135,7 @@
               <object class="GtkFrame">
                 <child type="label">
                   <object class="GtkLabel" id="total_section_label">
-                    <property name="label" translatable="1">Total</property>
+                    <property name="label" translatable="yes">Total</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
                     </attributes>
@@ -161,7 +161,7 @@
                     </child>
                     <child>
                       <object class="GtkLabel" id="total_uploaded_label">
-                        <property name="label" translatable="1">Uploaded:</property>
+                        <property name="label" translatable="yes">Uploaded:</property>
                         <property name="xalign">0</property>
                         <layout>
                           <property name="column">0</property>
@@ -186,7 +186,7 @@
                     </child>
                     <child>
                       <object class="GtkLabel" id="total_downloaded_label">
-                        <property name="label" translatable="1">Downloaded:</property>
+                        <property name="label" translatable="yes">Downloaded:</property>
                         <property name="xalign">0</property>
                         <layout>
                           <property name="column">0</property>
@@ -211,7 +211,7 @@
                     </child>
                     <child>
                       <object class="GtkLabel" id="total_ratio_label">
-                        <property name="label" translatable="1">Ratio:</property>
+                        <property name="label" translatable="yes">Ratio:</property>
                         <property name="xalign">0</property>
                         <layout>
                           <property name="column">0</property>
@@ -236,7 +236,7 @@
                     </child>
                     <child>
                       <object class="GtkLabel" id="total_duration_label">
-                        <property name="label" translatable="1">Duration:</property>
+                        <property name="label" translatable="yes">Duration:</property>
                         <property name="xalign">0</property>
                         <layout>
                           <property name="column">0</property>
@@ -273,7 +273,7 @@
         <property name="spacing">6</property>
         <child>
           <object class="GtkButton" id="reset_button">
-            <property name="label" translatable="1">_Reset</property>
+            <property name="label" translatable="yes">_Reset</property>
             <property name="focusable">1</property>
             <property name="receives-default">1</property>
             <property name="use-underline">1</property>
@@ -281,7 +281,7 @@
         </child>
         <child>
           <object class="GtkButton" id="close_button">
-            <property name="label" translatable="1">_Close</property>
+            <property name="label" translatable="yes">_Close</property>
             <property name="focusable">1</property>
             <property name="receives-default">1</property>
             <property name="use-underline">1</property>

--- a/gtk/ui/gtk4/TorrentUrlChooserDialog.ui
+++ b/gtk/ui/gtk4/TorrentUrlChooserDialog.ui
@@ -2,7 +2,7 @@
 <interface domain="transmission-gtk">
   <requires lib="gtk" version="4.0"/>
   <object class="GtkDialog" id="TorrentUrlChooserDialog">
-    <property name="title" translatable="1">Open URL</property>
+    <property name="title" translatable="yes">Open URL</property>
     <child internal-child="content_area">
       <object class="GtkBox" id="dialog_layout">
         <property name="orientation">vertical</property>
@@ -17,7 +17,7 @@
               <object class="GtkFrame">
                 <child type="label">
                   <object class="GtkLabel" id="url_section_label">
-                    <property name="label" translatable="1">Open torrent from URL</property>
+                    <property name="label" translatable="yes">Open torrent from URL</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
                     </attributes>
@@ -29,7 +29,7 @@
                     <property name="column-spacing">12</property>
                     <child>
                       <object class="GtkLabel" id="url_label">
-                        <property name="label" translatable="1">_URL</property>
+                        <property name="label" translatable="yes">_URL</property>
                         <property name="use-underline">1</property>
                         <property name="mnemonic-widget">url_entry</property>
                         <layout>
@@ -64,7 +64,7 @@
         <property name="spacing">6</property>
         <child>
           <object class="GtkButton" id="cancel_button">
-            <property name="label" translatable="1">_Cancel</property>
+            <property name="label" translatable="yes">_Cancel</property>
             <property name="focusable">1</property>
             <property name="receives-default">1</property>
             <property name="use-underline">1</property>
@@ -72,7 +72,7 @@
         </child>
         <child>
           <object class="GtkButton" id="open_button">
-            <property name="label" translatable="1">_Open</property>
+            <property name="label" translatable="yes">_Open</property>
             <property name="focusable">1</property>
             <property name="receives-default">1</property>
             <property name="use-underline">1</property>


### PR DESCRIPTION
Fixes https://github.com/transmission/transmission/issues/8255.

Replace all occurrences of `translatable="1"` and `translatable="true"`.  With `translatable="yes"`. [xgettext only checks for "yes"](https://github.com/GNOME/gtk/blob/main/gtk/gtkbuilder.c#L149), so some strings were not getting flagged for translation.

```sh
$ GTK_DEBUG='builder' ./gtk/transmission-gtk
Useless translatable attribute: '1' (xgettext only recognizes 'yes')
Useless translatable attribute: 'true' (xgettext only recognizes 'yes')
Useless translatable attribute: 'true' (xgettext only recognizes 'yes')
Useless translatable attribute: 'true' (xgettext only recognizes 'yes')
Useless translatable attribute: 'true' (xgettext only recognizes 'yes')
Useless translatable attribute: 'true' (xgettext only recognizes 'yes')
Useless translatable attribute: 'true' (xgettext only recognizes 'yes')
Useless translatable attribute: 'true' (xgettext only recognizes 'yes')
Useless translatable attribute: 'true' (xgettext only recognizes 'yes')
Useless translatable attribute: '1' (xgettext only recognizes 'yes')
Useless translatable attribute: '1' (xgettext only recognizes 'yes')
<child> in gtkmm__GtkButton is deprecated, just set the child property
Useless translatable attribute: '1' (xgettext only recognizes 'yes')
Useless translatable attribute: '1' (xgettext only recognizes 'yes')
Useless translatable attribute: '1' (xgettext only recognizes 'yes')
Useless translatable attribute: '1' (xgettext only recognizes 'yes')
Useless translatable attribute: '1' (xgettext only recognizes 'yes')
Useless translatable attribute: '1' (xgettext only recognizes 'yes')
Useless translatable attribute: '1' (xgettext only recognizes 'yes')
<child> in gtkmm__GtkButton is deprecated, just set the child property
Useless translatable attribute: '1' (xgettext only recognizes 'yes')
Useless translatable attribute: '1' (xgettext only recognizes 'yes')
<child> in gtkmm__GtkMenuButton is deprecated, just set the child property
<child> in gtkmm__GtkToggleButton is deprecated, just set the child property
Useless translatable attribute: '1' (xgettext only recognizes 'yes')
<child> in gtkmm__GtkMenuButton is deprecated, just set the child property
<child> in gtkmm__GtkApplicationWindow is deprecated, just set the child property
```

(Note: I've left the "deprecated, just set the child property" warnings alone since it's not breaking anything and since I'm not sure if that change should be applied to both GTK3 and GTK4?)

Notes: Fixed a `4.0.x` bug that prevented a handful of strings from being marked for translation.