### PR TITLE
fix: crash when removing a torrent that is being shown in the inspector

### DIFF
--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -332,6 +332,8 @@ static void removeKeRangerRansomware()
 @property(nonatomic) NSView* fPositioningView;
 @property(nonatomic) BOOL fSoundPlaying;
 
+- (void)removeTorrentsImpl:(NSArray<Torrent*>*)torrents deleteData:(BOOL)deleteData;
+
 @end
 
 @implementation Controller
@@ -1365,7 +1367,7 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
     }
     else
     {
-        [torrent closeRemoveTorrent:NO];
+        [self removeTorrentsImpl:@[ torrent ] deleteData:NO];
     }
 
     [self.fAddWindows removeObject:addController];
@@ -1459,7 +1461,7 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
     }
     else
     {
-        [torrent closeRemoveTorrent:NO];
+        [self removeTorrentsImpl:@[ torrent ] deleteData:NO];
     }
 
     [self.fAddWindows removeObject:addController];
@@ -1936,6 +1938,16 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
     [self confirmRemoveTorrents:torrents deleteData:deleteData];
 }
 
+- (void)removeTorrentsImpl:(NSArray<Torrent*>*)torrents deleteData:(BOOL)deleteData
+{
+    [self.fInfoController removeTorrentsFromInfo:torrents];
+
+    for (Torrent* torrent in torrents)
+    {
+        [torrent closeRemoveTorrent:deleteData];
+    }
+}
+
 - (void)confirmRemoveTorrents:(NSArray<Torrent*>*)torrents deleteData:(BOOL)deleteData
 {
     //miscellaneous
@@ -1993,10 +2005,7 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
 
                 //we can't closeRemoveTorrent: until it's no longer in the GUI at all
                 NSAnimationContext.currentContext.completionHandler = ^{
-                    for (Torrent* torrent in torrents)
-                    {
-                        [torrent closeRemoveTorrent:deleteData];
-                    }
+                    [self removeTorrentsImpl:torrents deleteData:deleteData];
 
                     [self fullUpdateUI];
                 };
@@ -2036,10 +2045,7 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
     if (!beganUpdate)
     {
         //do here if we're not doing it at the end of the animation
-        for (Torrent* torrent in torrents)
-        {
-            [torrent closeRemoveTorrent:deleteData];
-        }
+        [self removeTorrentsImpl:torrents deleteData:deleteData];
     }
 }
 

--- a/macosx/InfoWindowController.h
+++ b/macosx/InfoWindowController.h
@@ -12,6 +12,7 @@
 @property(nonatomic, readonly) BOOL canQuickLook;
 
 - (void)setInfoForTorrents:(NSArray<Torrent*>*)torrents;
+- (void)removeTorrentsFromInfo:(NSArray<Torrent*>*)torrents;
 - (void)updateInfoStats;
 - (void)updateOptions;
 

--- a/macosx/InfoWindowController.mm
+++ b/macosx/InfoWindowController.mm
@@ -208,6 +208,18 @@ typedef NS_ENUM(NSUInteger, TabTag) {
     [self resetInfo];
 }
 
+- (void)removeTorrentsFromInfo:(NSArray<Torrent*>*)torrents
+{
+    if (self.fTorrents.count == 0 || torrents.count == 0)
+    {
+        return;
+    }
+
+    NSMutableArray<Torrent*>* remaining = [self.fTorrents mutableCopy];
+    [remaining removeObjectsInArray:torrents];
+    [self setInfoForTorrents:remaining];
+}
+
 - (NSRect)windowWillUseStandardFrame:(NSWindow*)window defaultFrame:(NSRect)defaultFrame
 {
     NSRect windowRect = window.frame;


### PR DESCRIPTION
Possible fix for #8494.

CC @nevack as the primary stakeholder in this new code but TBH we're shipping 4.1.1 RSN so if any macOS @transmission/contributors can give review I'd appreciate it

The issue that Controller.mm tells InfoWindowController.mm to update while the latter still has a handle to a dangling Torrent pointer: `[Controller confirmRemoveTorrents]` --> `[Controller closeRemoveTorrent]` --> `[Controller fullUpdateUI]` --> `[Controller updateUI]` --> `[InfoWindowController updateInfoStats]`.

This PR fixes this by removing Torrents from the inspector right before calling `[Torrent closeRemoveTorrent]`.:

1. Adds a new method `[InfoController removeTorrentsFromInfo]` that removes torrents from the inspector
2. Adds a new private method `[Controller removeTorrentsImpl]` that calls the above + `[Torrent closeRemoveTorrent]`.
3. Updates `Controller` to use the new impl function any time it needs to remove a torrent

Notes: Fixed `4.1.0` crash when removing a torrent that was being show in the Inspector