### PR TITLE
fix: add magnet links from command line  4.1.x

### DIFF
--- a/gtk/Session.cc
+++ b/gtk/Session.cc
@@ -144,7 +144,7 @@ private:
     void inc_busy();
     void dec_busy();
 
-    bool add(Glib::ustring const& name, bool do_start, bool do_prompt, bool do_notify);
+    bool add(Glib::ustring const& name_in, bool do_start, bool do_prompt, bool do_notify);
     void add_file_async_callback(
         Glib::RefPtr<Gio::File> const& file,
         Glib::RefPtr<Gio::AsyncResult>& result,
@@ -822,8 +822,18 @@ void Session::Impl::add_file_async_callback(
 }
 
 // Add `name,` which might be a local filename, a magnet link, or a URI.
-bool Session::Impl::add(Glib::ustring const& name, bool const do_start, bool const do_prompt, bool const do_notify)
+bool Session::Impl::add(Glib::ustring const& name_in, bool const do_start, bool const do_prompt, bool const do_notify)
 {
+    auto name = name_in;
+
+    // `gio::File` doesn't seem to know how to stringify magnet links correctly.
+    // Unfortunately there are some code paths that unavoidably use `gio::File`
+    // e.g. Gtk::Application::on_open() so we have to do this:
+    if (auto constexpr BrokenMagnetLinkPrefix = "magnet:///?"sv; tr_strv_starts_with(name.raw(), BrokenMagnetLinkPrefix))
+    {
+        name.replace(0, std::size(BrokenMagnetLinkPrefix), "magnet:?");
+    }
+
     auto* const session = get_session();
     if (session == nullptr)
     {


### PR DESCRIPTION
fix another variant of #8123 reported by @roshanshariff and @fedepell at https://github.com/transmission/transmission/pull/8277#issuecomment-3863228875


Notes: Fixed a `4.1.0` bug that wouldn't let magnet links be added from the command line.