### PR TITLE
refactor: add libtransmission/types.h

### DIFF
--- a/Transmission.xcodeproj/project.pbxproj
+++ b/Transmission.xcodeproj/project.pbxproj
@@ -1152,6 +1152,8 @@
 		BEFC1DF30C07861A00B0BB3C /* port-forwarding-upnp.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; path = "port-forwarding-upnp.h"; sourceTree = "<group>"; };
 		BEFC1DF40C07861A00B0BB3C /* port-forwarding-upnp.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "port-forwarding-upnp.cc"; sourceTree = "<group>"; };
 		BEFC1DF50C07861A00B0BB3C /* transmission.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = transmission.h; sourceTree = "<group>"; };
+		EDEB86BE2BDF9E9D00112233 /* constants.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = constants.h; sourceTree = "<group>"; };
+		EDEB86BF2BDF9E9D00112233 /* types.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = types.h; sourceTree = "<group>"; };
 		BEFC1DF60C07861A00B0BB3C /* session.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = session.cc; sourceTree = "<group>"; };
 		BEFC1DF90C07861A00B0BB3C /* torrent.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = torrent.cc; sourceTree = "<group>"; };
 		BEFC1DFC0C07861A00B0BB3C /* port-forwarding.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; path = "port-forwarding.h"; sourceTree = "<group>"; };
@@ -2064,6 +2066,8 @@
 				A2679292130E00A000CB7464 /* tr-utp.cc */,
 				A2679293130E00A000CB7464 /* tr-utp.h */,
 				BEFC1DF50C07861A00B0BB3C /* transmission.h */,
+				EDEB86BE2BDF9E9D00112233 /* constants.h */,
+				EDEB86BF2BDF9E9D00112233 /* types.h */,
 				A24621360C769CF400088E81 /* session-thread.cc */,
 				A24621350C769CF400088E81 /* session-thread.h */,
 				BE7AA337F6752914B0C416B1 /* utils-ev.h */,

