### PR TITLE
build: wrap `fmt::fmt-header-only` with `transmission::fmt-header-only`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -623,6 +623,17 @@ tr_add_external_auto_library(FMT fmt
     CMAKE_ARGS
         -DFMT_INSTALL=OFF
         -DFMT_SYSTEM_HEADERS=ON)
+if(NOT TARGET transmission::fmt-header-only)
+    add_library(transmission::fmt-header-only INTERFACE IMPORTED)
+    target_link_libraries(transmission::fmt-header-only
+        INTERFACE
+            fmt::fmt-header-only)
+    target_compile_definitions(transmission::fmt-header-only
+        INTERFACE
+            FMT_USE_EXCEPTIONS=0 # {fmt} >= 11.2.0
+            FMT_EXCEPTIONS=0 # {fmt} < 11.2.0
+    )
+endif()
 
 tr_add_external_auto_library(SIGSLOT PalSigslot
     SUBPROJECT

--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -7,7 +7,7 @@ target_sources(${TR_NAME}-cli
 target_link_libraries(${TR_NAME}-cli
     PRIVATE
         ${TR_NAME}
-        fmt::fmt-header-only)
+        transmission::fmt-header-only)
 
 tr_win32_app_info(${TR_NAME}-cli
     "Transmission Utility ('cli', obsolete)"

--- a/daemon/CMakeLists.txt
+++ b/daemon/CMakeLists.txt
@@ -34,7 +34,7 @@ target_link_libraries(${TR_NAME}-daemon
     PRIVATE
         ${TR_NAME}
         libevent::core
-        fmt::fmt-header-only
+        transmission::fmt-header-only
         $<$<BOOL:${WITH_SYSTEMD}>:${SYSTEMD_LIBRARIES}>)
 
 tr_win32_app_info(${TR_NAME}-daemon

--- a/gtk/CMakeLists.txt
+++ b/gtk/CMakeLists.txt
@@ -200,7 +200,7 @@ target_link_libraries(${TR_NAME}-gtk
         ${TR_NAME}-app
         ${TR_NAME}
         transmission::gtk_impl
-        fmt::fmt-header-only
+        transmission::fmt-header-only
         $<$<BOOL:${WITH_APPINDICATOR}>:${APPINDICATOR_LIBRARIES}>)
 
 if(MSVC)

--- a/libtransmission-app/CMakeLists.txt
+++ b/libtransmission-app/CMakeLists.txt
@@ -22,4 +22,4 @@ target_include_directories(${LIBNAME}
 
 target_link_libraries(${LIBNAME}
     PUBLIC
-        fmt::fmt-header-only)
+        transmission::fmt-header-only)

--- a/libtransmission/CMakeLists.txt
+++ b/libtransmission/CMakeLists.txt
@@ -223,8 +223,6 @@ target_compile_definitions(${TR_NAME}
         $<$<BOOL:${USE_SYSTEM_B64}>:USE_SYSTEM_B64>
         $<$<BOOL:${HAVE_SO_REUSEPORT}>:HAVE_SO_REUSEPORT=1>
     PUBLIC
-        FMT_USE_EXCEPTIONS=0 # {fmt} >= 11.2.0
-        FMT_EXCEPTIONS=0 # {fmt} < 11.2.0
         $<$<STREQUAL:${CRYPTO_PKG},ccrypto>:WITH_CCRYPTO>
         $<$<STREQUAL:${CRYPTO_PKG},mbedtls>:WITH_MBEDTLS>
         $<$<STREQUAL:${CRYPTO_PKG},openssl>:WITH_OPENSSL>
@@ -284,7 +282,7 @@ target_link_libraries(${TR_NAME}
         $<$<BOOL:${HAVE_LIBATOMIC}>:atomic>
     PUBLIC
         transmission::crypto_impl
-        fmt::fmt-header-only
+        transmission::fmt-header-only
         Pal::Sigslot
         transmission::small
         libevent::core

--- a/macosx/CMakeLists.txt
+++ b/macosx/CMakeLists.txt
@@ -408,7 +408,7 @@ find_library(SPARKLE_FRAMEWORK Sparkle
 target_link_libraries(${TR_NAME}-mac
     PRIVATE
         ${TR_NAME}
-        fmt::fmt-header-only
+        transmission::fmt-header-only
         vdkqueue
         ${SPARKLE_FRAMEWORK}
         "-framework AppKit"

--- a/tests/libtransmission/CMakeLists.txt
+++ b/tests/libtransmission/CMakeLists.txt
@@ -83,7 +83,7 @@ target_link_libraries(libtransmission-test
         ${TR_NAME}
         GTest::gtest_main
         dht::dht
-        fmt::fmt-header-only
+        transmission::fmt-header-only
         libevent::core
         WideInteger::WideInteger)
 

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -9,7 +9,7 @@ foreach(P create edit remote show)
         PRIVATE
             ${TR_NAME}
             CURL::libcurl
-            fmt::fmt-header-only
+            transmission::fmt-header-only
             libevent::core)
 
     tr_win32_app_info(${TR_NAME}-${P}


### PR DESCRIPTION
Make sure all our usages of {fmt} have the proper macros defined.