### PR TITLE
fix(web): exception from destructing undefined property

### DIFF
--- a/web/src/remote.js
+++ b/web/src/remote.js
@@ -21,6 +21,10 @@ export const RPC = {
   _UpSpeedLimited: 'speed_limit_up_enabled',
 };
 
+function getResponseParams(response) {
+  return response.result ?? response.error.data.result;
+}
+
 export class Remote {
   _connection_alert = null;
   _session_id = '';
@@ -163,8 +167,8 @@ export class Remote {
       o.params.ids = torrentIds;
     }
     this.sendRequest(o, (response) => {
-      const { torrents, removed } = response.result;
-      callback.call(context, torrents, removed);
+      const res = getResponseParams(response);
+      callback.call(context, res.torrents, res.removed);
     });
   }
 
@@ -176,8 +180,8 @@ export class Remote {
       params: { path: dir },
     };
     this.sendRequest(o, (response) => {
-      const { path, size_bytes } = response.result;
-      callback.call(context, path, size_bytes);
+      const res = getResponseParams(response);
+      callback.call(context, res.path, res.size_bytes);
     });
   }
 


### PR DESCRIPTION
Fixes #8312.
Regression from #7269.

I changed these lines to use destructuring just because it felt cleaner, but we have to use property access `.` here in case the response parameter object does not exist, where destructuring will throw `TypeError` and `.` will not.

<img width="938" height="216" alt="image" src="https://github.com/user-attachments/assets/41681337-1355-4633-8deb-7dc3e4058e52" />

OTOH, the location of the response parameter object is now different depending on whether the API call is a success. This is handled in this PR too.