### PR TITLE
security: sanitise CTRL characters in filenames on all systems

### DIFF
--- a/libtransmission/torrent-files.cc
+++ b/libtransmission/torrent-files.cc
@@ -435,7 +435,7 @@ namespace
 // for potential support of different filesystems on the same OS
 [[nodiscard, maybe_unused]] auto constexpr is_unix_reserved_char(unsigned char ch) noexcept
 {
-    return ch == '/';
+    return ch == '/' || ch <= 31;
 }
 
 // https://docs.microsoft.com/en-us/windows/desktop/FileIO/naming-a-file

--- a/libtransmission/torrent-files.cc
+++ b/libtransmission/torrent-files.cc
@@ -433,9 +433,10 @@ namespace
 
 // `is_unix_reserved_char` and `is_win32_reserved_char` kept as `maybe_unused`
 // for potential support of different filesystems on the same OS
-[[nodiscard, maybe_unused]] auto constexpr is_unix_reserved_char(unsigned char ch) noexcept
+[[nodiscard, maybe_unused]] auto constexpr is_unix_reserved_char([[maybe_unused]] unsigned char ch) noexcept
 {
-    return ch == '/' || ch <= 31;
+    // TODO: keep this here for future uses
+    return false;
 }
 
 // https://docs.microsoft.com/en-us/windows/desktop/FileIO/naming-a-file
@@ -448,7 +449,6 @@ namespace
     {
     case '"':
     case '*':
-    case '/':
     case ':':
     case '<':
     case '>':
@@ -457,12 +457,17 @@ namespace
     case '|':
         return true;
     default:
-        return ch <= 31;
+        return false;
     }
 }
 
 [[nodiscard]] auto constexpr is_reserved_char(unsigned char ch, bool os_specific) noexcept
 {
+    if (ch <= 31 || ch == '/')
+    {
+        return true;
+    }
+
     if (!os_specific)
     {
         return is_unix_reserved_char(ch) || is_win32_reserved_char(ch);

--- a/tests/libtransmission/torrent-files-test.cc
+++ b/tests/libtransmission/torrent-files-test.cc
@@ -187,7 +187,7 @@ TEST_F(TorrentFilesTest, isSubpathPortable)
 
         // reserved characters
         { "hell:o.txt", NotWin32 },
-        { "hell\to.txt", NotWin32 },
+        { "hell\to.txt", false },
 
         // everything else
         { ".foo", true },


### PR DESCRIPTION
#Fixes #8465

Currently, Transmission on Windows does not allow CTRL characters (0x01-0x1F) in path names.  Enforce this on Unix variants as well.

While technically these characters are legal UTF-8, and are sometimes allowed by underlying filesystems, they are frowned upon by security watchers.  Manipulating path strings with backspaces, whitespace, and overwrites can lead to mis-selected files and other hijinx at the application level.  

There is no plausible upside to maintaining current behavior and lots of security downside.

Further, this has the added benefit of further normalizing path names across systems, such that Windows RPC clients see consistent names on Transmission servers running on all platforms.

Further, these characters may be allowed at the OS-level by MacOS, they are not allowed at the application and Finder level .

Notes: Disallowed control-characters in file and path names on POSIX systems