### PR TITLE
Check host validity in url schemes

### DIFF
--- a/libtransmission/announce-list.cc
+++ b/libtransmission/announce-list.cc
@@ -86,8 +86,10 @@ bool tr_announce_list::add(std::string_view announce_url, tr_tracker_tier_t tier
     // according to the definition in RFC 3986 Section 6.1, while consisting of
     // only US-ASCII characters. This ensures the URLs be represented correctly
     // when transmitted via UTF-8 mediums, for example JSON.
+    // It now works in two parts: the hostname, if present, is first converted to IDN,
+    // then the rest is percent-encoded as needed
     auto normalized_url = tr_urlbuf{};
-    tr_urlPercentEncode(std::back_inserter(normalized_url), announce_url, false);
+    normalized_url = tr_normalize_url(announce_url);
 
     // Make sure the announce URL is usable before we intern it.
     if (auto const announce = tr_urlParseTracker(normalized_url); !announce || !can_add(*announce))

--- a/libtransmission/torrent-metainfo.cc
+++ b/libtransmission/torrent-metainfo.cc
@@ -1,3 +1,4 @@
+
 // This file Copyright © Mnemosyne LLC.
 // It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
 // or any future license endorsed by Mnemosyne LLC.
@@ -347,10 +348,6 @@ struct MetainfoHandler final : public tr::benc::BasicHandler<MaxBencDepth>
 
             tm_.source_ = tr_strv_to_utf8_string(value);
         }
-        else if (pathIs(AnnounceKey))
-        {
-            tm_.announce_list().add(value, tier_);
-        }
         else if (pathIs(EncodingKey))
         {
             encoding_ = tr_strv_strip(value);
@@ -387,9 +384,12 @@ struct MetainfoHandler final : public tr::benc::BasicHandler<MaxBencDepth>
             // currently unused. TODO support for bittorrent v2
             // TODO https://github.com/transmission/transmission/issues/458
         }
-        else if (pathStartsWith(AnnounceListKey))
+        else if (pathIs(AnnounceKey) || pathStartsWith(AnnounceListKey))
         {
-            tm_.announce_list().add(value, tier_);
+            if (!tm_.announce_list().add(value, tier_))
+            {
+                tr_logAddWarn(fmt::format("invalid announce url '{}'", value));
+            }
         }
         else if (curdepth == 2 && (pathStartsWith(HttpSeedsKey) || pathStartsWith(UrlListKey)))
         {

--- a/libtransmission/web-utils.h
+++ b/libtransmission/web-utils.h
@@ -93,3 +93,5 @@ constexpr void tr_urlPercentEncode(BackInsertIter out, tr_sha1_digest_t const& d
 [[nodiscard]] char const* tr_webGetResponseStr(long response_code);
 
 [[nodiscard]] std::string tr_urlPercentDecode(std::string_view /*url*/);
+
+[[nodiscard]] std::string tr_normalize_url(std::string_view /*url*/);

--- a/tests/libtransmission/web-utils-test.cc
+++ b/tests/libtransmission/web-utils-test.cc
@@ -235,6 +235,7 @@ TEST_F(WebUtilsTest, urlIsValid)
 {
     EXPECT_FALSE(tr_urlIsValid("hello world"sv));
     EXPECT_FALSE(tr_urlIsValid("http://www.💩.com/announce/"sv));
+    EXPECT_TRUE(tr_urlIsValid(tr_normalize_url("http://www.💩.com/announce/"sv)));
     EXPECT_TRUE(tr_urlIsValid("http://www.example.com/announce/"sv));
     EXPECT_FALSE(tr_urlIsValid(""sv));
     EXPECT_FALSE(tr_urlIsValid("com"sv));
@@ -245,6 +246,16 @@ TEST_F(WebUtilsTest, urlIsValid)
 
     EXPECT_TRUE(tr_urlIsValid("sftp://www.example.com"sv));
     EXPECT_FALSE(tr_urlIsValidTracker("sftp://www.example.com"sv)); // unsupported tracker scheme
+
+    EXPECT_FALSE(tr_urlIsValid("x:/www.example.com"sv));
+    EXPECT_FALSE(tr_urlIsValid("x://www.example.com"sv));
+    EXPECT_TRUE(tr_urlIsValid("http://www.example.com?announce"sv)); // less common but legal
+    EXPECT_FALSE(tr_urlIsValid("http://www.example.com/announce/\u00E8"sv));
+    EXPECT_TRUE(tr_urlIsValid(tr_normalize_url("http://www.example.com/announce/\u00E8"sv)));
+    EXPECT_FALSE(tr_urlIsValid("http://www.example.com/announce/\x80"sv));
+    EXPECT_TRUE(tr_urlIsValid(tr_normalize_url("http://www.example.com/announce/\x80"sv)));
+    EXPECT_TRUE(tr_urlIsValid("http://[dead:beef::0]:12345/announce"sv));
+    EXPECT_FALSE(tr_urlIsValid("http://dead:beef::0:12345/announce"sv)); // without [], cannot specify port
 }
 
 TEST_F(WebUtilsTest, urlPercentDecode)


### PR DESCRIPTION
This is likely an informational draft, we may choose another approach.

Transmission does little to no checking of domain names.  It is easy to get different `sitename` for different parts of the RPC API for the same url.  Tr has no support for RFC 3494 (IDN). 

But important to publish code for domain-name (including labels and FQDN) checking as well as lightweight punycode support for international domain names (IDN).  Definitely do NOT think we should be pulling in libidn / libidn2.

This is meant to address #8463, #8328, problems with #8420, deficiences in PSL support (which itself does not check name validity),

Due to #8420 this PR will fail several tests, so hoping we undo that and then progress on some version of this.