### PR TITLE
macOS GHA remove Universality

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -371,7 +371,7 @@ jobs:
           name: binaries-${{ matrix.os }}-${{ matrix.arch }}-xcodebuild
           path: pfx-${{ matrix.arch }}/Build/Products/**/Transmission.app*
 
-  macos-cmake-universal:
+  macos-cmake:
     strategy:
       fail-fast: false
       matrix:
@@ -450,7 +450,7 @@ jobs:
         run: cmake --install obj --config RelWithDebInfo --strip
       - uses: actions/upload-artifact@v6
         with:
-          name: binaries-${{ matrix.os }}-cmake-universal
+          name: binaries-${{ matrix.os }}-cmake
           path: pfx/**/*
 
   alpine-musl:


### PR DESCRIPTION
This splits macOS xcodebuild into arm64 and intel builds, also the cmake builds were already arch specific and not universal, so dropping that name from the artifacts & actions to reduce confusion, macos builds without any arch are expected to be arm only and intel builds are specified either as intel or have x86_64 in the artifact's name