### PR TITLE
fix: warning in `tr-dht.cc`

### DIFF
--- a/libtransmission/tr-dht.cc
+++ b/libtransmission/tr-dht.cc
@@ -153,7 +153,7 @@ public:
         init_state(state_filename_);
 
         get_nodes_from_bootstrap_file(tr_pathbuf{ mediator_.config_dir(), "/dht.bootstrap"sv }, bootstrap_queue_);
-        for (auto const [host, port] : DefaultBootstraps)
+        for (auto const& [host, port] : DefaultBootstraps)
         {
             get_nodes_from_name(host, tr_port::from_host(port), bootstrap_queue_);
         }


### PR DESCRIPTION
```
  /home/runner/work/transmission/transmission/src/libtransmission/tr-dht.cc:156:25: warning: loop variable '[host, port]' creates a copy from type 'const value_type' (aka 'const std::pair<const char *, unsigned short>') [-Wrange-loop-construct]
    156 |         for (auto const [host, port] : DefaultBootstraps)
        |                         ^
  /home/runner/work/transmission/transmission/src/libtransmission/tr-dht.cc:156:14: note: use reference type 'const value_type &' (aka 'const std::pair<const char *, unsigned short> &') to prevent copying
    156 |         for (auto const [host, port] : DefaultBootstraps)
        |              ^~~~~~~~~~~~~~~~~~~~~~~~~
        |                         &
  1 warning generated.
```