### PR TITLE
fix(test): wait for previous torrent to be removed before continuing

### DIFF
--- a/tests/libtransmission/rpc-test.cc
+++ b/tests/libtransmission/rpc-test.cc
@@ -303,6 +303,7 @@ TEST_F(RpcTest, idAsync)
 
         // cleanup
         tr_torrentRemove(tor, false);
+        EXPECT_TRUE(waitFor([this] { return std::empty(session_->torrents()); }, 5s));
     }
 }
 


### PR DESCRIPTION
This should fix occasionally test failures in `RpcTest.idAync` that look like this:

```
  551/551 Test #320: LT.RpcTest.idAsync ...........................................................................................................................***Exception: SegFault 20.08 sec
  Running main() from /home/runner/work/transmission/transmission/src/third-party/googletest/googletest/src/gtest_main.cc
  Note: Google Test filter = RpcTest.idAsync
  [==========] Running 1 test from 1 test suite.
  [----------] Global test environment set-up.
  [----------] 1 test from RpcTest
  [ RUN      ] RpcTest.idAsync
  /home/runner/work/transmission/transmission/src/tests/libtransmission/test-fixtures.h:384: Failure
  Expected: (nullptr) != (tor), actual: (nullptr) vs NULL
  
  /home/runner/work/transmission/transmission/src/tests/libtransmission/rpc-test.cc:261: Failure
  Expected: (nullptr) != (tor), actual: (nullptr) vs NULL
  
  /home/runner/work/transmission/transmission/src/tests/libtransmission/rpc-test.cc:282: Failure
  Expected: (result) != (nullptr), actual: NULL vs (nullptr)
  
  /home/runner/work/transmission/transmission/src/tests/libtransmission/rpc-test.cc:284: Failure
  Expected equality of these values:
    error
      Which is: 8-byte object <D0-23 58-02 08-00 00-00>
    std::end(*response_map)
      Which is: 8-byte object <30-24 58-02 08-00 00-00>
```