### PR TITLE
refactor: use fewer raw C strings

### DIFF
--- a/daemon/daemon.cc
+++ b/daemon/daemon.cc
@@ -1041,7 +1041,7 @@ bool tr_daemon::init(int argc, char const* const argv[], bool* foreground, int* 
     config_dir_ = getConfigDir(argc, argv);
 
     /* load settings from defaults + config file */
-    settings_ = load_settings(config_dir_.c_str());
+    settings_ = load_settings(config_dir_);
 
     bool dumpSettings;
 


### PR DESCRIPTION
Forgot fixing one case of C string -> C++ string view

I find it odd it compiled without at least a warning