### PR TITLE
perf: remove torrents group title field setup.

### DIFF
--- a/macosx/GroupCell.mm
+++ b/macosx/GroupCell.mm
@@ -6,4 +6,11 @@
 
 @implementation GroupCell
 
+- (void)setBackgroundStyle:(NSBackgroundStyle)backgroundStyle {
+    [super setBackgroundStyle:backgroundStyle];
+    
+    __auto_type isEmphasized = backgroundStyle == NSBackgroundStyleEmphasized;
+    self.fGroupTitleField.textColor = isEmphasized ? NSColor.labelColor : NSColor.secondaryLabelColor;
+}
+
 @end

--- a/macosx/GroupCell.mm
+++ b/macosx/GroupCell.mm
@@ -6,9 +6,10 @@
 
 @implementation GroupCell
 
-- (void)setBackgroundStyle:(NSBackgroundStyle)backgroundStyle {
+- (void)setBackgroundStyle:(NSBackgroundStyle)backgroundStyle
+{
     [super setBackgroundStyle:backgroundStyle];
-    
+
     __auto_type isEmphasized = backgroundStyle == NSBackgroundStyleEmphasized;
     self.fGroupTitleField.textColor = isEmphasized ? NSColor.labelColor : NSColor.secondaryLabelColor;
 }

--- a/macosx/TorrentTableView.mm
+++ b/macosx/TorrentTableView.mm
@@ -371,9 +371,7 @@ static NSTimeInterval const kToggleProgressSeconds = 0.175;
         NSString* groupName = groupIndex != -1 ? [GroupsController.groups nameForIndex:groupIndex] :
                                                  NSLocalizedString(@"No Group", "Group table row");
 
-        NSInteger row = [self rowForItem:item];
         groupCell.fGroupTitleField.stringValue = groupName;
-        groupCell.fGroupTitleField.textColor = NSColor.labelColor;
 
         groupCell.fGroupDownloadField.stringValue = [NSString stringForSpeed:group.downloadRate];
         groupCell.fGroupDownloadView.image = [NSImage imageNamed:@"DownArrowGroupTemplate"];

--- a/macosx/TorrentTableView.mm
+++ b/macosx/TorrentTableView.mm
@@ -372,21 +372,8 @@ static NSTimeInterval const kToggleProgressSeconds = 0.175;
                                                  NSLocalizedString(@"No Group", "Group table row");
 
         NSInteger row = [self rowForItem:item];
-        if ([self isRowSelected:row])
-        {
-            NSMutableAttributedString* string = [[NSMutableAttributedString alloc] initWithString:groupName];
-            NSDictionary* attributes = @{
-                NSFontAttributeName : [NSFont boldSystemFontOfSize:11.0],
-                NSForegroundColorAttributeName : [NSColor labelColor]
-            };
-
-            [string addAttributes:attributes range:NSMakeRange(0, string.length)];
-            groupCell.fGroupTitleField.attributedStringValue = string;
-        }
-        else
-        {
-            groupCell.fGroupTitleField.stringValue = groupName;
-        }
+        groupCell.fGroupTitleField.stringValue = groupName;
+        groupCell.fGroupTitleField.textColor = NSColor.labelColor;
 
         groupCell.fGroupDownloadField.stringValue = [NSString stringForSpeed:group.downloadRate];
         groupCell.fGroupDownloadView.image = [NSImage imageNamed:@"DownArrowGroupTemplate"];


### PR DESCRIPTION
Remove unnecessary setup of torrents group title field.
Attributed string is overkill in this case.

Notes: Improved UI code to use less CPU.