### PR TITLE
feat(web): Add option to sort files alphabetically

### DIFF
--- a/web/src/inspector.js
+++ b/web/src/inspector.js
@@ -1036,7 +1036,18 @@ export class Inspector extends EventTarget {
       this.addNodeToView(tor, parent, sub);
     }
     if (sub.children) {
-      for (const value of Object.values(sub.children)) {
+      // sort entries - directories first
+      const sorted = Object.values(sub.children).toSorted((a, b) => {
+        if (a.children && !b.children) {
+          return -1;
+        }
+        if (!a.children && b.children) {
+          return 1;
+        }
+        return a.name.localeCompare(b.name);
+      });
+
+      for (const value of sorted) {
         this.addSubtreeToView(tor, parent, value);
       }
     }

--- a/web/src/inspector.js
+++ b/web/src/inspector.js
@@ -1043,13 +1043,13 @@ export class Inspector extends EventTarget {
       this.addNodeToView(tor, parent, sub);
     }
     if (sub.children) {
-      for (const value of this._getSortedFiles(sub.children)) {
+      for (const value of _getSortedFiles(sub.children)) {
         this.addSubtreeToView(tor, parent, value);
       }
     }
   }
 
-  _getSortedFiles(children) {
+  static getSortedFiles(children) {
     // sort entries - directories first
     return Object.values(children).toSorted((a, b) => {
       if (a.children && !b.children) {

--- a/web/src/inspector.js
+++ b/web/src/inspector.js
@@ -1043,13 +1043,13 @@ export class Inspector extends EventTarget {
       this.addNodeToView(tor, parent, sub);
     }
     if (sub.children) {
-      for (const value of _getSortedFiles(sub.children)) {
+      for (const value of Inspector._getSortedFiles(sub.children)) {
         this.addSubtreeToView(tor, parent, value);
       }
     }
   }
 
-  static getSortedFiles(children) {
+  static _getSortedFiles(children) {
     // sort entries - directories first
     return Object.values(children).toSorted((a, b) => {
       if (a.children && !b.children) {

--- a/web/src/inspector.js
+++ b/web/src/inspector.js
@@ -5,6 +5,7 @@
 
 import { FileRow } from './file-row.js';
 import { Formatter } from './formatter.js';
+import { Prefs } from './prefs.js';
 import { Torrent } from './torrent.js';
 import { Utils, createTextualTabsContainer, setTextContent } from './utils.js';
 
@@ -21,7 +22,7 @@ const peer_column_classes = [
 const webseed_column_classes = ['url', 'speed-down'];
 
 export class Inspector extends EventTarget {
-  constructor(controller) {
+  constructor(controller, prefs) {
     super();
 
     this.closed = false;
@@ -38,6 +39,11 @@ export class Inspector extends EventTarget {
     this.file_torrent_n = null;
     this.file_rows = null;
     this.elements.dismiss.addEventListener('click', () => this.close());
+
+    this.prefs_listener = this._onPrefsChange.bind(this);
+    this.prefs = prefs;
+    this.prefs.addEventListener('change', this.prefs_listener);
+
     Object.seal(this);
 
     controller.addEventListener(
@@ -58,6 +64,7 @@ export class Inspector extends EventTarget {
         'torrent-selection-changed',
         this.selection_listener,
       );
+      this.prefs.removeEventListener('change', this.prefs_listener);
       this.dispatchEvent(new Event('close'));
       for (const property of Object.keys(this)) {
         this[property] = null;
@@ -1036,8 +1043,16 @@ export class Inspector extends EventTarget {
       this.addNodeToView(tor, parent, sub);
     }
     if (sub.children) {
-      // sort entries - directories first
-      const sorted = Object.values(sub.children).toSorted((a, b) => {
+      for (const value of this._getSortedFiles(sub.children)) {
+        this.addSubtreeToView(tor, parent, value);
+      }
+    }
+  }
+
+  _getSortedFiles(children) {
+    // sort entries - directories first
+    if (this.prefs.file_sort_mode == Prefs.FileSortModeNatural) {
+      return Object.values(children).toSorted((a, b) => {
         if (a.children && !b.children) {
           return -1;
         }
@@ -1046,10 +1061,8 @@ export class Inspector extends EventTarget {
         }
         return a.name.localeCompare(b.name);
       });
-
-      for (const value of sorted) {
-        this.addSubtreeToView(tor, parent, value);
-      }
+    } else {
+      return Object.values(children);
     }
   }
 
@@ -1080,6 +1093,17 @@ export class Inspector extends EventTarget {
       for (const row of file_rows) {
         row.refresh();
       }
+    }
+  }
+
+  _onPrefsChange(event_) {
+    switch (event_.key) {
+      case Prefs.FileSortMode:
+        this._clearFileList();
+        this._updateFiles();
+        break;
+      default:
+        break;
     }
   }
 }

--- a/web/src/inspector.js
+++ b/web/src/inspector.js
@@ -1051,7 +1051,7 @@ export class Inspector extends EventTarget {
 
   _getSortedFiles(children) {
     // sort entries - directories first
-    if (this.prefs.file_sort_mode == Prefs.FileSortModeNatural) {
+    if (this.prefs.file_sort_mode === Prefs.FileSortModeNatural) {
       return Object.values(children).toSorted((a, b) => {
         if (a.children && !b.children) {
           return -1;
@@ -1097,13 +1097,9 @@ export class Inspector extends EventTarget {
   }
 
   _onPrefsChange(event_) {
-    switch (event_.key) {
-      case Prefs.FileSortMode:
-        this._clearFileList();
-        this._updateFiles();
-        break;
-      default:
-        break;
+    if (event_.key === Prefs.FileSortMode) {
+      this._clearFileList();
+      this._updateFiles();
     }
   }
 }

--- a/web/src/inspector.js
+++ b/web/src/inspector.js
@@ -1061,9 +1061,8 @@ export class Inspector extends EventTarget {
         }
         return a.name.localeCompare(b.name);
       });
-    } else {
-      return Object.values(children);
     }
+    return Object.values(children);
   }
 
   _updateFiles() {

--- a/web/src/inspector.js
+++ b/web/src/inspector.js
@@ -1051,18 +1051,15 @@ export class Inspector extends EventTarget {
 
   _getSortedFiles(children) {
     // sort entries - directories first
-    if (this.prefs.file_sort_mode === Prefs.FileSortModeNatural) {
-      return Object.values(children).toSorted((a, b) => {
-        if (a.children && !b.children) {
-          return -1;
-        }
-        if (!a.children && b.children) {
-          return 1;
-        }
-        return a.name.localeCompare(b.name);
-      });
-    }
-    return Object.values(children);
+    return Object.values(children).toSorted((a, b) => {
+      if (a.children && !b.children) {
+        return -1;
+      }
+      if (!a.children && b.children) {
+        return 1;
+      }
+      return a.name.localeCompare(b.name);
+    });
   }
 
   _updateFiles() {
@@ -1085,7 +1082,22 @@ export class Inspector extends EventTarget {
       this.file_rows = [];
       const fragment = document.createDocumentFragment();
       const tree = Inspector.createFileTreeModel(tor);
-      this.addSubtreeToView(tor, fragment, tree);
+
+      if (this.prefs.file_sort_mode === Prefs.FileSortModeNatural) {
+        this.addSubtreeToView(tor, fragment, tree);
+      } else {
+        for (const [index, file] of tor.getFiles().entries()) {
+          const node = {
+            children: {},
+            depth: 0,
+            file_index: index,
+            file_indices: [index],
+            name: file.name,
+          };
+          this.addNodeToView(tor, fragment, node);
+        }
+      }
+
       list.append(fragment);
     } else {
       // ...refresh the already-existing file list

--- a/web/src/overflow-menu.js
+++ b/web/src/overflow-menu.js
@@ -226,6 +226,24 @@ export class OverflowMenu extends EventTarget {
 
     add_checkbox('Reverse sort', listener);
 
+    // file sort mode
+
+    div = document.createElement('div');
+    div.classList.add('table-row');
+    options.append(div);
+
+    listener = (e) => {
+      e.dataset.pref = Prefs.FileSortMode;
+      e.checked = this.prefs.file_sort_mode !== Prefs.FileSortModeTorrent;
+      e.addEventListener('input', (event_) => {
+        this.prefs.file_sort_mode = event_.target.checked
+          ? Prefs.FileSortModeNatural
+          : Prefs.FileSortModeTorrent;
+      });
+    };
+
+    add_checkbox('Natural file sorting', listener);
+
     // compact
 
     div = document.createElement('div');

--- a/web/src/prefs.js
+++ b/web/src/prefs.js
@@ -128,6 +128,9 @@ Prefs.SortByState = 'state';
 Prefs.SortDescending = 'descending';
 Prefs.SortDirection = 'sort-direction';
 Prefs.SortMode = 'sort-mode';
+Prefs.FileSortMode = 'file-sort-mode';
+Prefs.FileSortModeNatural = 'natural';
+Prefs.FileSortModeTorrent = 'torrent';
 
 Prefs._Defaults = {
   [Prefs.AltSpeedEnabled]: false,
@@ -142,4 +145,5 @@ Prefs._Defaults = {
   [Prefs.RefreshRate]: 5,
   [Prefs.SortDirection]: Prefs.SortAscending,
   [Prefs.SortMode]: Prefs.SortByName,
+  [Prefs.FileSortMode]: Prefs.FileSortModeTorrent,
 };

--- a/web/src/transmission.js
+++ b/web/src/transmission.js
@@ -181,7 +181,7 @@ export class Transmission extends EventTarget {
           if (this.popup[0] instanceof Inspector) {
             this.popup[0].close();
           } else {
-            this.setCurrentPopup(new Inspector(this), 0);
+            this.setCurrentPopup(new Inspector(this, this.prefs), 0);
           }
           break;
         case 'show-move-dialog':


### PR DESCRIPTION
I've seen at least two torrents now where the file listing is out of order, causing the WebUI to render the list a bit oddly. For example, the first entry of one of these torrents should be the very last entry of the very last folder:

```
Folder6/File6
Folder1/File1
Folder1/File2
...
```

But in the WebUI this seems to pull that folder up to the top of the list:

```
Folder6
 - File6
 - File1
 - File2
 - File3
 - File4
Folder1
 - File1
 - File2
...
```

This PR adjusts `addSubtreeToView()` so that each subtree's children are sorted alphabetically, keeping directories on top.

Notes: Added Web UI option to sort file listings alphabetically.