### PR TITLE
fix: support Glib::ustring in Converters

### DIFF
--- a/gtk/main.cc
+++ b/gtk/main.cc
@@ -11,6 +11,7 @@
 #include <libtransmission-app/app.h>
 
 #include <libtransmission/transmission.h>
+#include <libtransmission/serializer.h>
 #include <libtransmission/utils.h>
 #include <libtransmission/version.h>
 
@@ -46,11 +47,29 @@ Glib::OptionEntry create_option_entry(Glib::ustring const& long_name, gchar shor
     entry.set_description(description);
     return entry;
 }
+
+bool to_ustring(tr_variant const& src, Glib::ustring* tgt)
+{
+    if (auto str = tr::serializer::to_value<std::string>(src))
+    {
+        *tgt = Glib::ustring{ std::move(*str) };
+        return true;
+    }
+
+    return false;
+}
+
+tr_variant from_ustring(Glib::ustring const& ustr)
+{
+    return tr::serializer::to_variant(ustr.raw());
+}
+
 } // namespace
 
 int main(int argc, char** argv)
 {
     tr::app::init();
+    tr::serializer::Converters::add(to_ustring, from_ustring);
 
     /* init i18n */
     bindtextdomain(AppTranslationDomainName, TRANSMISSIONLOCALEDIR);


### PR DESCRIPTION
fixes regression introduced in 64a53a8 reported by @OH-AU at https://github.com/transmission/transmission/issues/8327#issuecomment-3866346490

No `4.1.x` cherry-pick needed; this bug is only in `main`