### PR TITLE
chore: remove FMT_STRING macros

### DIFF
--- a/macosx/Torrent.mm
+++ b/macosx/Torrent.mm
@@ -714,7 +714,7 @@ bool trashDataFile(std::string_view const filename, tr_error* error)
     }
 
     auto const old_list = tr_torrentGetTrackerList(self.fHandle);
-    auto const new_list = fmt::format(FMT_STRING("{:s}\n\n{:s}"), old_list, new_tracker.UTF8String);
+    auto const new_list = fmt::format("{:s}\n\n{:s}", old_list, new_tracker.UTF8String);
     BOOL const success = tr_torrentSetTrackerList(self.fHandle, new_list);
 
     return success;

--- a/tests/libtransmission/test-fixtures.h
+++ b/tests/libtransmission/test-fixtures.h
@@ -153,7 +153,7 @@ public:
 
     static std::string createSandbox(std::string const& parent_dir, std::string const& tmpl)
     {
-        auto path = fmt::format(FMT_STRING("{:s}/{:s}"sv), tr_sys_path_resolve(parent_dir), tmpl);
+        auto path = fmt::format("{:s}/{:s}"sv, tr_sys_path_resolve(parent_dir), tmpl);
         tr_sys_dir_create_temp(std::data(path));
         tr_sys_path_native_separators(std::data(path));
         return path;


### PR DESCRIPTION
Related: #6497

Motivation: I came across this while reading https://github.com/transmission/transmission/actions/runs/21659807431/job/62442208142 which was hitting a clang-tidy warning from FMT_STRING_use:

> /home/runner/work/transmission/transmission/tests/libtransmission/test-fixtures.h:156:33: error: call to consteval function 'fmt::basic_format_string<char, std::basic_string<char>, const std::basic_string<char> &>::basic_format_string<FMT_COMPILE_STRING, 0>' is not a constant expression [clang-diagnostic-error]
  156 |         auto path = fmt::format(FMT_STRING("{:s}/{:s}"sv), tr_sys_path_resolve(parent_dir), tmpl);
      |                                 ^
/usr/include/fmt/format.h:1772:23: note: expanded from macro 'FMT_STRING'
 1772 | #define FMT_STRING(s) FMT_STRING_IMPL(s, fmt::detail::compile_string, )
      |                       ^
/usr/include/fmt/format.h:1749:3: note: expanded from macro 'FMT_STRING_IMPL'
 1749 |   [] {                                                                        \
      |   ^
/usr/include/fmt/core.h:2982:51: note: subexpression not valid in a constant expression
 2982 |     context_.advance_to(context_.begin() + (begin - &*context_.begin()));
      |                                             ~~~~~~^~~~~~~~~~~~~~~~~~~~
/usr/include/fmt/core.h:2663:15: note: in call to 'handler.on_format_specs(0, &"{:s}/{:s}"[2], &"{:s}/{:s}"[9])'
 2663 |       begin = handler.on_format_specs(adapter.arg_id, begin + 1, end);
      |               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/fmt/core.h:2688:21: note: in call to 'parse_replacement_field<char, fmt::detail::format_string_checker<char, fmt::detail::error_handler, std::basic_string<char>, std::basic_string<char>> &>(&"{:s}/{:s}"[1], &"{:s}/{:s}"[9], checker(s, {}))'
 2688 |         begin = p = parse_replacement_field(p - 1, end, handler);
      |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/fmt/core.h:3159:7: note: in call to 'parse_format_string<true, char, fmt::detail::format_string_checker<char, fmt::detail::error_handler, std::basic_string<char>, std::basic_string<char>>>({&"{:s}/{:s}"[0], 9}, checker(s, {}))'
 3159 |       detail::parse_format_string<true>(str_, checker(s, {}));
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/runner/work/transmission/transmission/tests/libtransmission/test-fixtures.h:156:33: note: in call to 'basic_format_string<FMT_COMPILE_STRING, 0>([] {
