### PR TITLE
fix: macOS crash regression introduced by #8315

### DIFF
--- a/macosx/TorrentTableView.mm
+++ b/macosx/TorrentTableView.mm
@@ -477,6 +477,8 @@ static NSTimeInterval const kToggleProgressSeconds = 0.175;
     NSMutableIndexSet* rows = self.fPendingSelectionReloadRows;
     self.fPendingSelectionReloadRows = nil;
 
+    NSInteger const numberOfRows = self.numberOfRows;
+    [rows removeIndexesInRange:NSMakeRange(numberOfRows, NSIntegerMax - numberOfRows)];
     if (rows.count > 0)
     {
         [self reloadDataForRowIndexes:rows columnIndexes:[NSIndexSet indexSetWithIndex:0]];


### PR DESCRIPTION
fix a timing issue introduced last week by 1dd096e77 in #8315. 

This bug is in 4.1.x as well, so this will need a cherry-pick.

Fixes #8408.