--- a/libtransmission/CMakeLists.txt
+++ b/libtransmission/CMakeLists.txt
@@ -45,6 +45,7 @@ target_sources(${TR_NAME}
         clients.h
         completion.cc
         completion.h
+        constants.h
         crypto-utils-ccrypto.cc
         crypto-utils-fallback.cc
         crypto-utils-mbedtls.cc
@@ -163,6 +164,7 @@ target_sources(${TR_NAME}
         tr-utp.cc
         tr-utp.h
         transmission.h
+        types.h
         utils-ev.cc
         utils-ev.h
         utils.cc

--- a/libtransmission/announce-list.cc
+++ b/libtransmission/announce-list.cc
@@ -11,8 +11,6 @@
 
 #include <small/map.hpp>
 
-#include "libtransmission/transmission.h"
-
 #include "libtransmission/announce-list.h"
 
 #include "tr-strbuf.h"
@@ -21,6 +19,7 @@
 #include "libtransmission/quark.h"
 #include "libtransmission/string-utils.h"
 #include "libtransmission/tr-assert.h"
+#include "libtransmission/types.h"
 #include "libtransmission/variant.h"
 #include "libtransmission/web-utils.h"
 

--- a/libtransmission/announce-list.h
+++ b/libtransmission/announce-list.h
@@ -11,10 +11,9 @@
 #include <string_view>
 #include <vector>
 
-#include "libtransmission/transmission.h"
-
 #include "libtransmission/interned-string.h"
 #include "libtransmission/tr-macros.h" // TR_CONSTEXPR_VEC
+#include "libtransmission/types.h"
 #include "libtransmission/variant.h"
 #include "libtransmission/web-utils.h"
 

--- a/libtransmission/announcer-common.h
+++ b/libtransmission/announcer-common.h
@@ -18,13 +18,11 @@
 #include <string_view>
 #include <vector>
 
-#include "libtransmission/transmission.h"
-
 #include "libtransmission/announcer.h"
 #include "libtransmission/interned-string.h"
 #include "libtransmission/net.h"
 #include "libtransmission/peer-mgr.h" // tr_pex
-#include "libtransmission/tr-macros.h" // tr_peer_id_t
+#include "libtransmission/types.h" // tr_peer_id_t
 #include "libtransmission/utils.h"
 
 struct tr_url_parsed_t;

--- a/libtransmission/announcer-http.cc
+++ b/libtransmission/announcer-http.cc
@@ -25,8 +25,6 @@
 
 #define LIBTRANSMISSION_ANNOUNCER_MODULE
 
-#include "libtransmission/transmission.h"
-
 #include "libtransmission/announcer-common.h"
 #include "libtransmission/benc.h"
 #include "libtransmission/crypto-utils.h"
@@ -38,8 +36,8 @@
 #include "libtransmission/session.h"
 #include "libtransmission/string-utils.h"
 #include "libtransmission/tr-assert.h"
-#include "libtransmission/tr-macros.h"
 #include "libtransmission/tr-strbuf.h" // tr_strbuf, tr_urlbuf
+#include "libtransmission/types.h"
 #include "libtransmission/utils.h"
 #include "libtransmission/web-utils.h"
 #include "libtransmission/web.h"

--- a/libtransmission/announcer-udp.cc
+++ b/libtransmission/announcer-udp.cc
@@ -43,7 +43,6 @@
 #include "libtransmission/peer-mgr.h" // for tr_pex::fromCompact4()
 #include "libtransmission/tr-assert.h"
 #include "libtransmission/tr-buffer.h"
-#include "libtransmission/tr-macros.h"
 #include "libtransmission/tr-strbuf.h"
 #include "libtransmission/utils.h"
 #include "libtransmission/web-utils.h"

--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -26,8 +26,6 @@
 
 #define LIBTRANSMISSION_ANNOUNCER_MODULE
 
-#include "libtransmission/transmission.h"
-
 #include "libtransmission/announce-list.h"
 #include "libtransmission/announcer-common.h"
 #include "libtransmission/announcer.h"
@@ -39,7 +37,7 @@
 #include "libtransmission/timer.h"
 #include "libtransmission/torrent.h"
 #include "libtransmission/tr-assert.h"
-#include "libtransmission/tr-macros.h" // tr_sha1_digest_t, TR_C...
+#include "libtransmission/types.h" // tr_sha1_digest_t
 #include "libtransmission/utils.h"
 #include "libtransmission/web-utils.h"
 

--- a/libtransmission/announcer.h
+++ b/libtransmission/announcer.h
@@ -24,8 +24,6 @@
 #include <sys/socket.h> // socklen_t
 #endif
 
-#include "libtransmission/transmission.h"
-
 #include "libtransmission/interned-string.h"
 #include "libtransmission/peer-mgr.h"
 

--- a/libtransmission/api-compat.cc
+++ b/libtransmission/api-compat.cc
@@ -12,14 +12,13 @@
 #include <string_view>
 #include <vector>
 
-#include "libtransmission/transmission.h"
-
 #include "libtransmission/api-compat.h"
 #include "libtransmission/env.h"
 #include "libtransmission/quark.h"
 #include "libtransmission/rpcimpl.h"
 #include "libtransmission/serializer.h"
 #include "libtransmission/string-utils.h"
+#include "libtransmission/types.h"
 #include "libtransmission/variant.h"
 
 namespace tr::api_compat

--- a/libtransmission/bandwidth.cc
+++ b/libtransmission/bandwidth.cc
@@ -16,13 +16,12 @@
 
 #include <fmt/format.h>
 
-#include "libtransmission/transmission.h"
-
 #include "libtransmission/bandwidth.h"
 #include "libtransmission/crypto-utils.h"
 #include "libtransmission/log.h"
 #include "libtransmission/peer-io.h"
 #include "libtransmission/tr-assert.h"
+#include "libtransmission/types.h"
 #include "libtransmission/utils.h" // tr_time_msec()
 #include "libtransmission/values.h"
 

--- a/libtransmission/bandwidth.h
+++ b/libtransmission/bandwidth.h
@@ -16,9 +16,8 @@
 #include <utility> // for std::move()
 #include <vector>
 
-#include "libtransmission/transmission.h"
-
 #include "libtransmission/tr-assert.h"
+#include "libtransmission/types.h"
 #include "libtransmission/values.h"
 
 class tr_peerIo;

--- a/libtransmission/block-info.h
+++ b/libtransmission/block-info.h
@@ -7,7 +7,7 @@
 
 #include <cstdint> // uint32_t, uint64_t
 
-#include "libtransmission/transmission.h"
+#include "libtransmission/types.h"
 
 struct tr_block_info
 {

--- a/libtransmission/blocklist.cc
+++ b/libtransmission/blocklist.cc
@@ -27,9 +27,8 @@
 
 #include <fmt/format.h>
 
-#include "libtransmission/transmission.h"
-
 #include "libtransmission/blocklist.h"
+#include "libtransmission/constants.h"
 #include "libtransmission/crypto-utils.h"
 #include "libtransmission/error.h"
 #include "libtransmission/file.h"
@@ -38,6 +37,7 @@
 #include "libtransmission/string-utils.h"
 #include "libtransmission/tr-assert.h"
 #include "libtransmission/tr-strbuf.h"
+#include "libtransmission/types.h"
 #include "libtransmission/utils.h" // for _()
 
 using namespace std::literals;

--- a/libtransmission/cache.cc
+++ b/libtransmission/cache.cc
@@ -15,14 +15,13 @@
 
 #include <fmt/format.h>
 
-#include "libtransmission/transmission.h"
-
 #include "libtransmission/cache.h"
 #include "libtransmission/inout.h"
 #include "libtransmission/log.h"
 #include "libtransmission/torrent.h"
 #include "libtransmission/torrents.h"
 #include "libtransmission/tr-assert.h"
+#include "libtransmission/types.h"
 
 Cache::Key Cache::make_key(tr_torrent const& tor, tr_block_info::Location const loc) noexcept
 {

--- a/libtransmission/cache.h
+++ b/libtransmission/cache.h
@@ -17,10 +17,9 @@
 
 #include <small/vector.hpp>
 
-#include "libtransmission/transmission.h"
-
 #include "libtransmission/block-info.h"
 #include "libtransmission/values.h"
+#include "libtransmission/types.h"
 
 class tr_torrents;
 struct tr_torrent;

--- a/libtransmission/clients.cc
+++ b/libtransmission/clients.cc
@@ -19,7 +19,7 @@
 #include <fmt/format.h>
 
 #include "libtransmission/clients.h"
-#include "libtransmission/tr-macros.h" // tr_peer_id_t
+#include "libtransmission/types.h"
 #include "libtransmission/utils.h"
 
 using namespace std::literals;

--- a/libtransmission/clients.h
+++ b/libtransmission/clients.h
@@ -11,7 +11,7 @@
 
 #include <cstddef> // size_t
 
-#include "libtransmission/tr-macros.h" // tr_peer_id_t
+#include "libtransmission/types.h" // tr_peer_id_t
 
 /**
  * @brief parse a peer-id into a human-readable client name and version number

--- a/libtransmission/completion.cc
+++ b/libtransmission/completion.cc
@@ -10,13 +10,12 @@
 #include <utility>
 #include <vector>
 
-#include "libtransmission/transmission.h"
-
 #include "libtransmission/bitfield.h"
 #include "libtransmission/block-info.h"
 #include "libtransmission/completion.h"
 #include "libtransmission/tr-assert.h"
 #include "libtransmission/torrent.h"
+#include "libtransmission/types.h"
 
 tr_completion::tr_completion(tr_torrent const* tor, tr_block_info const* block_info)
     : tr_completion{ [tor](tr_piece_index_t const piece) { return tor->piece_is_wanted(piece); }, block_info }

--- a/libtransmission/completion.h
+++ b/libtransmission/completion.h
@@ -16,11 +16,9 @@
 #include <optional>
 #include <vector>
 
-#include "libtransmission/transmission.h"
-
 #include "libtransmission/block-info.h"
 #include "libtransmission/bitfield.h"
-#include "libtransmission/tr-macros.h"
+#include "libtransmission/types.h"
 
 /**
  * @brief knows which blocks and pieces we have

--- a/libtransmission/constants.h
+++ b/libtransmission/constants.h
@@ -1,0 +1,26 @@
+// This file Copyright © Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
+
+#pragma once
+
+#include "libtransmission/types.h"
+
+inline auto constexpr TrInet6AddrStrlen = 46U;
+
+inline auto constexpr TrAddrStrlen = 64U;
+
+inline auto constexpr TrDefaultBlocklistFilename = std::string_view{ "blocklist.bin" };
+inline auto constexpr TrDefaultHttpServerBasePath = std::string_view{ "/transmission/" };
+inline auto constexpr TrDefaultPeerLimitGlobal = 200U;
+inline auto constexpr TrDefaultPeerLimitTorrent = 50U;
+inline auto constexpr TrDefaultPeerPort = 51413U;
+inline auto constexpr TrDefaultPeerSocketTos = std::string_view{ "le" };
+inline auto constexpr TrDefaultRpcPort = 9091U;
+inline auto constexpr TrDefaultRpcWhitelist = std::string_view{ "127.0.0.1,::1" };
+
+inline auto constexpr TrHttpServerRpcRelativePath = std::string_view{ "rpc" };
+inline auto constexpr TrHttpServerWebRelativePath = std::string_view{ "web/" };
+inline auto constexpr TrRpcSessionIdHeader = std::string_view{ "X-Transmission-Session-Id" };
+inline auto constexpr TrRpcVersionHeader = std::string_view{ "X-Transmission-Rpc-Version" };

--- a/libtransmission/crypto-utils-ccrypto.cc
+++ b/libtransmission/crypto-utils-ccrypto.cc
@@ -11,11 +11,10 @@
 
 #include <fmt/format.h>
 
-#include "libtransmission/transmission.h"
-
 #include "libtransmission/crypto-utils.h"
 #include "libtransmission/log.h"
 #include "libtransmission/tr-assert.h"
+#include "libtransmission/types.h"
 #include "libtransmission/utils.h"
 
 #define TR_CRYPTO_X509_FALLBACK

--- a/libtransmission/crypto-utils-mbedtls.cc
+++ b/libtransmission/crypto-utils-mbedtls.cc
@@ -14,11 +14,10 @@
 
 #include <fmt/format.h>
 
-#include "libtransmission/transmission.h"
-
 #include "libtransmission/crypto-utils.h"
 #include "libtransmission/log.h"
 #include "libtransmission/tr-assert.h"
+#include "libtransmission/types.h"
 #include "libtransmission/utils.h"
 
 #define TR_CRYPTO_X509_FALLBACK

--- a/libtransmission/crypto-utils-openssl.cc
+++ b/libtransmission/crypto-utils-openssl.cc
@@ -25,7 +25,7 @@
 #include "libtransmission/crypto-utils.h"
 #include "libtransmission/log.h"
 #include "libtransmission/tr-assert.h"
-#include "libtransmission/tr-macros.h" // tr_sha1_digest_t, tr_sha25...
+#include "libtransmission/types.h"
 #include "libtransmission/utils.h"
 
 #if !defined(WITH_OPENSSL)

--- a/libtransmission/crypto-utils-wolfssl.cc
+++ b/libtransmission/crypto-utils-wolfssl.cc
@@ -14,11 +14,10 @@
 
 #include <fmt/format.h>
 
-#include "libtransmission/transmission.h"
-
 #include "libtransmission/crypto-utils.h"
 #include "libtransmission/log.h"
 #include "libtransmission/tr-assert.h"
+#include "libtransmission/types.h"
 #include "libtransmission/utils.h"
 
 #ifndef WITH_WOLFSSL

--- a/libtransmission/crypto-utils.cc
+++ b/libtransmission/crypto-utils.cc
@@ -29,7 +29,6 @@ extern "C"
 #include "libtransmission/crypto-utils.h"
 #include "libtransmission/string-utils.h"
 #include "libtransmission/tr-assert.h"
-#include "libtransmission/tr-macros.h"
 
 using namespace std::literals;
 

--- a/libtransmission/crypto-utils.h
+++ b/libtransmission/crypto-utils.h
@@ -15,8 +15,8 @@
 #include <string>
 #include <string_view>
 
-#include "libtransmission/tr-macros.h" // tr_sha1_digest_t, tr_sha256_d...
 #include "libtransmission/tr-strbuf.h"
+#include "libtransmission/types.h" // tr_sha1_digest_t, tr_sha256_d...
 
 #if defined(WITH_CCRYPTO)
 #include <CommonCrypto/CommonDigest.h>

--- a/libtransmission/file-piece-map.cc
+++ b/libtransmission/file-piece-map.cc
@@ -11,13 +11,12 @@
 
 #include <small/set.hpp>
 
-#include "libtransmission/transmission.h"
-
 #include "libtransmission/bitfield.h"
 #include "libtransmission/block-info.h"
 #include "libtransmission/file-piece-map.h"
 #include "libtransmission/torrent-metainfo.h"
 #include "libtransmission/tr-assert.h"
+#include "libtransmission/types.h"
 
 tr_file_piece_map::tr_file_piece_map(tr_torrent_metainfo const& tm)
 {

--- a/libtransmission/file-piece-map.h
+++ b/libtransmission/file-piece-map.h
@@ -14,10 +14,9 @@
 #include <cstddef> // for size_t
 #include <vector>
 
-#include "libtransmission/transmission.h"
-
 #include "libtransmission/bitfield.h"
 #include "libtransmission/tr-macros.h" // TR_CONSTEXPR_VEC
+#include "libtransmission/types.h"
 
 struct tr_block_info;
 struct tr_torrent_metainfo;

--- a/libtransmission/file-win32.cc
+++ b/libtransmission/file-win32.cc
@@ -17,13 +17,12 @@
 
 #include <fmt/format.h>
 
-#include "libtransmission/transmission.h"
-
 #include "libtransmission/crypto-utils.h" /* tr_rand_int() */
 #include "libtransmission/error.h"
 #include "libtransmission/file.h"
 #include "libtransmission/string-utils.h"
 #include "libtransmission/tr-assert.h"
+#include "libtransmission/types.h"
 
 using namespace std::literals;
 

--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -14,8 +14,6 @@
 
 #include <fmt/format.h>
 
-#include "libtransmission/transmission.h"
-
 #include "libtransmission/bitfield.h"
 #include "libtransmission/clients.h"
 #include "libtransmission/crypto-utils.h"
@@ -27,7 +25,7 @@
 #include "libtransmission/timer.h"
 #include "libtransmission/tr-assert.h"
 #include "libtransmission/tr-buffer.h"
-#include "libtransmission/tr-macros.h" // tr_peer_id_t
+#include "libtransmission/types.h" // tr_peer_id_t
 
 #define tr_logAddTraceHand(handshake, msg) \
     tr_logAddTrace(msg, fmt::format("handshake {}", (handshake)->peer_io_->display_name()))

--- a/libtransmission/handshake.h
+++ b/libtransmission/handshake.h
@@ -23,12 +23,10 @@
 
 #include <small/vector.hpp>
 
-#include "libtransmission/transmission.h"
-
 #include "libtransmission/peer-mse.h" // tr_message_stream_encryption::DH
 #include "libtransmission/peer-io.h"
 #include "libtransmission/timer.h"
-#include "libtransmission/tr-macros.h" // tr_sha1_digest_t, tr_peer_id_t
+#include "libtransmission/types.h" // tr_sha1_digest_t, tr_peer_id_t
 
 struct tr_error;
 struct tr_socket_address;

--- a/libtransmission/inout.cc
+++ b/libtransmission/inout.cc
@@ -12,8 +12,6 @@
 
 #include <fmt/format.h>
 
-#include "libtransmission/transmission.h"
-
 #include "libtransmission/block-info.h" // tr_block_info
 #include "libtransmission/crypto-utils.h"
 #include "libtransmission/error.h"
@@ -24,8 +22,8 @@
 #include "libtransmission/torrent-files.h"
 #include "libtransmission/torrent.h"
 #include "libtransmission/tr-assert.h"
-#include "libtransmission/tr-macros.h" // tr_sha1_digest_t
 #include "libtransmission/tr-strbuf.h" // tr_pathbuf
+#include "libtransmission/types.h"
 #include "libtransmission/utils.h"
 
 using namespace std::literals;

--- a/libtransmission/inout.h
+++ b/libtransmission/inout.h
@@ -12,9 +12,8 @@
 #include <cstddef> // size_t
 #include <cstdint> // uint8_t, uint32_t
 
-#include "libtransmission/transmission.h"
-
 #include "libtransmission/block-info.h"
+#include "libtransmission/types.h"
 
 struct tr_torrent;
 

--- a/libtransmission/log.cc
+++ b/libtransmission/log.cc
@@ -31,7 +31,6 @@
 #include "libtransmission/log.h"
 #include "libtransmission/string-utils.h"
 #include "libtransmission/tr-assert.h"
-#include "libtransmission/tr-macros.h"
 #include "libtransmission/utils.h"
 
 using namespace std::literals;

--- a/libtransmission/magnet-metainfo.cc
+++ b/libtransmission/magnet-metainfo.cc
@@ -20,8 +20,8 @@
 #include "libtransmission/error.h"
 #include "libtransmission/magnet-metainfo.h"
 #include "libtransmission/string-utils.h"
-#include "libtransmission/tr-macros.h" // for tr_sha1_digest_t
 #include "libtransmission/tr-strbuf.h" // for tr_urlbuf
+#include "libtransmission/types.h" // for tr_sha1_digest_t
 #include "libtransmission/web-utils.h"
 
 using namespace std::literals;

--- a/libtransmission/makemeta.cc
+++ b/libtransmission/makemeta.cc
@@ -17,8 +17,6 @@
 
 #include <fmt/format.h>
 
-#include "libtransmission/transmission.h"
-
 #include "libtransmission/block-info.h" // tr_block_info
 #include "libtransmission/crypto-utils.h"
 #include "libtransmission/error.h"
@@ -32,6 +30,7 @@
 #include "libtransmission/torrent-files.h"
 #include "libtransmission/tr-assert.h"
 #include "libtransmission/tr-strbuf.h" // tr_pathbuf
+#include "libtransmission/types.h"
 #include "libtransmission/utils.h" // for _()
 #include "libtransmission/variant.h"
 #include "libtransmission/version.h"

--- a/libtransmission/makemeta.h
+++ b/libtransmission/makemeta.h
@@ -13,14 +13,13 @@
 #include <utility> // std::pair
 #include <vector>
 
-#include "libtransmission/transmission.h"
-
 #include "libtransmission/announce-list.h"
 #include "libtransmission/block-info.h"
 #include "libtransmission/error.h"
 #include "libtransmission/file.h"
 #include "libtransmission/torrent-files.h"
 #include "libtransmission/tr-macros.h" // TR_CONSTEXPR_VEC
+#include "libtransmission/types.h"
 
 class tr_metainfo_builder
 {

--- a/libtransmission/net.cc
+++ b/libtransmission/net.cc
@@ -35,8 +35,8 @@
 #include "libtransmission/session.h"
 #include "libtransmission/string-utils.h"
 #include "libtransmission/tr-assert.h"
-#include "libtransmission/tr-macros.h"
 #include "libtransmission/tr-strbuf.h"
+#include "libtransmission/types.h"
 #include "libtransmission/utils.h"
 
 using namespace std::literals;

--- a/libtransmission/net.h
+++ b/libtransmission/net.h
@@ -61,9 +61,8 @@ using tr_socket_t = int;
 #define set_sockerrno(save) (sockerrno) = (save)
 #endif
 
-#include "libtransmission/transmission.h" // tr_peer_from
-
 #include "libtransmission/tr-assert.h"
+#include "libtransmission/types.h"
 #include "libtransmission/utils.h" // for tr_compare_3way()
 
 /**

--- a/libtransmission/open-files.cc
+++ b/libtransmission/open-files.cc
@@ -11,8 +11,6 @@
 
 #include <fmt/format.h>
 
-#include "libtransmission/transmission.h"
-
 #include "libtransmission/error-types.h"
 #include "libtransmission/error.h"
 #include "libtransmission/file.h"
@@ -20,6 +18,7 @@
 #include "libtransmission/open-files.h"
 #include "libtransmission/tr-assert.h"
 #include "libtransmission/tr-strbuf.h"
+#include "libtransmission/types.h"
 #include "libtransmission/utils.h" // _()
 
 namespace

--- a/libtransmission/open-files.h
+++ b/libtransmission/open-files.h
@@ -15,10 +15,9 @@
 #include <string_view>
 #include <utility>
 
-#include "libtransmission/transmission.h"
-
 #include "libtransmission/file.h" // tr_sys_file_t
 #include "libtransmission/lru-cache.h"
+#include "libtransmission/types.h"
 
 // A pool of open files that are cached while reading / writing torrents' data
 class tr_open_files

--- a/libtransmission/peer-common.h
+++ b/libtransmission/peer-common.h
@@ -14,12 +14,11 @@
 #include <cstdint> // uint8_t, uint32_t, uint64_t
 #include <string>
 
-#include "libtransmission/transmission.h"
-
 #include "libtransmission/bitfield.h"
 #include "libtransmission/block-info.h"
 #include "libtransmission/history.h"
 #include "libtransmission/net.h" // tr_port
+#include "libtransmission/types.h"
 
 /**
  * @addtogroup peers Peers

--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -22,8 +22,6 @@
 
 #include <fmt/format.h>
 
-#include "libtransmission/transmission.h"
-
 #include "libtransmission/bandwidth.h"
 #include "libtransmission/block-info.h" // tr_block_info
 #include "libtransmission/error.h"
@@ -34,6 +32,7 @@
 #include "libtransmission/session.h"
 #include "libtransmission/timer.h"
 #include "libtransmission/tr-assert.h"
+#include "libtransmission/types.h"
 #include "libtransmission/utils.h" // for _()
 
 struct sockaddr;

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -19,14 +19,12 @@
 
 #include <event2/util.h> // for evutil_socket_t
 
-#include "libtransmission/transmission.h"
-
 #include "libtransmission/bandwidth.h"
 #include "libtransmission/block-info.h"
 #include "libtransmission/peer-mse.h"
 #include "libtransmission/peer-socket.h"
 #include "libtransmission/tr-buffer.h"
-#include "libtransmission/tr-macros.h" // tr_sha1_digest_t
+#include "libtransmission/types.h"
 #include "libtransmission/utils-ev.h"
 
 struct struct_utp_context;

--- a/libtransmission/peer-mgr-wishlist.cc
+++ b/libtransmission/peer-mgr-wishlist.cc
@@ -16,12 +16,12 @@
 
 #define LIBTRANSMISSION_PEER_MODULE
 
-#include "libtransmission/transmission.h"
-
 #include "libtransmission/bitfield.h"
 #include "libtransmission/crypto-utils.h" // for tr_salt_shaker
-#include "libtransmission/tr-assert.h"
 #include "libtransmission/peer-mgr-wishlist.h"
+#include "libtransmission/tr-assert.h"
+#include "libtransmission/tr-macros.h" // TR_CONSTEXPR_VEC
+#include "libtransmission/types.h"
 #include "libtransmission/utils.h"
 
 namespace

--- a/libtransmission/peer-mgr-wishlist.h
+++ b/libtransmission/peer-mgr-wishlist.h
@@ -14,7 +14,7 @@
 #include <memory>
 #include <vector>
 
-#include "libtransmission/transmission.h"
+#include "libtransmission/types.h"
 
 class tr_bitfield;
 

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -28,8 +28,6 @@
 #include <fmt/format.h>
 
 #define LIBTRANSMISSION_PEER_MODULE
-#include "libtransmission/transmission.h"
-
 #include "libtransmission/announcer.h"
 #include "libtransmission/block-info.h" // tr_block_info
 #include "libtransmission/clients.h"
@@ -52,7 +50,7 @@
 #include "libtransmission/torrent.h"
 #include "libtransmission/torrents.h"
 #include "libtransmission/tr-assert.h"
-#include "libtransmission/tr-macros.h"
+#include "libtransmission/types.h"
 #include "libtransmission/utils.h"
 #include "libtransmission/values.h"
 #include "libtransmission/webseed.h"

--- a/libtransmission/peer-mgr.h
+++ b/libtransmission/peer-mgr.h
@@ -17,12 +17,11 @@
 #include <string>
 #include <vector>
 
-#include "libtransmission/transmission.h" // tr_block_span_t (ptr only)
-
 #include "libtransmission/blocklist.h"
 #include "libtransmission/handshake.h"
 #include "libtransmission/net.h" /* tr_address */
 #include "libtransmission/tr-assert.h"
+#include "libtransmission/types.h"
 #include "libtransmission/utils.h" /* tr_compare_3way */
 #include "libtransmission/variant.h"
 

--- a/libtransmission/peer-mse.cc
+++ b/libtransmission/peer-mse.cc
@@ -16,7 +16,7 @@
 #include "libtransmission/peer-mse.h"
 #include "libtransmission/tr-arc4.h"
 #include "libtransmission/tr-assert.h"
-#include "libtransmission/tr-macros.h" // tr_sha1_digest_t
+#include "libtransmission/types.h" // tr_sha1_digest_t
 
 // workaround bug in GCC < 10.4
 // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=99859

--- a/libtransmission/peer-mse.h
+++ b/libtransmission/peer-mse.h
@@ -16,8 +16,8 @@
 #include <cstddef> // size_t, std::byte
 #include <cstdint> // uint8_t
 
-#include "libtransmission/tr-macros.h" // tr_sha1_digest_t
 #include "libtransmission/tr-arc4.h"
+#include "libtransmission/types.h" // tr_sha1_digest_t
 
 // Spec: https://wiki.vuze.com/w/Message_Stream_Encryption
 namespace tr_message_stream_encryption

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -28,8 +28,6 @@
 
 #include <small/vector.hpp>
 
-#include "libtransmission/transmission.h"
-
 #include "libtransmission/bitfield.h"
 #include "libtransmission/block-info.h"
 #include "libtransmission/cache.h"
@@ -49,7 +47,7 @@
 #include "libtransmission/torrent.h"
 #include "libtransmission/tr-assert.h"
 #include "libtransmission/tr-buffer.h"
-#include "libtransmission/tr-macros.h"
+#include "libtransmission/types.h"
 #include "libtransmission/variant.h"
 #include "libtransmission/version.h"
 

--- a/libtransmission/peer-msgs.h
+++ b/libtransmission/peer-msgs.h
@@ -14,11 +14,10 @@
 #include <cstddef> // for size_t
 #include <memory>
 
-#include "libtransmission/transmission.h" // for tr_direction, tr_block_ind...
-
 #include "libtransmission/interned-string.h"
 #include "libtransmission/net.h" // tr_socket_address
 #include "libtransmission/peer-common.h" // for tr_peer
+#include "libtransmission/types.h"
 
 class tr_peerIo;
 class tr_peerMsgs;

--- a/libtransmission/port-forwarding-natpmp.cc
+++ b/libtransmission/port-forwarding-natpmp.cc
@@ -21,8 +21,6 @@
 
 #define LIBTRANSMISSION_PORT_FORWARDING_MODULE
 
-#include "libtransmission/transmission.h"
-
 #include "libtransmission/log.h"
 #include "libtransmission/net.h"
 #include "libtransmission/port-forwarding-natpmp.h"

--- a/libtransmission/port-forwarding-natpmp.h
+++ b/libtransmission/port-forwarding-natpmp.h
@@ -14,9 +14,8 @@
 
 #include "natpmp.h"
 
-#include "libtransmission/transmission.h" // tr_port_forwarding_state
-
 #include "libtransmission/net.h" // tr_port
+#include "libtransmission/types.h"
 
 class tr_natpmp
 {

--- a/libtransmission/port-forwarding-upnp.cc
+++ b/libtransmission/port-forwarding-upnp.cc
@@ -20,14 +20,13 @@
 
 #define LIBTRANSMISSION_PORT_FORWARDING_MODULE
 
-#include "libtransmission/transmission.h"
-
+#include "libtransmission/constants.h"
 #include "libtransmission/log.h"
 #include "libtransmission/net.h"
 #include "libtransmission/port-forwarding-upnp.h"
 #include "libtransmission/string-utils.h"
 #include "libtransmission/tr-assert.h"
-#include "libtransmission/tr-macros.h" // TrAddrStrlen
+#include "libtransmission/types.h"
 #include "libtransmission/utils.h" // for _(), tr_strerror()
 
 #ifndef MINIUPNPC_API_VERSION

--- a/libtransmission/port-forwarding-upnp.h
+++ b/libtransmission/port-forwarding-upnp.h
@@ -16,8 +16,6 @@
 
 #include <string>
 
-#include "libtransmission/transmission.h"
-
 class tr_port;
 struct tr_upnp;
 

--- a/libtransmission/port-forwarding.cc
+++ b/libtransmission/port-forwarding.cc
@@ -10,9 +10,6 @@
 #include <fmt/format.h>
 
 #define LIBTRANSMISSION_PORT_FORWARDING_MODULE
-
-#include "libtransmission/transmission.h"
-
 #include "libtransmission/log.h"
 #include "libtransmission/port-forwarding-natpmp.h"
 #include "libtransmission/port-forwarding-upnp.h"

--- a/libtransmission/port-forwarding.h
+++ b/libtransmission/port-forwarding.h
@@ -11,9 +11,8 @@
 
 #include <memory> // for std::unique_ptr
 
-#include "libtransmission/transmission.h" // for tr_port_forwarding_state
-
 #include "libtransmission/net.h"
+#include "libtransmission/types.h" // for tr_port_forwarding_state
 
 namespace tr
 {

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -14,8 +14,6 @@
 
 #include <fmt/format.h>
 
-#include "libtransmission/transmission.h"
-
 #include "libtransmission/api-compat.h"
 #include "libtransmission/bitfield.h"
 #include "libtransmission/error.h"
@@ -32,6 +30,7 @@
 #include "libtransmission/torrent-metainfo.h"
 #include "libtransmission/torrent.h"
 #include "libtransmission/tr-assert.h"
+#include "libtransmission/types.h"
 #include "libtransmission/utils.h"
 #include "libtransmission/variant.h"
 

--- a/libtransmission/resume.h
+++ b/libtransmission/resume.h
@@ -11,8 +11,6 @@
 
 #include <cstdint> // uint64_t
 
-#include "libtransmission/transmission.h"
-
 #include "libtransmission/torrent.h"
 
 namespace tr_resume

--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -34,8 +34,6 @@
 
 #include <libdeflate.h>
 
-#include "libtransmission/transmission.h"
-
 #include "libtransmission/crypto-utils.h" /* tr_ssha1_matches() */
 #include "libtransmission/error.h"
 #include "libtransmission/file-utils.h"
@@ -49,6 +47,7 @@
 #include "libtransmission/string-utils.h"
 #include "libtransmission/timer.h"
 #include "libtransmission/tr-strbuf.h"
+#include "libtransmission/types.h"
 #include "libtransmission/variant.h"
 #include "libtransmission/web-utils.h"
 

--- a/libtransmission/rpc-server.h
+++ b/libtransmission/rpc-server.h
@@ -16,11 +16,11 @@
 #include <string_view>
 #include <vector>
 
-#include "libtransmission/transmission.h"
-
+#include "libtransmission/constants.h" // TrDefaultHttpServerBasePath
 #include "libtransmission/net.h"
 #include "libtransmission/quark.h"
 #include "libtransmission/serializer.h"
+#include "libtransmission/types.h"
 #include "libtransmission/utils-ev.h"
 
 class tr_rpc_address;

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -45,6 +45,7 @@
 #include "libtransmission/torrent.h"
 #include "libtransmission/tr-assert.h"
 #include "libtransmission/tr-strbuf.h"
+#include "libtransmission/types.h"
 #include "libtransmission/utils.h"
 #include "libtransmission/values.h"
 #include "libtransmission/variant.h"

--- a/libtransmission/serializer.cc
+++ b/libtransmission/serializer.cc
@@ -22,8 +22,6 @@
 #include <small/set.hpp>
 #include <small/vector.hpp>
 
-#include "libtransmission/transmission.h"
-
 #include "libtransmission/log.h" // for tr_log_level
 #include "libtransmission/net.h" // for tr_port
 #include "libtransmission/open-files.h" // for tr_open_files::Preallocation
@@ -33,6 +31,7 @@
 #include "libtransmission/utils.h" // for tr_strv_strip(), tr_strlower()
 #include "libtransmission/variant.h"
 #include "libtransmission/tr-assert.h"
+#include "libtransmission/types.h"
 
 using namespace std::literals;
 

--- a/libtransmission/session-alt-speeds.cc
+++ b/libtransmission/session-alt-speeds.cc
@@ -10,10 +10,9 @@
 
 #include <fmt/chrono.h>
 
-#include "libtransmission/transmission.h"
-
 #include "libtransmission/log.h"
 #include "libtransmission/session-alt-speeds.h"
+#include "libtransmission/types.h"
 #include "libtransmission/variant.h"
 #include "libtransmission/utils.h" // for _()
 

--- a/libtransmission/session-alt-speeds.h
+++ b/libtransmission/session-alt-speeds.h
@@ -15,10 +15,9 @@
 #include <ctime> // for time_t
 #include <optional>
 
-#include "libtransmission/transmission.h" // for TR_SCHED_ALL
-
 #include "libtransmission/quark.h"
 #include "libtransmission/serializer.h"
+#include "libtransmission/types.h" // for TR_SCHED_ALL
 #include "libtransmission/values.h"
 
 struct tr_variant;

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -58,6 +58,7 @@
 #include "libtransmission/tr-lpd.h"
 #include "libtransmission/tr-strbuf.h"
 #include "libtransmission/tr-utp.h"
+#include "libtransmission/types.h"
 #include "libtransmission/variant.h"
 #include "libtransmission/version.h"
 #include "libtransmission/web.h"
@@ -905,6 +906,11 @@ void tr_sessionSet(tr_session* session, tr_variant const& settings)
 }
 
 // ---
+
+std::string tr_session::Settings::get_default_download_dir()
+{
+    return tr_getDefaultDownloadDir();
+}
 
 void tr_session::Settings::fixup_from_preferred_transports()
 {

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -37,8 +37,6 @@
 
 #include <small/vector.hpp>
 
-#include "libtransmission/transmission.h"
-
 #include "libtransmission/announce-list.h"
 #include "libtransmission/announcer.h"
 #include "libtransmission/bandwidth.h"
@@ -50,6 +48,7 @@
 #include "libtransmission/net.h" // for tr_port, tr_tos_t
 #include "libtransmission/open-files.h"
 #include "libtransmission/peer-io.h" // tr_preferred_transport
+#include "libtransmission/platform.h"
 #include "libtransmission/port-forwarding.h"
 #include "libtransmission/quark.h"
 #include "libtransmission/rpc-server.h"
@@ -65,6 +64,7 @@
 #include "libtransmission/tr-dht.h"
 #include "libtransmission/tr-lpd.h"
 #include "libtransmission/tr-macros.h"
+#include "libtransmission/types.h"
 #include "libtransmission/utils-ev.h"
 #include "libtransmission/verify.h"
 #include "libtransmission/web.h"
@@ -468,8 +468,8 @@ public:
         std::string bind_address_ipv6;
         std::string blocklist_url = "http://www.example.com/blocklist";
         std::string default_trackers_str;
-        std::string download_dir = tr_getDefaultDownloadDir();
-        std::string incomplete_dir = tr_getDefaultDownloadDir();
+        std::string download_dir = get_default_download_dir();
+        std::string incomplete_dir = get_default_download_dir();
         std::string peer_congestion_algorithm;
         std::string script_torrent_added_filename;
         std::string script_torrent_done_filename;
@@ -487,6 +487,8 @@ public:
     private:
         template<auto MemberPtr>
         using Field = tr::serializer::Field<MemberPtr>;
+
+        [[nodiscard]] static std::string get_default_download_dir();
 
         static constexpr auto Fields = std::tuple{
             Field<&Settings::announce_ip>{ TR_KEY_announce_ip },

--- a/libtransmission/stats.cc
+++ b/libtransmission/stats.cc
@@ -7,8 +7,6 @@
 #include <optional>
 #include <utility>
 
-#include "libtransmission/transmission.h"
-
 #include "libtransmission/api-compat.h"
 #include "libtransmission/file.h"
 #include "libtransmission/quark.h"

--- a/libtransmission/stats.h
+++ b/libtransmission/stats.h
@@ -14,7 +14,7 @@
 #include <string>
 #include <string_view>
 
-#include "libtransmission/transmission.h" // for tr_session_stats
+#include "libtransmission/types.h" // for tr_session_stats
 
 // per-session data structure for bandwidth use statistics
 class tr_stats

--- a/libtransmission/subprocess-win32.cc
+++ b/libtransmission/subprocess-win32.cc
@@ -17,12 +17,11 @@
 
 #include <windows.h>
 
-#include "libtransmission/transmission.h"
-
 #include "libtransmission/error.h"
 #include "libtransmission/string-utils.h"
 #include "libtransmission/subprocess.h"
 #include "libtransmission/tr-assert.h"
+#include "libtransmission/types.h"
 #include "libtransmission/utils.h"
 
 using namespace std::literals;

--- a/libtransmission/torrent-ctor.cc
+++ b/libtransmission/torrent-ctor.cc
@@ -8,6 +8,7 @@
 #include "libtransmission/torrent-ctor.h"
 #include "libtransmission/error.h"
 #include "libtransmission/file-utils.h"
+#include "libtransmission/types.h"
 
 using namespace std::literals;
 

--- a/libtransmission/torrent-ctor.h
+++ b/libtransmission/torrent-ctor.h
@@ -16,11 +16,9 @@
 #include <string_view>
 #include <vector>
 
-#include "libtransmission/transmission.h"
-
 #include "libtransmission/torrent-metainfo.h"
 #include "libtransmission/torrent.h"
-#include "libtransmission/tr-macros.h"
+#include "libtransmission/types.h"
 
 struct tr_error;
 struct tr_session;

--- a/libtransmission/torrent-files.cc
+++ b/libtransmission/torrent-files.cc
@@ -20,8 +20,6 @@
 
 #include <small/map.hpp>
 
-#include "libtransmission/transmission.h"
-
 #include "libtransmission/error.h"
 #include "libtransmission/file-utils.h"
 #include "libtransmission/file.h"
@@ -29,6 +27,7 @@
 #include "libtransmission/string-utils.h"
 #include "libtransmission/torrent-files.h"
 #include "libtransmission/tr-strbuf.h"
+#include "libtransmission/types.h"
 #include "libtransmission/utils.h"
 
 using namespace std::literals;

--- a/libtransmission/torrent-files.h
+++ b/libtransmission/torrent-files.h
@@ -16,11 +16,10 @@
 #include <utility>
 #include <vector>
 
-#include "libtransmission/transmission.h"
-
 #include "libtransmission/file.h"
 #include "libtransmission/tr-macros.h"
 #include "libtransmission/tr-strbuf.h"
+#include "libtransmission/types.h"
 
 struct tr_error;
 

--- a/libtransmission/torrent-metainfo.cc
+++ b/libtransmission/torrent-metainfo.cc
@@ -13,8 +13,6 @@
 
 #include <fmt/format.h>
 
-#include "libtransmission/transmission.h"
-
 #include "libtransmission/benc.h"
 #include "libtransmission/crypto-utils.h"
 #include "libtransmission/error.h"
@@ -25,8 +23,8 @@
 #include "libtransmission/torrent-files.h"
 #include "libtransmission/torrent-metainfo.h"
 #include "libtransmission/tr-assert.h"
-#include "libtransmission/tr-macros.h"
 #include "libtransmission/tr-strbuf.h"
+#include "libtransmission/types.h"
 #include "libtransmission/utils.h"
 
 using namespace std::literals;

--- a/libtransmission/torrent-metainfo.h
+++ b/libtransmission/torrent-metainfo.h
@@ -11,12 +11,11 @@
 #include <string_view>
 #include <vector>
 
-#include "libtransmission/transmission.h"
-
 #include "libtransmission/block-info.h"
 #include "libtransmission/magnet-metainfo.h"
 #include "libtransmission/torrent-files.h"
 #include "libtransmission/tr-macros.h"
+#include "libtransmission/types.h"
 
 struct tr_error;
 

--- a/libtransmission/torrent-queue.h
+++ b/libtransmission/torrent-queue.h
@@ -14,7 +14,7 @@
 #include <string_view>
 #include <vector>
 
-#include "libtransmission/transmission.h"
+#include "libtransmission/types.h"
 
 class tr_torrent_queue
 {

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -21,7 +21,6 @@
 #include <fmt/format.h>
 
 #include "libtransmission/transmission.h"
-#include "libtransmission/tr-macros.h"
 
 #include "libtransmission/announcer.h"
 #include "libtransmission/bandwidth.h"
@@ -45,6 +44,7 @@
 #include "libtransmission/torrent.h"
 #include "libtransmission/tr-assert.h"
 #include "libtransmission/tr-strbuf.h"
+#include "libtransmission/types.h"
 #include "libtransmission/utils.h"
 #include "libtransmission/version.h"
 #include "libtransmission/web-utils.h"

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -22,8 +22,6 @@
 
 #include <sigslot/signal.hpp>
 
-#include "libtransmission/transmission.h"
-
 #include "libtransmission/announce-list.h"
 #include "libtransmission/bandwidth.h"
 #include "libtransmission/bitfield.h"
@@ -39,6 +37,7 @@
 #include "libtransmission/torrent-metainfo.h"
 #include "libtransmission/tr-assert.h"
 #include "libtransmission/tr-macros.h"
+#include "libtransmission/types.h"
 #include "libtransmission/verify.h"
 
 struct tr_ctor;

--- a/libtransmission/torrents.cc
+++ b/libtransmission/torrents.cc
@@ -8,13 +8,11 @@
 #include <string_view>
 #include <vector>
 
-#include "libtransmission/transmission.h"
-
 #include "libtransmission/magnet-metainfo.h"
 #include "libtransmission/torrent.h"
 #include "libtransmission/torrents.h"
 #include "libtransmission/tr-assert.h"
-#include "libtransmission/tr-macros.h"
+#include "libtransmission/types.h"
 
 namespace
 {

--- a/libtransmission/torrents.h
+++ b/libtransmission/torrents.h
@@ -18,10 +18,7 @@
 #include <utility>
 #include <vector>
 
-#include "libtransmission/transmission.h"
-
 #include "libtransmission/torrent-metainfo.h"
-#include "libtransmission/tr-macros.h"
 
 struct tr_torrent;
 

--- a/libtransmission/tr-assert.h
+++ b/libtransmission/tr-assert.h
@@ -9,8 +9,6 @@
 
 #include <string_view>
 
-#include "libtransmission/tr-macros.h"
-
 [[noreturn]] bool tr_assert_report(std::string_view file, long line, std::string_view message);
 
 #define TR_ASSERT(x) ((void)((x) || tr_assert_report(__FILE__, __LINE__, #x)))

--- a/libtransmission/tr-buffer.h
+++ b/libtransmission/tr-buffer.h
@@ -17,7 +17,6 @@
 #include "libtransmission/error.h"
 #include "libtransmission/net.h" // tr_socket_t
 #include "libtransmission/tr-assert.h"
-#include "libtransmission/tr-macros.h" // TR_CONSTEXPR
 #include "libtransmission/utils.h" // for tr_htonll(), tr_ntohll()
 
 namespace tr

--- a/libtransmission/tr-dht.cc
+++ b/libtransmission/tr-dht.cc
@@ -33,8 +33,6 @@
 
 #include <fmt/format.h>
 
-#include "libtransmission/transmission.h"
-
 #include "libtransmission/crypto-utils.h"
 #include "libtransmission/file.h"
 #include "libtransmission/log.h"

--- a/libtransmission/tr-dht.h
+++ b/libtransmission/tr-dht.h
@@ -22,10 +22,8 @@
 
 #include <dht/dht.h>
 
-#include "libtransmission/transmission.h"
-
 #include "libtransmission/net.h" // tr_port
-#include "libtransmission/tr-macros.h"
+#include "libtransmission/types.h"
 
 struct tr_pex;
 

--- a/libtransmission/tr-lpd.cc
+++ b/libtransmission/tr-lpd.cc
@@ -27,8 +27,6 @@
 
 #include <fmt/format.h>
 
-#include "libtransmission/transmission.h"
-
 #include "libtransmission/crypto-utils.h" // for tr_rand_obj()
 #include "libtransmission/log.h"
 #include "libtransmission/net.h"
@@ -36,6 +34,7 @@
 #include "libtransmission/timer.h"
 #include "libtransmission/tr-assert.h"
 #include "libtransmission/tr-lpd.h"
+#include "libtransmission/types.h"
 #include "libtransmission/utils.h" // for tr_net_init()
 #include "libtransmission/utils-ev.h" // for tr_net_init()
 

--- a/libtransmission/tr-lpd.h
+++ b/libtransmission/tr-lpd.h
@@ -14,8 +14,6 @@
 #include <string_view>
 #include <vector>
 
-#include "libtransmission/transmission.h"
-
 #include "libtransmission/net.h" // for tr_address, tr_port
 
 struct event_base;

--- a/libtransmission/tr-macros.h
+++ b/libtransmission/tr-macros.h
@@ -5,12 +5,6 @@
 
 #pragma once
 
-#include <array>
-#include <cstddef> // for std::byte
-#include <cstdint> // for uint32_t
-
-// ---
-
 #if __cpp_lib_constexpr_vector >= 201907L
 #define TR_CONSTEXPR_VEC constexpr
 #else
@@ -44,33 +38,3 @@
 #else
 #define TR_UCLIBC_CHECK_VERSION(major, minor, micro) 0
 #endif
-
-// ---
-
-inline auto constexpr TrInet6AddrStrlen = 46U;
-
-inline auto constexpr TrAddrStrlen = 64U;
-
-// https://www.bittorrent.org/beps/bep_0007.html
-// "The client SHOULD include a key parameter in its announces. The key
-// should remain the same for a particular infohash during a torrent
-// session. Together with the peer_id this allows trackers to uniquely
-// identify clients for the purpose of statistics-keeping when they
-// announce from multiple IP.
-// The key should be generated so it has at least 32bits worth of entropy."
-//
-// https://www.bittorrent.org/beps/bep_0015.html
-// "Clients that resolve hostnames to v4 and v6 and then announce to both
-// should use the same [32-bit integer] key for both so that trackers that
-// care about accurate statistics-keeping can match the two announces."
-using tr_announce_key_t = uint32_t;
-
-// https://www.bittorrent.org/beps/bep_0003.html
-// A string of length 20 which this downloader uses as its id. Each
-// downloader generates its own id at random at the start of a new
-// download. This value will also almost certainly have to be escaped.
-using tr_peer_id_t = std::array<char, 20>;
-
-using tr_sha1_digest_t = std::array<std::byte, 20>;
-
-using tr_sha256_digest_t = std::array<std::byte, 32>;

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -20,82 +20,9 @@
 #include <string_view>
 #include <vector>
 
-#include "libtransmission/tr-macros.h"
+#include "libtransmission/constants.h"
+#include "libtransmission/types.h"
 #include "libtransmission/values.h"
-
-using tr_file_index_t = size_t;
-using tr_piece_index_t = uint32_t;
-/* Assuming a 16 KiB block (tr_block_info::BlockSize), a 32-bit block index gives us a maximum torrent size of 64 TiB.
- * When we ever need to grow past that, change tr_block_index_t and  tr_piece_index_t to uint64_t. */
-using tr_block_index_t = uint32_t;
-using tr_byte_index_t = uint64_t;
-using tr_tracker_tier_t = uint32_t;
-using tr_tracker_id_t = uint32_t;
-using tr_torrent_id_t = int;
-using tr_mode_t = uint16_t;
-
-inline auto constexpr TrDefaultBlocklistFilename = std::string_view{ "blocklist.bin" };
-inline auto constexpr TrDefaultHttpServerBasePath = std::string_view{ "/transmission/" };
-inline auto constexpr TrDefaultPeerLimitGlobal = 200U;
-inline auto constexpr TrDefaultPeerLimitTorrent = 50U;
-inline auto constexpr TrDefaultPeerPort = 51413U;
-inline auto constexpr TrDefaultPeerSocketTos = std::string_view{ "le" };
-inline auto constexpr TrDefaultRpcPort = 9091U;
-inline auto constexpr TrDefaultRpcWhitelist = std::string_view{ "127.0.0.1,::1" };
-
-inline auto constexpr TrHttpServerRpcRelativePath = std::string_view{ "rpc" };
-inline auto constexpr TrHttpServerWebRelativePath = std::string_view{ "web/" };
-inline auto constexpr TrRpcSessionIdHeader = std::string_view{ "X-Transmission-Session-Id" };
-inline auto constexpr TrRpcVersionHeader = std::string_view{ "X-Transmission-Rpc-Version" };
-
-struct tr_block_span_t
-{
-    tr_block_index_t begin;
-    tr_block_index_t end;
-};
-
-struct tr_byte_span_t
-{
-    uint64_t begin;
-    uint64_t end;
-};
-
-struct tr_ctor;
-struct tr_error;
-struct tr_session;
-struct tr_torrent;
-struct tr_torrent_metainfo;
-struct tr_variant;
-
-enum tr_verify_added_mode : uint8_t
-{
-    // See discussion @ https://github.com/transmission/transmission/pull/2626
-    // Let newly-added torrents skip upfront verify do it on-demand later.
-    TR_VERIFY_ADDED_FAST = 0,
-
-    // Force torrents to be fully verified as they are added.
-    TR_VERIFY_ADDED_FULL = 1
-};
-
-enum tr_encryption_mode : uint8_t
-{
-    TR_CLEAR_PREFERRED,
-    TR_ENCRYPTION_PREFERRED,
-    TR_ENCRYPTION_REQUIRED
-};
-
-enum tr_priority_t : int8_t
-{
-    TR_PRI_LOW = -1,
-    TR_PRI_NORMAL = 0, /* since Normal is 0, memset initializes nicely */
-    TR_PRI_HIGH = 1
-};
-
-enum : int8_t
-{
-    TR_RATIO_NA = -1,
-    TR_RATIO_INF = -2
-};
 
 // --- Startup & Shutdown
 
@@ -356,37 +283,6 @@ void tr_sessionSetRPCPasswordEnabled(tr_session* session, bool is_enabled);
 
 void tr_sessionSetDefaultTrackers(tr_session* session, std::string_view trackers);
 
-enum tr_rpc_callback_type : uint8_t
-{
-    TR_RPC_TORRENT_ADDED,
-    TR_RPC_TORRENT_STARTED,
-    TR_RPC_TORRENT_STOPPED,
-    TR_RPC_TORRENT_REMOVING,
-    TR_RPC_TORRENT_TRASHING, /* _REMOVING + delete local data */
-    TR_RPC_TORRENT_CHANGED, /* catch-all for the "torrent_set" rpc method */
-    TR_RPC_TORRENT_MOVED,
-    TR_RPC_SESSION_CHANGED,
-    TR_RPC_SESSION_QUEUE_POSITIONS_CHANGED, /* catch potentially multiple torrents being moved in the queue */
-    TR_RPC_SESSION_CLOSE
-};
-
-enum tr_rpc_callback_status : uint8_t
-{
-    /* no special handling is needed by the caller */
-    TR_RPC_OK = 0,
-    /* indicates to the caller that the client will take care of
-     * removing the torrent itself. For example the client may
-     * need to keep the torrent alive long enough to cleanly close
-     * some resources in another thread. */
-    TR_RPC_NOREMOVE = (1 << 1)
-};
-
-using tr_rpc_func = tr_rpc_callback_status (*)( //
-    tr_session* session,
-    tr_rpc_callback_type type,
-    struct tr_torrent* tor_or_null,
-    void* user_data);
-
 /**
  * Register to be notified whenever something is changed via RPC,
  * such as a torrent being added, removed, started, stopped, etc.
@@ -399,17 +295,6 @@ using tr_rpc_func = tr_rpc_callback_status (*)( //
 void tr_sessionSetRPCCallback(tr_session* session, tr_rpc_func func, void* user_data);
 
 // ---
-
-/** @brief Used by `tr_sessionGetStats()` and `tr_sessionGetCumulativeStats()` */
-struct tr_session_stats
-{
-    float ratio; /* TR_RATIO_INF, TR_RATIO_NA, or total up/down */
-    uint64_t uploadedBytes; /* total up */
-    uint64_t downloadedBytes; /* total down */
-    uint64_t filesAdded; /* number of files added */
-    uint64_t sessionCount; /* program started N times */
-    uint64_t secondsActive; /* how long Transmission's been running */
-};
 
 /** @brief Get bandwidth use statistics for the current session */
 tr_session_stats tr_sessionGetStats(tr_session const* session);
@@ -456,24 +341,7 @@ uint16_t tr_sessionSetPeerPortRandom(tr_session* session);
 bool tr_sessionGetPeerPortRandomOnStart(tr_session const* session);
 void tr_sessionSetPeerPortRandomOnStart(tr_session* session, bool random);
 
-enum tr_port_forwarding_state : uint8_t
-{
-    TR_PORT_ERROR,
-    TR_PORT_UNMAPPED,
-    TR_PORT_UNMAPPING,
-    TR_PORT_MAPPING,
-    TR_PORT_MAPPED
-};
-
 tr_port_forwarding_state tr_sessionGetPortForwarding(tr_session const* session);
-
-enum class tr_direction : uint8_t
-{
-    ClientToPeer = 0,
-    Up = 0,
-    PeerToClient = 1,
-    Down = 1,
-};
 
 // --- Session primary speed limits
 
@@ -500,24 +368,8 @@ void tr_sessionSetAltSpeedBegin(tr_session* session, size_t minutes_since_midnig
 size_t tr_sessionGetAltSpeedEnd(tr_session const* session);
 void tr_sessionSetAltSpeedEnd(tr_session* session, size_t minutes_since_midnight);
 
-enum tr_sched_day : uint8_t
-{
-    TR_SCHED_SUN = (1 << 0),
-    TR_SCHED_MON = (1 << 1),
-    TR_SCHED_TUES = (1 << 2),
-    TR_SCHED_WED = (1 << 3),
-    TR_SCHED_THURS = (1 << 4),
-    TR_SCHED_FRI = (1 << 5),
-    TR_SCHED_SAT = (1 << 6),
-    TR_SCHED_WEEKDAY = (TR_SCHED_MON | TR_SCHED_TUES | TR_SCHED_WED | TR_SCHED_THURS | TR_SCHED_FRI),
-    TR_SCHED_WEEKEND = (TR_SCHED_SUN | TR_SCHED_SAT),
-    TR_SCHED_ALL = (TR_SCHED_WEEKDAY | TR_SCHED_WEEKEND)
-};
-
 tr_sched_day tr_sessionGetAltSpeedDay(tr_session const* session);
 void tr_sessionSetAltSpeedDay(tr_session* session, tr_sched_day day);
-
-using tr_altSpeedFunc = void (*)(tr_session* session, bool active, bool user_driven, void*);
 
 void tr_sessionSetAltSpeedFunc(tr_session* session, tr_altSpeedFunc func, void* user_data);
 
@@ -653,15 +505,6 @@ size_t tr_sessionGetAllTorrents(tr_session* session, tr_torrent** buf, size_t bu
 
 // ---
 
-enum TrScript : uint8_t
-{
-    TR_SCRIPT_ON_TORRENT_ADDED,
-    TR_SCRIPT_ON_TORRENT_DONE,
-    TR_SCRIPT_ON_TORRENT_DONE_SEEDING,
-
-    TR_SCRIPT_N_TYPES
-};
-
 [[nodiscard]] std::string tr_sessionGetScript(tr_session const* session, TrScript type);
 
 void tr_sessionSetScript(tr_session* session, TrScript type, std::string_view script_filename);
@@ -719,12 +562,6 @@ void tr_blocklistSetURL(tr_session* session, std::string_view url);
  * Other settings, e.g. torrent priority, are optional.
  * When ready, pass the builder object to `tr_torrentNew()`.
  */
-
-enum tr_ctorMode : uint8_t
-{
-    TR_FALLBACK, /* indicates the ctor value should be used only in case of missing resume settings */
-    TR_FORCE /* indicates the ctor value should be used regardless of what's in the resume settings */
-};
 
 /** @brief Create a torrent constructor object used to instantiate a `tr_torrent`
     @param session the tr_session. */
@@ -809,8 +646,6 @@ tr_torrent* tr_torrentNew(tr_ctor* ctor, tr_torrent** setme_duplicate_of);
 /** @addtogroup tr_torrent Torrents
     @{ */
 
-using tr_torrent_remove_func = std::function<bool(std::string_view filename, tr_error* error)>;
-
 /**
  * @brief Removes our torrent and .resume files for this torrent
  * @param remove_func A function that deletes a file.
@@ -827,9 +662,6 @@ void tr_torrentStart(tr_torrent* torrent);
 
 /** @brief Stop (pause) a torrent */
 void tr_torrentStop(tr_torrent* torrent);
-
-using tr_torrent_rename_done_func = std::function<
-    void(tr_torrent* torrent, char const* oldpath, char const* newname, int error, void* user_data)>;
 
 /**
  * @brief Rename a file or directory in a torrent.
@@ -879,13 +711,6 @@ void tr_torrentRenamePath(
     std::string_view newname,
     tr_torrent_rename_done_func callback,
     void* callback_user_data);
-
-enum : uint8_t
-{
-    TR_LOC_MOVING,
-    TR_LOC_DONE,
-    TR_LOC_ERROR
-};
 
 /**
  * @brief Tell transmission where to find this torrent's local data.
@@ -946,16 +771,6 @@ void tr_torrentUseSessionLimits(tr_torrent* tor, bool enabled);
 
 // --- Ratio Limits
 
-enum tr_ratiolimit : uint8_t
-{
-    /* follow the global settings */
-    TR_RATIOLIMIT_GLOBAL = 0,
-    /* override the global settings, seeding until a certain ratio */
-    TR_RATIOLIMIT_SINGLE = 1,
-    /* override the global settings, seeding regardless of ratio */
-    TR_RATIOLIMIT_UNLIMITED = 2
-};
-
 tr_ratiolimit tr_torrentGetRatioMode(tr_torrent const* tor);
 void tr_torrentSetRatioMode(tr_torrent* tor, tr_ratiolimit mode);
 
@@ -965,16 +780,6 @@ void tr_torrentSetRatioLimit(tr_torrent* tor, double desired_ratio);
 bool tr_torrentGetSeedRatio(tr_torrent const* tor, double* ratio);
 
 // --- Idle Time Limits
-
-enum tr_idlelimit : uint8_t
-{
-    /* follow the global settings */
-    TR_IDLELIMIT_GLOBAL = 0,
-    /* override the global settings, seeding until a certain idle time */
-    TR_IDLELIMIT_SINGLE = 1,
-    /* override the global settings, seeding regardless of activity */
-    TR_IDLELIMIT_UNLIMITED = 2
-};
 
 tr_idlelimit tr_torrentGetIdleMode(tr_torrent const* tor);
 void tr_torrentSetIdleMode(tr_torrent* tor, tr_idlelimit mode);
@@ -1052,27 +857,6 @@ bool tr_torrentSetTrackerList(tr_torrent* tor, std::string_view txt);
 
 // ---
 
-enum tr_completeness : uint8_t
-{
-    TR_LEECH, /* doesn't have all the desired pieces */
-    TR_SEED, /* has the entire torrent */
-    TR_PARTIAL_SEED /* has the desired pieces, but not the entire torrent */
-};
-
-/**
- * @param was_running whether or not the torrent was running when
- *                    it changed its completeness state
- */
-using tr_torrent_completeness_func = void (*)( //
-    tr_torrent* torrent,
-    tr_completeness completeness,
-    bool was_running,
-    void* user_data);
-
-using tr_session_ratio_limit_hit_func = void (*)(tr_session*, tr_torrent* torrent, void* user_data);
-
-using tr_session_idle_limit_hit_func = void (*)(tr_session*, tr_torrent* torrent, void* user_data);
-
 /**
  * Register to be notified whenever a torrent's "completeness"
  * changes. This will be called, for example, when a torrent
@@ -1087,8 +871,6 @@ using tr_session_idle_limit_hit_func = void (*)(tr_session*, tr_torrent* torrent
  * @see `tr_completeness`
  */
 void tr_sessionSetCompletenessCallback(tr_session* session, tr_torrent_completeness_func callback, void* user_data);
-
-using tr_session_metadata_func = void (*)(tr_session* session, tr_torrent* torrent, void* user_data);
 
 /**
  * Register to be notified whenever a torrent changes from
@@ -1133,127 +915,9 @@ void tr_torrentManualUpdate(tr_torrent* torrent);
 
 bool tr_torrentCanManualUpdate(tr_torrent const* torrent);
 
-// --- tr_peer_stat
-
-struct tr_peer_stat
-{
-    std::string addr;
-    std::string flag_str;
-
-    // The user agent, e.g. `BitTorrent 7.9.1`.
-    // Will be an empty string if the agent cannot be determined.
-    std::string user_agent;
-
-    tr::Values::Speed rate_to_peer;
-    tr::Values::Speed rate_to_client;
-
-    // how many requests the peer has made that we haven't responded to yet
-    size_t active_reqs_to_client = {};
-
-    // how many requests we've made and are currently awaiting a response for
-    size_t active_reqs_to_peer = {};
-
-    size_t bytes_to_peer = {};
-    size_t bytes_to_client = {};
-
-    tr_peer_id_t peer_id = {};
-
-    float progress = {};
-
-    // THESE NEXT FOUR FIELDS ARE EXPERIMENTAL.
-    // Don't rely on them; they'll probably go away
-    // how many blocks we've sent to this peer in the last 120 seconds
-    uint32_t blocks_to_peer = {};
-    // how many blocks this client's sent to us in the last 120 seconds
-    uint32_t blocks_to_client = {};
-    // how many requests to this peer that we've cancelled in the last 120 seconds
-    uint32_t cancels_to_peer = {};
-    // how many requests this peer made of us, then cancelled, in the last 120 seconds
-    uint32_t cancels_to_client = {};
-
-    uint16_t port = {};
-    uint8_t from = {};
-
-    bool client_is_choked = {};
-    bool client_is_interested = {};
-    bool is_downloading_from = {};
-    bool is_encrypted = {};
-    bool is_incoming = {};
-    bool is_seed = {};
-    bool is_uploading_to = {};
-    bool is_utp = {};
-    bool peer_is_choked = {};
-    bool peer_is_interested = {};
-};
-
 std::vector<tr_peer_stat> tr_torrentPeers(tr_torrent const* torrent);
 
 // --- tr_tracker_stat
-
-enum tr_tracker_state : uint8_t
-{
-    /* we won't (announce,scrape) this torrent to this tracker because
-     * the torrent is stopped, or because of an error, or whatever */
-    TR_TRACKER_INACTIVE = 0,
-    /* we will (announce,scrape) this torrent to this tracker, and are
-     * waiting for enough time to pass to satisfy the tracker's interval */
-    TR_TRACKER_WAITING = 1,
-    /* it's time to (announce,scrape) this torrent, and we're waiting on a
-     * free slot to open up in the announce manager */
-    TR_TRACKER_QUEUED = 2,
-    /* we're (announcing,scraping) this torrent right now */
-    TR_TRACKER_ACTIVE = 3
-};
-
-// NOLINTBEGIN(modernize-avoid-c-arrays)
-/*
- * Unlike other _view structs, it is safe to keep a tr_tracker_view copy.
- * The announce and scrape strings are interned & never go out-of-scope.
- */
-struct tr_tracker_view
-{
-    char const* announce; // full announce URL
-    char const* scrape; // full scrape URL
-    char host_and_port[72]; // uniquely-identifying tracker name (`${host}:${port}`)
-
-    // The tracker site's name. Uses the first label before the public suffix
-    // (https://publicsuffix.org/) in the announce URL's host.
-    // e.g. "https://www.example.co.uk/announce/"'s sitename is "example"
-    // RFC 1034 says labels must be less than 64 chars
-    char sitename[64];
-
-    char lastAnnounceResult[128]; // if hasAnnounced, the human-readable result of latest announce
-    char lastScrapeResult[128]; // if hasScraped, the human-readable result of the latest scrape
-
-    time_t lastAnnounceStartTime; // if hasAnnounced, when the latest announce request was sent
-    time_t lastAnnounceTime; // if hasAnnounced, when the latest announce reply was received
-    time_t nextAnnounceTime; // if announceState == TR_TRACKER_WAITING, time of next announce
-
-    time_t lastScrapeStartTime; // if hasScraped, when the latest scrape request was sent
-    time_t lastScrapeTime; // if hasScraped, when the latest scrape reply was received
-    time_t nextScrapeTime; // if scrapeState == TR_TRACKER_WAITING, time of next scrape
-
-    int downloadCount; // number of times this torrent's been downloaded, or -1 if unknown
-    int lastAnnouncePeerCount; // if hasAnnounced, the number of peers the tracker gave us
-    int leecherCount; // number of leechers the tracker knows of, or -1 if unknown
-    int seederCount; // number of seeders the tracker knows of, or -1 if unknown
-    int downloader_count; // number of downloaders (BEP-21) the tracker knows of, or -1 if unknown
-
-    size_t tier; // which tier this tracker is in
-    tr_tracker_id_t id; // unique transmission-generated ID for use in libtransmission API
-
-    tr_tracker_state announceState; // whether we're announcing, waiting to announce, etc.
-    tr_tracker_state scrapeState; // whether we're scraping, waiting to scrape, etc.
-
-    bool hasAnnounced; // true iff we've announced to this tracker during this session
-    bool hasScraped; // true iff we've scraped this tracker during this session
-    bool isBackup; // only one tracker per tier is used; the others are kept as backups
-    bool lastAnnounceSucceeded; // if hasAnnounced, whether or not the latest announce succeeded
-    bool lastAnnounceTimedOut; // true iff the latest announce request timed out
-    bool lastScrapeSucceeded; // if hasScraped, whether or not the latest scrape succeeded
-    bool lastScrapeTimedOut; // true iff the latest scrape request timed out
-};
-// NOLINTEND(modernize-avoid-c-arrays)
 
 struct tr_tracker_view tr_torrentTracker(tr_torrent const* torrent, size_t i);
 
@@ -1266,63 +930,13 @@ struct tr_tracker_view tr_torrentTracker(tr_torrent const* torrent, size_t i);
  */
 size_t tr_torrentTrackerCount(tr_torrent const* torrent);
 
-/*
- * This view structure is intended for short-term use. Its pointers are owned
- * by the torrent and may be invalidated if the torrent is edited or removed.
- */
-struct tr_file_view
-{
-    char const* name; // This file's name. Includes the full subpath in the torrent.
-    uint64_t have; // the current size of the file, i.e. how much we've downloaded
-    uint64_t length; // the total size of the file
-    double progress; // have / length
-    tr_piece_index_t beginPiece; // piece index where this file starts
-    tr_piece_index_t endPiece; // piece index where this file ends (exclusive)
-    tr_priority_t priority; // the file's priority
-    bool wanted; // do we want to download this file?
-};
 tr_file_view tr_torrentFile(tr_torrent const* torrent, tr_file_index_t file);
 
 size_t tr_torrentFileCount(tr_torrent const* torrent);
 
-/*
- * This view structure is intended for short-term use. Its pointers are owned
- * by the torrent and may be invalidated if the torrent is edited or removed.
- */
-struct tr_webseed_view
-{
-    char const* url; // the url to download from
-    bool is_downloading; // can be true even if speed is 0, e.g. slow download
-    uint64_t download_bytes_per_second; // current download speed
-};
-
 struct tr_webseed_view tr_torrentWebseed(tr_torrent const* torrent, size_t nth);
 
 size_t tr_torrentWebseedCount(tr_torrent const* torrent);
-
-/*
- * This view structure is intended for short-term use. Its pointers are owned
- * by the torrent and may be invalidated if the torrent is edited or removed.
- */
-struct tr_torrent_view
-{
-    char const* name;
-    char const* hash_string;
-
-    char const* comment; // optional; may be nullptr
-    char const* creator; // optional; may be nullptr
-    char const* source; // optional; may be nullptr
-
-    uint64_t total_size; // total size of the torrent, in bytes
-
-    time_t date_created;
-
-    uint32_t piece_size;
-    tr_piece_index_t n_pieces;
-
-    bool is_private;
-    bool is_folder;
-};
 
 struct tr_torrent_view tr_torrentView(tr_torrent const* tor);
 
@@ -1347,210 +961,6 @@ void tr_torrentAmountFinished(tr_torrent const* torrent, float* tab, int n_tabs)
 void tr_torrentVerify(tr_torrent* torrent);
 
 bool tr_torrentHasMetadata(tr_torrent const* tor);
-
-/**
- * What the torrent is doing right now.
- *
- * Note: these values will become a straight enum at some point in the future.
- * Do not rely on their current `bitfield` implementation
- */
-enum tr_torrent_activity : uint8_t
-{
-    TR_STATUS_STOPPED = 0, /* Torrent is stopped */
-    TR_STATUS_CHECK_WAIT = 1, /* Queued to check files */
-    TR_STATUS_CHECK = 2, /* Checking files */
-    TR_STATUS_DOWNLOAD_WAIT = 3, /* Queued to download */
-    TR_STATUS_DOWNLOAD = 4, /* Downloading */
-    TR_STATUS_SEED_WAIT = 5, /* Queued to seed */
-    TR_STATUS_SEED = 6 /* Seeding */
-};
-enum tr_peer_from : uint8_t
-{
-    TR_PEER_FROM_INCOMING = 0, /* connections made to the listening port */
-    TR_PEER_FROM_LPD, /* peers found by local announcements */
-    TR_PEER_FROM_TRACKER, /* peers found from a tracker */
-    TR_PEER_FROM_DHT, /* peers found from the DHT */
-    TR_PEER_FROM_PEX, /* peers found from PEX */
-    TR_PEER_FROM_RESUME, /* peers found in the .resume file */
-    TR_PEER_FROM_LTEP, /* peer address provided in an LTEP handshake */
-    TR_PEER_FROM_N_TYPES
-};
-enum tr_eta : time_t // NOLINT(performance-enum-size)
-{
-    TR_ETA_NOT_AVAIL = -1,
-    TR_ETA_UNKNOWN = -2,
-};
-
-/** @brief Used by `tr_torrentStat()` to tell clients about a torrent's state and statistics */
-struct tr_stat
-{
-    /** A warning or error message regarding the torrent.
-        @see error */
-    std::string error_string;
-
-    /** Byte count of all the piece data we'll have downloaded when we're done,
-        whether or not we have it yet. If we only want some of the files,
-        this may be less than `tr_torrent_view.total_size`.
-        [0...tr_torrent_view.total_size] */
-    uint64_t size_when_done = {};
-
-    /** Byte count of how much data is left to be downloaded until we've got
-        all the pieces that we want. [0...tr_stat.sizeWhenDone] */
-    uint64_t left_until_done = {};
-
-    /** Byte count of all the piece data we want and don't have yet,
-        but that a connected peer does have. [0...leftUntilDone] */
-    uint64_t desired_available = {};
-
-    /** Byte count of all the corrupt data you've ever downloaded for
-        this torrent. If you're on a poisoned torrent, this number can
-        grow very large. */
-    uint64_t corrupt_ever = {};
-
-    /** Byte count of all data you've ever uploaded for this torrent. */
-    uint64_t uploaded_ever = {};
-
-    /** Byte count of all the non-corrupt data you've ever downloaded
-        for this torrent. If you deleted the files and downloaded a second
-        time, this will be `2*totalSize`.. */
-    uint64_t downloaded_ever = {};
-
-    /** Byte count of all the checksum-verified data we have for this torrent.
-      */
-    uint64_t have_valid = {};
-
-    /** Byte count of all the partial piece data we have for this torrent.
-        As pieces become complete, this value may decrease as portions of it
-        are moved to `corrupt` or `haveValid`. */
-    uint64_t have_unchecked = {};
-
-    // Speed of all piece being sent for this torrent.
-    // This ONLY counts piece data.
-    tr::Values::Speed piece_upload_speed;
-
-    // Speed of all piece being received for this torrent.
-    // This ONLY counts piece data.
-    tr::Values::Speed piece_download_speed;
-
-    // When the torrent was first added
-    time_t added_date = {};
-
-    // When the torrent finished downloading
-    time_t done_date = {};
-
-    // When the torrent was last started
-    time_t start_date = {};
-
-    // The last time we uploaded or downloaded piece data on this torrent
-    time_t activity_date = {};
-
-    // The last time during this session that a rarely-changing field
-    // changed -- e.g. any `tr_torrent_metainfo` field (trackers, filenames, name)
-    // or download directory. RPC clients can monitor this to know when
-    // to reload fields that rarely change.
-    time_t edit_date = {};
-
-    // Number of seconds since the last activity (or since started).
-    // -1 if activity is not seeding or downloading.
-    time_t idle_secs = {};
-
-    // Cumulative seconds the torrent's ever spent downloading
-    time_t seconds_downloading = {};
-
-    // Cumulative seconds the torrent's ever spent seeding
-    time_t seconds_seeding = {};
-
-    // If downloading, estimated number of seconds left until the torrent is done.
-    // If seeding, estimated number of seconds left until seed ratio is reached.
-    time_t eta = {};
-
-    // If seeding, number of seconds left until the idle time limit is reached.
-    time_t eta_idle = {};
-
-    // This torrent's queue position.
-    // All torrents have a queue position, even if it's not queued.
-    size_t queue_position = {};
-
-    // When `tr_stat.activity` is `TR_STATUS_CHECK` or `TR_STATUS_CHECK_WAIT`,
-    // this is the percentage of how much of the files has been
-    // verified. When it gets to 1, the verify process is done.
-    // Range is [0..1]
-    // @see `tr_stat.activity`
-    float recheck_progress = {};
-
-    // How much has been downloaded of the entire torrent.
-    // Range is [0..1]
-    float percent_complete = {};
-
-    // How much of the metadata the torrent has.
-    // For torrents added from a torrent this will always be 1.
-    // For magnet links, this number will from from 0 to 1 as the metadata is downloaded.
-    // Range is [0..1]
-    float metadata_percent_complete = {};
-
-    // How much has been downloaded of the files the user wants. This differs
-    // from percentComplete if the user wants only some of the torrent's files.
-    // Range is [0..1]
-    // @see tr_stat.left_until_done
-    float percent_done = {};
-
-    // How much has been uploaded to satisfy the seed ratio.
-    // This is 1 if the ratio is reached or the torrent is set to seed forever.
-    // Range is [0..1] */
-    float seed_ratio_percent_done = {};
-
-    // Total uploaded bytes / size_when_done.
-    // NB: In Transmission 3.00 and earlier, this was total upload / download,
-    // which caused edge cases when total download was less than size_when_done.
-    float upload_ratio = {};
-
-    // The torrent's unique Id.
-    // @see `tr_torrentId()`
-    tr_torrent_id_t id = {};
-
-    // Number of peers that we're connected to
-    uint16_t peers_connected = {};
-
-    // How many connected peers we found out about from the tracker, or from pex,
-    // or from incoming connections, or from our resume file.
-    std::array<uint16_t, TR_PEER_FROM_N_TYPES> peers_from = {};
-
-    // How many known peers we found out about from the tracker, or from pex,
-    // or from incoming connections, or from our resume file.
-    std::array<uint16_t, TR_PEER_FROM_N_TYPES> known_peers_from = {};
-
-    // Number of peers that are sending data to us.
-    uint16_t peers_sending_to_us = {};
-
-    // Number of peers that we're sending data to
-    uint16_t peers_getting_from_us = {};
-
-    // Number of webseeds that are sending data to us.
-    uint16_t webseeds_sending_to_us = {};
-
-    // What is this torrent doing right now?
-    tr_torrent_activity activity = {};
-
-    enum class Error : uint8_t
-    {
-        Ok, // everything's fine
-        TrackerWarning, // tracker returned a warning
-        TrackerError, // tracker returned an error
-        LocalError // local non-tracker error, e.g. disk full or file permissions
-    };
-
-    // Defines what kind of text is in error_string.
-    // @see errorString
-    Error error = Error::Ok;
-
-    // A torrent is considered finished if it has met its seed ratio.
-    // As a result, only paused torrents can be finished.
-    bool finished = {};
-
-    // True if the torrent is running, but has been idle for long enough
-    // to be considered stalled.  @see `tr_sessionGetQueueStalledMinutes()`
-    bool is_stalled = {};
-};
 
 // Return a `tr_stat` structure with updated information on the torrent.
 // This is typically called by the GUI clients every

--- a/libtransmission/types.h
+++ b/libtransmission/types.h
@@ -1,0 +1,625 @@
+// This file Copyright © Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
+
+#pragma once
+
+#include <array>
+#include <cstddef> // size_t, std::byte
+#include <cstdint> // uint16_t, uint32_t, uint64_t
+#include <ctime> // time_t
+#include <functional>
+#include <string_view>
+#include <string>
+
+#include "libtransmission/values.h"
+
+struct tr_ctor;
+struct tr_error;
+struct tr_session;
+struct tr_torrent;
+struct tr_torrent_metainfo;
+struct tr_variant;
+
+// https://www.bittorrent.org/beps/bep_0007.html
+// "The client SHOULD include a key parameter in its announces. The key
+// should remain the same for a particular infohash during a torrent
+// session. Together with the peer_id this allows trackers to uniquely
+// identify clients for the purpose of statistics-keeping when they
+// announce from multiple IP.
+// The key should be generated so it has at least 32bits worth of entropy."
+//
+// https://www.bittorrent.org/beps/bep_0015.html
+// "Clients that resolve hostnames to v4 and v6 and then announce to both
+// should use the same [32-bit integer] key for both so that trackers that
+// care about accurate statistics-keeping can match the two announces."
+using tr_announce_key_t = uint32_t;
+
+// Assuming a 16 KiB block (tr_block_info::BlockSize), a 32-bit block
+// index gives us a maximum torrent size of 64 TiB. When we ever need to
+// grow past that, change tr_block_index_t and  tr_piece_index_t to uint64_t.
+using tr_block_index_t = uint32_t;
+
+using tr_byte_index_t = uint64_t;
+
+using tr_file_index_t = size_t;
+
+using tr_mode_t = uint16_t;
+
+// https://www.bittorrent.org/beps/bep_0003.html
+// A string of length 20 which this downloader uses as its id. Each
+// downloader generates its own id at random at the start of a new
+// download. This value will also almost certainly have to be escaped.
+using tr_peer_id_t = std::array<char, 20>;
+
+using tr_piece_index_t = uint32_t;
+
+using tr_sha1_digest_t = std::array<std::byte, 20>;
+
+using tr_sha256_digest_t = std::array<std::byte, 32>;
+
+using tr_torrent_id_t = int;
+
+using tr_tracker_id_t = uint32_t;
+
+using tr_tracker_tier_t = uint32_t;
+
+enum : uint8_t
+{
+    TR_LOC_MOVING,
+    TR_LOC_DONE,
+    TR_LOC_ERROR
+};
+
+enum : int8_t
+{
+    TR_RATIO_NA = -1,
+    TR_RATIO_INF = -2
+};
+
+enum TrScript : uint8_t
+{
+    TR_SCRIPT_ON_TORRENT_ADDED,
+    TR_SCRIPT_ON_TORRENT_DONE,
+    TR_SCRIPT_ON_TORRENT_DONE_SEEDING,
+
+    TR_SCRIPT_N_TYPES
+};
+
+enum tr_completeness : uint8_t
+{
+    TR_LEECH, /* doesn't have all the desired pieces */
+    TR_SEED, /* has the entire torrent */
+    TR_PARTIAL_SEED /* has the desired pieces, but not the entire torrent */
+};
+
+enum tr_ctorMode : uint8_t
+{
+    TR_FALLBACK, /* indicates the ctor value should be used only in case of missing resume settings */
+    TR_FORCE /* indicates the ctor value should be used regardless of what's in the resume settings */
+};
+
+enum class tr_direction : uint8_t
+{
+    ClientToPeer = 0,
+    Up = 0,
+    PeerToClient = 1,
+    Down = 1,
+};
+
+enum tr_encryption_mode : uint8_t
+{
+    TR_CLEAR_PREFERRED,
+    TR_ENCRYPTION_PREFERRED,
+    TR_ENCRYPTION_REQUIRED
+};
+
+enum tr_eta : time_t // NOLINT(performance-enum-size)
+{
+    TR_ETA_NOT_AVAIL = -1,
+    TR_ETA_UNKNOWN = -2,
+};
+
+enum tr_idlelimit : uint8_t
+{
+    /* follow the global settings */
+    TR_IDLELIMIT_GLOBAL = 0,
+    /* override the global settings, seeding until a certain idle time */
+    TR_IDLELIMIT_SINGLE = 1,
+    /* override the global settings, seeding regardless of activity */
+    TR_IDLELIMIT_UNLIMITED = 2
+};
+
+enum tr_peer_from : uint8_t
+{
+    TR_PEER_FROM_INCOMING = 0, /* connections made to the listening port */
+    TR_PEER_FROM_LPD, /* peers found by local announcements */
+    TR_PEER_FROM_TRACKER, /* peers found from a tracker */
+    TR_PEER_FROM_DHT, /* peers found from the DHT */
+    TR_PEER_FROM_PEX, /* peers found from PEX */
+    TR_PEER_FROM_RESUME, /* peers found in the .resume file */
+    TR_PEER_FROM_LTEP, /* peer address provided in an LTEP handshake */
+    TR_PEER_FROM_N_TYPES
+};
+
+enum tr_priority_t : int8_t
+{
+    TR_PRI_LOW = -1,
+    TR_PRI_NORMAL = 0, /* since Normal is 0, memset initializes nicely */
+    TR_PRI_HIGH = 1
+};
+
+enum tr_port_forwarding_state : uint8_t
+{
+    TR_PORT_ERROR,
+    TR_PORT_UNMAPPED,
+    TR_PORT_UNMAPPING,
+    TR_PORT_MAPPING,
+    TR_PORT_MAPPED
+};
+
+enum tr_ratiolimit : uint8_t
+{
+    /* follow the global settings */
+    TR_RATIOLIMIT_GLOBAL = 0,
+    /* override the global settings, seeding until a certain ratio */
+    TR_RATIOLIMIT_SINGLE = 1,
+    /* override the global settings, seeding regardless of ratio */
+    TR_RATIOLIMIT_UNLIMITED = 2
+};
+
+enum tr_rpc_callback_type : uint8_t
+{
+    TR_RPC_TORRENT_ADDED,
+    TR_RPC_TORRENT_STARTED,
+    TR_RPC_TORRENT_STOPPED,
+    TR_RPC_TORRENT_REMOVING,
+    TR_RPC_TORRENT_TRASHING, /* _REMOVING + delete local data */
+    TR_RPC_TORRENT_CHANGED, /* catch-all for the "torrent_set" rpc method */
+    TR_RPC_TORRENT_MOVED,
+    TR_RPC_SESSION_CHANGED,
+    TR_RPC_SESSION_QUEUE_POSITIONS_CHANGED, /* catch potentially multiple torrents being moved in the queue */
+    TR_RPC_SESSION_CLOSE
+};
+
+enum tr_rpc_callback_status : uint8_t
+{
+    /* no special handling is needed by the caller */
+    TR_RPC_OK = 0,
+    /* indicates to the caller that the client will take care of
+     * removing the torrent itself. For example the client may
+     * need to keep the torrent alive long enough to cleanly close
+     * some resources in another thread. */
+    TR_RPC_NOREMOVE = (1 << 1)
+};
+
+enum tr_sched_day : uint8_t
+{
+    TR_SCHED_SUN = (1 << 0),
+    TR_SCHED_MON = (1 << 1),
+    TR_SCHED_TUES = (1 << 2),
+    TR_SCHED_WED = (1 << 3),
+    TR_SCHED_THURS = (1 << 4),
+    TR_SCHED_FRI = (1 << 5),
+    TR_SCHED_SAT = (1 << 6),
+    TR_SCHED_WEEKDAY = (TR_SCHED_MON | TR_SCHED_TUES | TR_SCHED_WED | TR_SCHED_THURS | TR_SCHED_FRI),
+    TR_SCHED_WEEKEND = (TR_SCHED_SUN | TR_SCHED_SAT),
+    TR_SCHED_ALL = (TR_SCHED_WEEKDAY | TR_SCHED_WEEKEND)
+};
+
+/**
+ * What the torrent is doing right now.
+ *
+ * Note: these values will become a straight enum at some point in the future.
+ * Do not rely on their current `bitfield` implementation
+ */
+enum tr_torrent_activity : uint8_t
+{
+    TR_STATUS_STOPPED = 0, /* Torrent is stopped */
+    TR_STATUS_CHECK_WAIT = 1, /* Queued to check files */
+    TR_STATUS_CHECK = 2, /* Checking files */
+    TR_STATUS_DOWNLOAD_WAIT = 3, /* Queued to download */
+    TR_STATUS_DOWNLOAD = 4, /* Downloading */
+    TR_STATUS_SEED_WAIT = 5, /* Queued to seed */
+    TR_STATUS_SEED = 6 /* Seeding */
+};
+
+enum tr_tracker_state : uint8_t
+{
+    /* we won't (announce,scrape) this torrent to this tracker because
+     * the torrent is stopped, or because of an error, or whatever */
+    TR_TRACKER_INACTIVE = 0,
+    /* we will (announce,scrape) this torrent to this tracker, and are
+     * waiting for enough time to pass to satisfy the tracker's interval */
+    TR_TRACKER_WAITING = 1,
+    /* it's time to (announce,scrape) this torrent, and we're waiting on a
+     * free slot to open up in the announce manager */
+    TR_TRACKER_QUEUED = 2,
+    /* we're (announcing,scraping) this torrent right now */
+    TR_TRACKER_ACTIVE = 3
+};
+
+enum tr_verify_added_mode : uint8_t
+{
+    // See discussion @ https://github.com/transmission/transmission/pull/2626
+    // Let newly-added torrents skip upfront verify do it on-demand later.
+    TR_VERIFY_ADDED_FAST = 0,
+
+    // Force torrents to be fully verified as they are added.
+    TR_VERIFY_ADDED_FULL = 1
+};
+
+struct tr_block_span_t
+{
+    tr_block_index_t begin;
+    tr_block_index_t end;
+};
+
+struct tr_byte_span_t
+{
+    uint64_t begin;
+    uint64_t end;
+};
+
+/*
+ * This view structure is intended for short-term use. Its pointers are owned
+ * by the torrent and may be invalidated if the torrent is edited or removed.
+ */
+struct tr_file_view
+{
+    char const* name; // This file's name. Includes the full subpath in the torrent.
+    uint64_t have; // the current size of the file, i.e. how much we've downloaded
+    uint64_t length; // the total size of the file
+    double progress; // have / length
+    tr_piece_index_t beginPiece; // piece index where this file starts
+    tr_piece_index_t endPiece; // piece index where this file ends (exclusive)
+    tr_priority_t priority; // the file's priority
+    bool wanted; // do we want to download this file?
+};
+
+struct tr_peer_stat
+{
+    std::string addr;
+    std::string flag_str;
+
+    // The user agent, e.g. `BitTorrent 7.9.1`.
+    // Will be an empty string if the agent cannot be determined.
+    std::string user_agent;
+
+    tr::Values::Speed rate_to_peer;
+    tr::Values::Speed rate_to_client;
+
+    // how many requests the peer has made that we haven't responded to yet
+    size_t active_reqs_to_client = {};
+
+    // how many requests we've made and are currently awaiting a response for
+    size_t active_reqs_to_peer = {};
+
+    size_t bytes_to_peer = {};
+    size_t bytes_to_client = {};
+
+    tr_peer_id_t peer_id = {};
+
+    float progress = {};
+
+    // THESE NEXT FOUR FIELDS ARE EXPERIMENTAL.
+    // Don't rely on them; they'll probably go away
+    // how many blocks we've sent to this peer in the last 120 seconds
+    uint32_t blocks_to_peer = {};
+    // how many blocks this client's sent to us in the last 120 seconds
+    uint32_t blocks_to_client = {};
+    // how many requests to this peer that we've cancelled in the last 120 seconds
+    uint32_t cancels_to_peer = {};
+    // how many requests this peer made of us, then cancelled, in the last 120 seconds
+    uint32_t cancels_to_client = {};
+
+    uint16_t port = {};
+    uint8_t from = {};
+
+    bool client_is_choked = {};
+    bool client_is_interested = {};
+    bool is_downloading_from = {};
+    bool is_encrypted = {};
+    bool is_incoming = {};
+    bool is_seed = {};
+    bool is_uploading_to = {};
+    bool is_utp = {};
+    bool peer_is_choked = {};
+    bool peer_is_interested = {};
+};
+
+/** @brief Used by `tr_sessionGetStats()` and `tr_sessionGetCumulativeStats()` */
+struct tr_session_stats
+{
+    float ratio; /* TR_RATIO_INF, TR_RATIO_NA, or total up/down */
+    uint64_t uploadedBytes; /* total up */
+    uint64_t downloadedBytes; /* total down */
+    uint64_t filesAdded; /* number of files added */
+    uint64_t sessionCount; /* program started N times */
+    uint64_t secondsActive; /* how long Transmission's been running */
+};
+
+struct tr_stat
+{
+    /** A warning or error message regarding the torrent.
+        @see error */
+    std::string error_string;
+
+    /** Byte count of all the piece data we'll have downloaded when we're done,
+        whether or not we have it yet. If we only want some of the files,
+        this may be less than `tr_torrent_view.total_size`.
+        [0...tr_torrent_view.total_size] */
+    uint64_t size_when_done = {};
+
+    /** Byte count of how much data is left to be downloaded until we've got
+        all the pieces that we want. [0...tr_stat.sizeWhenDone] */
+    uint64_t left_until_done = {};
+
+    /** Byte count of all the piece data we want and don't have yet,
+        but that a connected peer does have. [0...leftUntilDone] */
+    uint64_t desired_available = {};
+
+    /** Byte count of all the corrupt data you've ever downloaded for
+        this torrent. If you're on a poisoned torrent, this number can
+        grow very large. */
+    uint64_t corrupt_ever = {};
+
+    /** Byte count of all data you've ever uploaded for this torrent. */
+    uint64_t uploaded_ever = {};
+
+    /** Byte count of all the non-corrupt data you've ever downloaded
+        for this torrent. If you deleted the files and downloaded a second
+        time, this will be `2*totalSize`.. */
+    uint64_t downloaded_ever = {};
+
+    /** Byte count of all the checksum-verified data we have for this torrent.
+      */
+    uint64_t have_valid = {};
+
+    /** Byte count of all the partial piece data we have for this torrent.
+        As pieces become complete, this value may decrease as portions of it
+        are moved to `corrupt` or `haveValid`. */
+    uint64_t have_unchecked = {};
+
+    // Speed of all piece being sent for this torrent.
+    // This ONLY counts piece data.
+    tr::Values::Speed piece_upload_speed;
+
+    // Speed of all piece being received for this torrent.
+    // This ONLY counts piece data.
+    tr::Values::Speed piece_download_speed;
+
+    // When the torrent was first added
+    time_t added_date = {};
+
+    // When the torrent finished downloading
+    time_t done_date = {};
+
+    // When the torrent was last started
+    time_t start_date = {};
+
+    // The last time we uploaded or downloaded piece data on this torrent
+    time_t activity_date = {};
+
+    // The last time during this session that a rarely-changing field
+    // changed -- e.g. any `tr_torrent_metainfo` field (trackers, filenames, name)
+    // or download directory. RPC clients can monitor this to know when
+    // to reload fields that rarely change.
+    time_t edit_date = {};
+
+    // Number of seconds since the last activity (or since started).
+    // -1 if activity is not seeding or downloading.
+    time_t idle_secs = {};
+
+    // Cumulative seconds the torrent's ever spent downloading
+    time_t seconds_downloading = {};
+
+    // Cumulative seconds the torrent's ever spent seeding
+    time_t seconds_seeding = {};
+
+    // If downloading, estimated number of seconds left until the torrent is done.
+    // If seeding, estimated number of seconds left until seed ratio is reached.
+    time_t eta = {};
+
+    // If seeding, number of seconds left until the idle time limit is reached.
+    time_t eta_idle = {};
+
+    // This torrent's queue position.
+    // All torrents have a queue position, even if it's not queued.
+    size_t queue_position = {};
+
+    // When `tr_stat.activity` is `TR_STATUS_CHECK` or `TR_STATUS_CHECK_WAIT`,
+    // this is the percentage of how much of the files has been
+    // verified. When it gets to 1, the verify process is done.
+    // Range is [0..1]
+    // @see `tr_stat.activity`
+    float recheck_progress = {};
+
+    // How much has been downloaded of the entire torrent.
+    // Range is [0..1]
+    float percent_complete = {};
+
+    // How much of the metadata the torrent has.
+    // For torrents added from a torrent this will always be 1.
+    // For magnet links, this number will from from 0 to 1 as the metadata is downloaded.
+    // Range is [0..1]
+    float metadata_percent_complete = {};
+
+    // How much has been downloaded of the files the user wants. This differs
+    // from percentComplete if the user wants only some of the torrent's files.
+    // Range is [0..1]
+    // @see tr_stat.left_until_done
+    float percent_done = {};
+
+    // How much has been uploaded to satisfy the seed ratio.
+    // This is 1 if the ratio is reached or the torrent is set to seed forever.
+    // Range is [0..1] */
+    float seed_ratio_percent_done = {};
+
+    // Total uploaded bytes / size_when_done.
+    // NB: In Transmission 3.00 and earlier, this was total upload / download,
+    // which caused edge cases when total download was less than size_when_done.
+    float upload_ratio = {};
+
+    // The torrent's unique Id.
+    // @see `tr_torrentId()`
+    tr_torrent_id_t id = {};
+
+    // Number of peers that we're connected to
+    uint16_t peers_connected = {};
+
+    // How many connected peers we found out about from the tracker, or from pex,
+    // or from incoming connections, or from our resume file.
+    std::array<uint16_t, TR_PEER_FROM_N_TYPES> peers_from = {};
+
+    // How many known peers we found out about from the tracker, or from pex,
+    // or from incoming connections, or from our resume file.
+    std::array<uint16_t, TR_PEER_FROM_N_TYPES> known_peers_from = {};
+
+    // Number of peers that are sending data to us.
+    uint16_t peers_sending_to_us = {};
+
+    // Number of peers that we're sending data to
+    uint16_t peers_getting_from_us = {};
+
+    // Number of webseeds that are sending data to us.
+    uint16_t webseeds_sending_to_us = {};
+
+    // What is this torrent doing right now?
+    tr_torrent_activity activity = {};
+
+    enum class Error : uint8_t
+    {
+        Ok, // everything's fine
+        TrackerWarning, // tracker returned a warning
+        TrackerError, // tracker returned an error
+        LocalError // local non-tracker error, e.g. disk full or file permissions
+    };
+
+    // Defines what kind of text is in error_string.
+    // @see errorString
+    Error error = Error::Ok;
+
+    // A torrent is considered finished if it has met its seed ratio.
+    // As a result, only paused torrents can be finished.
+    bool finished = {};
+
+    // True if the torrent is running, but has been idle for long enough
+    // to be considered stalled.  @see `tr_sessionGetQueueStalledMinutes()`
+    bool is_stalled = {};
+};
+
+/*
+ * This view structure is intended for short-term use. Its pointers are owned
+ * by the torrent and may be invalidated if the torrent is edited or removed.
+ */
+struct tr_torrent_view
+{
+    char const* name;
+    char const* hash_string;
+
+    char const* comment; // optional; may be nullptr
+    char const* creator; // optional; may be nullptr
+    char const* source; // optional; may be nullptr
+
+    uint64_t total_size; // total size of the torrent, in bytes
+
+    time_t date_created;
+
+    uint32_t piece_size;
+    tr_piece_index_t n_pieces;
+
+    bool is_private;
+    bool is_folder;
+};
+
+// NOLINTBEGIN(modernize-avoid-c-arrays)
+/*
+ * Unlike other _view structs, it is safe to keep a tr_tracker_view copy.
+ * The announce and scrape strings are interned & never go out-of-scope.
+ */
+struct tr_tracker_view
+{
+    char const* announce; // full announce URL
+    char const* scrape; // full scrape URL
+    char host_and_port[72]; // uniquely-identifying tracker name (`${host}:${port}`)
+
+    // The tracker site's name. Uses the first label before the public suffix
+    // (https://publicsuffix.org/) in the announce URL's host.
+    // e.g. "https://www.example.co.uk/announce/"'s sitename is "example"
+    // RFC 1034 says labels must be less than 64 chars
+    char sitename[64];
+
+    char lastAnnounceResult[128]; // if hasAnnounced, the human-readable result of latest announce
+    char lastScrapeResult[128]; // if hasScraped, the human-readable result of the latest scrape
+
+    time_t lastAnnounceStartTime; // if hasAnnounced, when the latest announce request was sent
+    time_t lastAnnounceTime; // if hasAnnounced, when the latest announce reply was received
+    time_t nextAnnounceTime; // if announceState == TR_TRACKER_WAITING, time of next announce
+
+    time_t lastScrapeStartTime; // if hasScraped, when the latest scrape request was sent
+    time_t lastScrapeTime; // if hasScraped, when the latest scrape reply was received
+    time_t nextScrapeTime; // if scrapeState == TR_TRACKER_WAITING, time of next scrape
+
+    int downloadCount; // number of times this torrent's been downloaded, or -1 if unknown
+    int lastAnnouncePeerCount; // if hasAnnounced, the number of peers the tracker gave us
+    int leecherCount; // number of leechers the tracker knows of, or -1 if unknown
+    int seederCount; // number of seeders the tracker knows of, or -1 if unknown
+    int downloader_count; // number of downloaders (BEP-21) the tracker knows of, or -1 if unknown
+
+    size_t tier; // which tier this tracker is in
+    tr_tracker_id_t id; // unique transmission-generated ID for use in libtransmission API
+
+    tr_tracker_state announceState; // whether we're announcing, waiting to announce, etc.
+    tr_tracker_state scrapeState; // whether we're scraping, waiting to scrape, etc.
+
+    bool hasAnnounced; // true iff we've announced to this tracker during this session
+    bool hasScraped; // true iff we've scraped this tracker during this session
+    bool isBackup; // only one tracker per tier is used; the others are kept as backups
+    bool lastAnnounceSucceeded; // if hasAnnounced, whether or not the latest announce succeeded
+    bool lastAnnounceTimedOut; // true iff the latest announce request timed out
+    bool lastScrapeSucceeded; // if hasScraped, whether or not the latest scrape succeeded
+    bool lastScrapeTimedOut; // true iff the latest scrape request timed out
+};
+// NOLINTEND(modernize-avoid-c-arrays)
+
+/*
+ * This view structure is intended for short-term use. Its pointers are owned
+ * by the torrent and may be invalidated if the torrent is edited or removed.
+ */
+struct tr_webseed_view
+{
+    char const* url; // the url to download from
+    bool is_downloading; // can be true even if speed is 0, e.g. slow download
+    uint64_t download_bytes_per_second; // current download speed
+};
+
+using tr_altSpeedFunc = void (*)(tr_session* session, bool active, bool user_driven, void*);
+
+using tr_session_idle_limit_hit_func = void (*)(tr_session*, tr_torrent* torrent, void* user_data);
+
+using tr_session_metadata_func = void (*)(tr_session* session, tr_torrent* torrent, void* user_data);
+
+using tr_session_ratio_limit_hit_func = void (*)(tr_session*, tr_torrent* torrent, void* user_data);
+
+/**
+ * @param was_running whether or not the torrent was running when
+ *                    it changed its completeness state
+ */
+using tr_torrent_completeness_func = void (*)( //
+    tr_torrent* torrent,
+    tr_completeness completeness,
+    bool was_running,
+    void* user_data);
+
+using tr_torrent_remove_func = std::function<bool(std::string_view filename, tr_error* error)>;
+
+using tr_rpc_func = tr_rpc_callback_status (*)( //
+    tr_session* session,
+    tr_rpc_callback_type type,
+    struct tr_torrent* tor_or_null,
+    void* user_data);
+
+using tr_torrent_rename_done_func = std::function<
+    void(tr_torrent* torrent, char const* oldpath, char const* newname, int error, void* user_data)>;

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -40,14 +40,13 @@
 
 #include <fast_float/fast_float.h>
 
-#include "libtransmission/transmission.h"
-
 #include "libtransmission/env.h"
 #include "libtransmission/mime-types.h"
 #include "libtransmission/serializer.h"
 #include "libtransmission/string-utils.h"
 #include "libtransmission/tr-assert.h"
 #include "libtransmission/tr-strbuf.h"
+#include "libtransmission/types.h"
 #include "libtransmission/utils.h"
 #include "libtransmission/values.h"
 

--- a/libtransmission/verify.cc
+++ b/libtransmission/verify.cc
@@ -15,11 +15,9 @@
 #include <utility> // for std::move()
 #include <vector>
 
-#include "libtransmission/transmission.h"
-
 #include "libtransmission/crypto-utils.h"
 #include "libtransmission/file.h"
-#include "libtransmission/tr-macros.h"
+#include "libtransmission/types.h"
 #include "libtransmission/verify.h"
 
 using namespace std::chrono_literals;

--- a/libtransmission/verify.h
+++ b/libtransmission/verify.h
@@ -19,10 +19,8 @@
 #include <thread>
 #include <utility> // std::move
 
-#include "libtransmission/transmission.h"
-
 #include "libtransmission/torrent-metainfo.h"
-#include "libtransmission/tr-macros.h"
+#include "libtransmission/types.h"
 
 class tr_verify_worker
 {

--- a/libtransmission/watchdir-kqueue.cc
+++ b/libtransmission/watchdir-kqueue.cc
@@ -22,8 +22,6 @@
 #include <fmt/format.h>
 
 #define LIBTRANSMISSION_WATCHDIR_MODULE
-#include "libtransmission/transmission.h"
-
 #include "libtransmission/log.h"
 #include "libtransmission/string-utils.h"
 #include "libtransmission/tr-strbuf.h"

--- a/libtransmission/watchdir-win32.cc
+++ b/libtransmission/watchdir-win32.cc
@@ -20,13 +20,11 @@
 #include <fmt/format.h>
 
 #define LIBTRANSMISSION_WATCHDIR_MODULE
-
-#include "libtransmission/transmission.h"
-
 #include "libtransmission/log.h"
 #include "libtransmission/net.h"
 #include "libtransmission/string-utils.h"
 #include "libtransmission/tr-assert.h"
+#include "libtransmission/types.h"
 #include "libtransmission/utils.h"
 #include "libtransmission/watchdir-base.h"
 

--- a/libtransmission/web-utils.cc
+++ b/libtransmission/web-utils.cc
@@ -20,14 +20,14 @@
 #define PSL_STATIC
 #include <libpsl.h>
 
+#include "libtransmission/web-utils.h"
+
 #include "libtransmission/log.h"
 #include "libtransmission/net.h"
 #include "libtransmission/string-utils.h"
 #include "libtransmission/tr-assert.h"
-#include "libtransmission/tr-macros.h"
 #include "libtransmission/tr-strbuf.h"
 #include "libtransmission/utils.h"
-#include "libtransmission/web-utils.h"
 
 using namespace std::literals;
 

--- a/libtransmission/web-utils.h
+++ b/libtransmission/web-utils.h
@@ -14,7 +14,7 @@
 
 #include <fmt/format.h>
 
-#include "libtransmission/tr-macros.h" // tr_sha1_digest_t
+#include "libtransmission/types.h" // tr_sha1_digest_t
 
 /** @brief convenience function to determine if an address is an IP address (IPv4 or IPv6) */
 bool tr_addressIsIP(char const* address);

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -17,8 +17,6 @@
 
 #include <fmt/format.h>
 
-#include "libtransmission/transmission.h"
-
 #include "libtransmission/bandwidth.h"
 #include "libtransmission/bitfield.h"
 #include "libtransmission/block-info.h"
@@ -31,8 +29,8 @@
 #include "libtransmission/torrent.h"
 #include "libtransmission/tr-assert.h"
 #include "libtransmission/tr-buffer.h"
-#include "libtransmission/tr-macros.h"
 #include "libtransmission/tr-strbuf.h"
+#include "libtransmission/types.h"
 #include "libtransmission/web-utils.h"
 #include "libtransmission/web.h"
 #include "libtransmission/webseed.h"
@@ -392,7 +390,7 @@ void tr_webseed_task::use_fetched_blocks()
                 [session = session_, tor_id = tor.id(), block = loc_.block, block_buf, webseed = webseed_]()
                 {
                     auto data = std::unique_ptr<Cache::BlockData>{ block_buf };
-                    if (auto const* const torrent = tr_torrentFindFromId(session, tor_id); torrent != nullptr)
+                    if (auto const* const torrent = session->torrents().get(tor_id); torrent != nullptr)
                     {
                         webseed->active_requests.unset(block);
                         session->cache->write_block(tor_id, block, std::move(data));

--- a/libtransmission/webseed.h
+++ b/libtransmission/webseed.h
@@ -12,8 +12,6 @@
 #include <memory>
 #include <string_view>
 
-#include "libtransmission/transmission.h"
-
 #include "libtransmission/peer-common.h"
 
 using tr_peer_callback_webseed = tr_peer_callback_generic;

--- a/tests/libtransmission/test-fixtures.h
+++ b/tests/libtransmission/test-fixtures.h
@@ -21,6 +21,8 @@
 
 #include <gtest/gtest.h>
 
+#include <libtransmission/transmission.h>
+
 #include <libtransmission/crypto-utils.h> // tr_base64_decode()
 #include <libtransmission/error.h>
 #include <libtransmission/file.h> // tr_sys_file_*()


### PR DESCRIPTION
more prework for https://github.com/transmission/transmission/issues/8410.

Moves the type declarations out of `libtransmission/tr-macros.h` and `libtransmission/transmission.h` into a new header `libtransmission/types.h`.

Goals:

- Move BitTorrent-specific pieces out of `tr-macros.h` so that 8410 can move it to `lib/base/macros.h`
- Have a "clean" header (ie only includes std headers) that defines our structs.
- Reduce the visibility of the legacy C API in `libtransmission/`.