### PR TITLE
perf: use timer to flush outbuf to avoid taking lock frequently

### DIFF
--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -85,6 +85,7 @@ tr_peerIo::tr_peerIo(
     : bandwidth_{ parent_bandwidth }
     , info_hash_{ info_hash != nullptr ? *info_hash : tr_sha1_digest_t{} }
     , session_{ session }
+    , flush_outbuf_trigger_{ session->timerMaker().create() }
     , client_is_seed_{ client_is_seed }
     , is_incoming_{ is_incoming }
 {
@@ -106,7 +107,7 @@ std::shared_ptr<tr_peerIo> tr_peerIo::create(
         new tr_peerIo{ session, std::move(socket), parent, info_hash, is_incoming, is_seed }
     };
     io->bandwidth().set_peer(io);
-    io->flush_outbuf_trigger_ = session->timerMaker().create(
+    io->flush_outbuf_trigger_->set_callback(
         [weak = io->weak_from_this()]
         {
             if (auto const ptr = weak.lock())

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -395,7 +395,7 @@ private:
     GotError got_error_ = nullptr;
     void* user_data_ = nullptr;
 
-    std::unique_ptr<tr::Timer> flush_outbuf_trigger_;
+    std::unique_ptr<tr::Timer> const flush_outbuf_trigger_;
 
     tr::evhelpers::event_unique_ptr event_read_;
     tr::evhelpers::event_unique_ptr event_write_;


### PR DESCRIPTION
Fixes #8359.
Fixes #8397.

`Notes:` Improved laggy user interface when bandwidth usage is high.

### tl:dr

Avoid queuing redundant function calls to the session thread frequently by leveraging `tr::Timer`. This will cut down CPU cycles spent waiting on the session thread's thread locking significantly.

### Details

`tr_peerIo::write_bytes()` is called very frequently during transfers, and within it `tr_session::queue_session_thread()` is called unconditionally to queue a function call that flushes the outbound buffer, and that eventually leads to this `event_active()` call.

https://github.com/transmission/transmission/blob/ea043d642bf3adad852f6e0154f3c5f3feb7dae8/libtransmission/session-thread.cc#L211

Every `event_active()` call needs acquire a lock:

https://github.com/transmission/transmission/blob/ea043d642bf3adad852f6e0154f3c5f3feb7dae8/libtransmission/session-thread.cc#L47

This is an expensive operation, and you can imagine when called frequently, it can saturate the session thread when network transfers are active, and I think this is the reason there's multiple reports of laggy user interface in `4.1.0`.

`tr::Timer` doesn't have this problem because it checks a Boolean variable to see if the timer is already active, and return early if that's true, before calling any libevent functions that needs to acquire the lock.

https://github.com/transmission/transmission/blob/ea043d642bf3adad852f6e0154f3c5f3feb7dae8/libtransmission/timer-ev.cc#L58-L61

So this PR leverages this characteristic to shave off all the redundant function calls queued to flush the outbound buffer (calling it once flushes as much data as the bandwidth limit allows), while also removing a lot of the overhead from calling libevent functions.