### PR TITLE
perf: reload only groups when toggle group row ratio.

### DIFF
--- a/macosx/TorrentTableView.mm
+++ b/macosx/TorrentTableView.mm
@@ -789,17 +789,20 @@ static NSTimeInterval const kToggleProgressSeconds = 0.175;
 {
     BOOL displayGroupRowRatio = [self.fDefaults boolForKey:@"DisplayGroupRowRatio"];
     [self.fDefaults setBool:!displayGroupRowRatio forKey:@"DisplayGroupRowRatio"];
-    if ([self.fDefaults boolForKey:@"SortByGroup"]) {
+    if ([self.fDefaults boolForKey:@"SortByGroup"])
+    {
         __auto_type count = [self.dataSource outlineView:self numberOfChildrenOfItem:nil];
         __auto_type indexSet = [[NSMutableIndexSet alloc] init];
-        for (NSInteger i = 0; i < count; ++i) {
-            __auto_type item = (NSObject *)[self.dataSource outlineView:self child:i ofItem:nil];
-            if ([item isKindOfClass:[TorrentGroup class]]) {
+        for (NSInteger i = 0; i < count; ++i)
+        {
+            __auto_type item = (NSObject*)[self.dataSource outlineView:self child:i ofItem:nil];
+            if ([item isKindOfClass:[TorrentGroup class]])
+            {
                 __auto_type row = [self rowForItem:item];
                 [indexSet addIndex:row];
             }
         }
-        
+
         [self reloadDataForRowIndexes:indexSet columnIndexes:[NSIndexSet indexSetWithIndex:0]];
     }
 }

--- a/macosx/TorrentTableView.mm
+++ b/macosx/TorrentTableView.mm
@@ -785,25 +785,54 @@ static NSTimeInterval const kToggleProgressSeconds = 0.175;
     }
 }
 
+- (void)updateGroupRatio:(BOOL)displayGroupRowRatio inCell:(GroupCell*)groupCell forGroup:(TorrentGroup*)group
+{
+    groupCell.fGroupDownloadField.hidden = displayGroupRowRatio;
+    groupCell.fGroupDownloadView.hidden = displayGroupRowRatio;
+
+    if (displayGroupRowRatio)
+    {
+        groupCell.fGroupUploadAndRatioView.image = [NSImage imageNamed:@"YingYangGroupTemplate"];
+        groupCell.fGroupUploadAndRatioView.image.accessibilityDescription = NSLocalizedString(@"Ratio", "Torrent -> status image");
+
+        groupCell.fGroupUploadAndRatioField.stringValue = [NSString stringForRatio:group.ratio];
+
+        NSString* tooltipRatio = NSLocalizedString(@"Ratio", "Torrent table -> group row -> tooltip");
+        groupCell.fGroupUploadAndRatioField.toolTip = tooltipRatio;
+        groupCell.fGroupUploadAndRatioView.toolTip = tooltipRatio;
+    }
+    else
+    {
+        groupCell.fGroupUploadAndRatioView.image = [NSImage imageNamed:@"UpArrowGroupTemplate"];
+        groupCell.fGroupUploadAndRatioView.image.accessibilityDescription = NSLocalizedString(@"UL", "Torrent -> status image");
+
+        groupCell.fGroupUploadAndRatioField.stringValue = [NSString stringForSpeed:group.uploadRate];
+
+        NSString* tooltipUpload = NSLocalizedString(@"Upload speed", "Torrent table -> group row -> tooltip");
+        groupCell.fGroupUploadAndRatioField.toolTip = tooltipUpload;
+        groupCell.fGroupUploadAndRatioView.toolTip = tooltipUpload;
+    }
+}
+
 - (void)toggleGroupRowRatio
 {
     BOOL displayGroupRowRatio = [self.fDefaults boolForKey:@"DisplayGroupRowRatio"];
-    [self.fDefaults setBool:!displayGroupRowRatio forKey:@"DisplayGroupRowRatio"];
+    BOOL updatedDisplayGroupRowRatio = !displayGroupRowRatio;
+    [self.fDefaults setBool:updatedDisplayGroupRowRatio forKey:@"DisplayGroupRowRatio"];
+
     if ([self.fDefaults boolForKey:@"SortByGroup"])
     {
         __auto_type count = [self.dataSource outlineView:self numberOfChildrenOfItem:nil];
-        __auto_type indexSet = [[NSMutableIndexSet alloc] init];
         for (NSInteger i = 0; i < count; ++i)
         {
             __auto_type item = (NSObject*)[self.dataSource outlineView:self child:i ofItem:nil];
             if ([item isKindOfClass:[TorrentGroup class]])
             {
                 __auto_type row = [self rowForItem:item];
-                [indexSet addIndex:row];
+                __auto_type groupCell = [self viewAtColumn:0 row:row makeIfNecessary:NO];
+                [self updateGroupRatio:updatedDisplayGroupRowRatio inCell:groupCell forGroup:(TorrentGroup*)item];
             }
         }
-
-        [self reloadDataForRowIndexes:indexSet columnIndexes:[NSIndexSet indexSetWithIndex:0]];
     }
 }
 

--- a/macosx/TorrentTableView.mm
+++ b/macosx/TorrentTableView.mm
@@ -789,7 +789,19 @@ static NSTimeInterval const kToggleProgressSeconds = 0.175;
 {
     BOOL displayGroupRowRatio = [self.fDefaults boolForKey:@"DisplayGroupRowRatio"];
     [self.fDefaults setBool:!displayGroupRowRatio forKey:@"DisplayGroupRowRatio"];
-    [self reloadVisibleRows];
+    if ([self.fDefaults boolForKey:@"SortByGroup"]) {
+        __auto_type count = [self.dataSource outlineView:self numberOfChildrenOfItem:nil];
+        __auto_type indexSet = [[NSMutableIndexSet alloc] init];
+        for (NSInteger i = 0; i < count; ++i) {
+            __auto_type item = (NSObject *)[self.dataSource outlineView:self child:i ofItem:nil];
+            if ([item isKindOfClass:[TorrentGroup class]]) {
+                __auto_type row = [self rowForItem:item];
+                [indexSet addIndex:row];
+            }
+        }
+        
+        [self reloadDataForRowIndexes:indexSet columnIndexes:[NSIndexSet indexSetWithIndex:0]];
+    }
 }
 
 - (IBAction)toggleControlForTorrent:(id)sender


### PR DESCRIPTION
Very clumsy functionality.

Group can be selected and expanded.
But also by clicking on one of its parts group will toggle appearance of this part.

I guess ratio can be always in group ( next to Download Speed ).