### PR TITLE
ci: include `.github/actions` in check-diffs

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -69,7 +69,7 @@ jobs:
           get_changes tests      CMakeLists.txt cmake third-party libtransmission utils tests
           get_changes utils      CMakeLists.txt cmake third-party libtransmission utils
           get_changes web        CMakeLists.txt cmake web
-          get_changes ci-actions .github/workflows/actions.yml
+          get_changes ci-actions .github/workflows/actions.yml .github/actions
           cat "$GITHUB_OUTPUT"
 
   code-style:


### PR DESCRIPTION
This directory contains composite actions that are essential to `.github/workflows/actions.yml`, so we should test changes in the composite actions too.