### PR TITLE
fix: crash in torrent rename dialog after torrent removal

### DIFF
--- a/macosx/Torrent.mm
+++ b/macosx/Torrent.mm
@@ -196,6 +196,7 @@ bool trashDataFile(char const* filename, void* /*user_data*/, tr_error* error)
     [self setTimeMachineExclude:NO];
 
     tr_torrentRemove(self.fHandle, trashFiles, trashDataFile, nullptr);
+    _fHandle = nullptr;
 }
 
 - (void)changeDownloadFolderBeforeUsing:(NSString*)folder determinationType:(TorrentDeterminationType)determinationType
@@ -821,6 +822,15 @@ bool trashDataFile(char const* filename, void* /*user_data*/, tr_error* error)
     NSParameterAssert(newName != nil);
     NSParameterAssert(![newName isEqualToString:@""]);
 
+    if (self.fHandle == nullptr)
+    {
+        if (completionHandler != nullptr)
+        {
+            completionHandler(NO);
+        }
+        return;
+    }
+
     NSDictionary* contextInfo = @{ @"Torrent" : self, @"CompletionHandler" : [completionHandler copy] };
 
     tr_torrentRenamePath(self.fHandle, tr_torrentName(self.fHandle), newName.UTF8String, renameCallback, (__bridge_retained void*)(contextInfo));
@@ -833,6 +843,15 @@ bool trashDataFile(char const* filename, void* /*user_data*/, tr_error* error)
     NSParameterAssert(node.torrent == self);
     NSParameterAssert(newName != nil);
     NSParameterAssert(![newName isEqualToString:@""]);
+
+    if (self.fHandle == nullptr)
+    {
+        if (completionHandler != nullptr)
+        {
+            completionHandler(NO);
+        }
+        return;
+    }
 
     NSDictionary* contextInfo = @{ @"Torrent" : self, @"Nodes" : @[ node ], @"CompletionHandler" : [completionHandler copy] };
 


### PR DESCRIPTION
Fixes https://github.com/transmission/transmission/issues/8394.

Needs review from macOS reviewers, cc @livings124 @nevack @Coeur @lolgear 

Note: I know setting `fHandle = nullptr;` feels dangerous here because we have an uncomfortable number of unchecked references to `fHandle` in `Torrent.mm`. The thing is, all those references are equally risky before and after this change, since `tr_torrentRemove()` invalidates `fHandle`. But since this PR resets the pointer to `nullptr`, it means at lest we can test the handle before using it.

Notes: Fixed a crash in the "Rename File ..." dialog when trying to rename a torrent right when the torrent finished downloading.
