### PR TITLE
fix: cache `[Torrent hashString]`

### DIFF
--- a/macosx/Torrent.mm
+++ b/macosx/Torrent.mm
@@ -46,6 +46,7 @@ static dispatch_queue_t timeMachineExcludeQueue;
 @property(nonatomic) TorrentDeterminationType fDownloadFolderDetermination;
 
 @property(nonatomic) BOOL fResumeOnWake;
+@property(nonatomic, copy, readonly) NSString* hashString;
 
 - (void)renameFinished:(BOOL)success
                  nodes:(NSArray<FileListNode*>*)nodes
@@ -739,7 +740,7 @@ bool trashDataFile(char const* filename, void* /*user_data*/, tr_error* error)
 
 - (NSString*)hashString
 {
-    return @(tr_torrentView(self.fHandle).hash_string);
+    return _hashString;
 }
 
 - (BOOL)privateTorrent
@@ -1849,6 +1850,7 @@ bool trashDataFile(char const* filename, void* /*user_data*/, tr_error* error)
     }
 
     _fResumeOnWake = NO;
+    _hashString = @(tr_torrentView(self.fHandle).hash_string);
 
     //don't do after this point - it messes with auto-group functionality
     if (!self.magnet)


### PR DESCRIPTION
The macOS `Torrent` class now caches its `hashString` property:

1. Now it always returns the correct value, even after `tr_torrentRemove()` has been called. If any code path exists where a torrent's hash is queried _after_ `tr_torrentRemove()` is called but _before_ the Torrent is destroyed, we'll now get the correct hash value instead of dereferencing a nullptr.

2. Minor performance win: avoids the cost (and potential thread issues) of repeated calls to `tr_torrentView()`.

This PR is sort of related to #8241 but is more limited in scope & safer for a semver/patch release.

Notes: Improved performance of internal Torrent lookup code.