### PR TITLE
feat: add multiple dht bootstrap nodes

### DIFF
--- a/libtransmission/tr-dht.cc
+++ b/libtransmission/tr-dht.cc
@@ -153,9 +153,9 @@ public:
         init_state(state_filename_);
 
         get_nodes_from_bootstrap_file(tr_pathbuf{ mediator_.config_dir(), "/dht.bootstrap"sv }, bootstrap_queue_);
-        for (auto const& bp : default_bootstraps)
+        for (auto const [host, port] : default_bootstraps)
         {
-            get_nodes_from_name(bp.first, tr_port::from_host(bp.second), bootstrap_queue_);
+            get_nodes_from_name(host, tr_port::from_host(port), bootstrap_queue_);
         }
         bootstrap_timer_->start_single_shot(100ms);
 

--- a/libtransmission/tr-dht.cc
+++ b/libtransmission/tr-dht.cc
@@ -109,6 +109,17 @@ extern "C"
 
 } // extern "C"
 
+namespace
+{
+
+constexpr std::array<std::pair<char const*, uint16_t>, 3> const default_bootstraps = { {
+    { "dht.transmissionbt.com", 6881 },
+    { "router.bittorrent.com", 6881 },
+    { "dht.libtorrent.org", 25401 },
+} };
+
+}
+
 class tr_dht_impl final : public tr_dht
 {
 private:
@@ -142,7 +153,10 @@ public:
         init_state(state_filename_);
 
         get_nodes_from_bootstrap_file(tr_pathbuf{ mediator_.config_dir(), "/dht.bootstrap"sv }, bootstrap_queue_);
-        get_nodes_from_name("dht.transmissionbt.com", tr_port::from_host(6881), bootstrap_queue_);
+        for (auto const& bp : default_bootstraps)
+        {
+            get_nodes_from_name(bp.first, tr_port::from_host(bp.second), bootstrap_queue_);
+        }
         bootstrap_timer_->start_single_shot(100ms);
 
         mediator_.api().init(udp4_socket_, udp6_socket_, std::data(id_), nullptr);

--- a/libtransmission/tr-dht.cc
+++ b/libtransmission/tr-dht.cc
@@ -112,7 +112,7 @@ extern "C"
 namespace
 {
 
-constexpr std::array<std::pair<char const*, uint16_t>, 3> const default_bootstraps = { {
+constexpr std::array<std::pair<char const*, uint16_t>, 3> const DefaultBootstraps = { {
     { "dht.transmissionbt.com", 6881 },
     { "router.bittorrent.com", 6881 },
     { "dht.libtorrent.org", 25401 },
@@ -153,7 +153,7 @@ public:
         init_state(state_filename_);
 
         get_nodes_from_bootstrap_file(tr_pathbuf{ mediator_.config_dir(), "/dht.bootstrap"sv }, bootstrap_queue_);
-        for (auto const [host, port] : default_bootstraps)
+        for (auto const [host, port] : DefaultBootstraps)
         {
             get_nodes_from_name(host, tr_port::from_host(port), bootstrap_queue_);
         }


### PR DESCRIPTION
fixes #8440

Notes: Added more DHT bootstrap nodes to make it faster to find peers without a tracker.