### PR TITLE
fix: mime-type icons on Windows

### DIFF
--- a/qt/IconCache.cc
+++ b/qt/IconCache.cc
@@ -84,21 +84,10 @@ QIcon IconCache::getMimeTypeIcon(QString const& mime_type_name, bool multifile) 
 
     if (!multifile)
     {
-        QMimeDatabase const mime_db;
+        static auto const mime_db = QMimeDatabase{};
         auto const type = mime_db.mimeTypeForName(mime_type_name);
-        icon = getThemeIcon(type.iconName());
-
-        if (icon.isNull())
-        {
-            icon = getThemeIcon(type.genericIconName());
-        }
-
-        if (icon.isNull())
-        {
-            icon = file_icon_;
-        }
-
-        return icon;
+        auto const filename = QStringLiteral("filename.%1").arg(type.preferredSuffix());
+        return guessMimeIcon(filename, file_icon_);
     }
 
     auto const mime_icon = getMimeTypeIcon(mime_type_name, false);


### PR DESCRIPTION
Fixes #4566.

Cherry-pick of #8443 for `4.1.x`.

Notes: Fixed broken icons in the torrent list on Windows.