### PR TITLE
fix: crash when editing tracker list immediately after pausing torrent

### DIFF
--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -1802,15 +1802,19 @@ void tr_announcer_impl::resetTorrent(tr_torrent* tor)
         }
     }
 
-    // kickstart any tiers that didn't get started
-    if (tor->is_running())
+    // kickstart any tiers that didn't get started:
+    // 1. ensure every tier has a current tracker
+    // 2. if we weren't already talking to the current tracker, then say hello
+    auto const is_running = tor->is_running();
+    auto const now = tr_time();
+    for (auto& tier : newer->tiers)
     {
-        auto const now = tr_time();
-        for (auto& tier : newer->tiers)
+        if (!tier.current_tracker_index_)
         {
-            if (!tier.current_tracker_index_)
+            tier.useNextTracker();
+
+            if (is_running)
             {
-                tier.useNextTracker();
                 tier_announce_event_push(&tier, TR_ANNOUNCE_EVENT_STARTED, now);
             }
         }


### PR DESCRIPTION
Fixes #8422.

The issue was that it was possible to get a `tr_tier` into a state where a tier had pending announce events but no current tracker when:

1. User pauses a torrent
2. Pausing adds a "stopped" announce event to the announce queue
3. User quickly edits the tracker list, removing the current tracker

In these situations, it was possible for the tier to not have a "current tracker" index. This PR fixes that by ensuring we call `tr_tier::useNextTracker()` for any tier that doesn't have a current tracker, paused or not.

This is still a _weird_ edge case since the tracker that needs the "stop" announcement is the one that got the "start" announcement. But the user has explicitly told us to not use that tracker so :man_shrugging: let's at least not crash.