### PR TITLE
ci: don't build web on BSD

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1228,7 +1228,6 @@ jobs:
               libpsl \
               miniupnpc \
               ninja \
-              `[ '${{ needs.what-to-make.outputs.make-web }}' = 'true' ] && echo npm` \
               pkgconf \
               `[ '${{ needs.what-to-make.outputs.make-qt }}' = 'true' ] && echo qt6-svg qt6-tools` \
               rapidjson \
@@ -1249,7 +1248,7 @@ jobs:
               -DENABLE_QT=${{ (needs.what-to-make.outputs.make-qt == 'true') && 'ON' || 'OFF' }} \
               -DENABLE_TESTS=${{ (needs.what-to-make.outputs.make-tests == 'true') && 'ON' || 'OFF' }} \
               -DENABLE_UTILS=${{ (needs.what-to-make.outputs.make-utils == 'true') && 'ON' || 'OFF' }} \
-              -DREBUILD_WEB=${{ (needs.what-to-make.outputs.make-web == 'true') && 'ON' || 'OFF' }} \
+              -DREBUILD_WEB=OFF \
               -DENABLE_DEPRECATED=ON \
               -DENABLE_WERROR=ON \
               -DRUN_CLANG_TIDY=OFF \
@@ -1326,7 +1325,6 @@ jobs:
               libpsl \
               miniupnpc \
               ninja \
-              `[ '${{ needs.what-to-make.outputs.make-web }}' = 'true' ] && echo node` \
               `[ '${{ needs.what-to-make.outputs.make-qt }}' = 'true' ] && echo qt6-qtsvg qt6-qttools` \
               rapidjson \
               utfcpp
@@ -1345,7 +1343,7 @@ jobs:
               -DENABLE_QT=${{ (needs.what-to-make.outputs.make-qt == 'true') && 'ON' || 'OFF' }} \
               -DENABLE_TESTS=${{ (needs.what-to-make.outputs.make-tests == 'true') && 'ON' || 'OFF' }} \
               -DENABLE_UTILS=${{ (needs.what-to-make.outputs.make-utils == 'true') && 'ON' || 'OFF' }} \
-              -DREBUILD_WEB=${{ (needs.what-to-make.outputs.make-web == 'true') && 'ON' || 'OFF' }} \
+              -DREBUILD_WEB=OFF \
               -DENABLE_DEPRECATED=ON \
               -DENABLE_WERROR=ON \
               -DRUN_CLANG_TIDY=OFF \
@@ -1425,7 +1423,6 @@ jobs:
               libpsl \
               miniupnpc \
               ninja-build \
-              `[ '${{ needs.what-to-make.outputs.make-web }}' = 'true' ] && echo nodejs` \
               pkgconf \
               `[ '${{ needs.what-to-make.outputs.make-qt }}' = 'true' ] && echo qt6-qtsvg qt6-qttools` \
               rapidjson \
@@ -1452,7 +1449,7 @@ jobs:
               -DENABLE_QT=${{ (needs.what-to-make.outputs.make-qt == 'true') && 'ON' || 'OFF' }} \
               -DENABLE_TESTS=${{ (needs.what-to-make.outputs.make-tests == 'true') && 'ON' || 'OFF' }} \
               -DENABLE_UTILS=${{ (needs.what-to-make.outputs.make-utils == 'true') && 'ON' || 'OFF' }} \
-              -DREBUILD_WEB=${{ (needs.what-to-make.outputs.make-web == 'true') && 'ON' || 'OFF' }} \
+              -DREBUILD_WEB=OFF \
               -DENABLE_DEPRECATED=ON \
               -DENABLE_WERROR=ON \
               -DRUN_CLANG_TIDY=OFF \
@@ -1551,7 +1548,7 @@ jobs:
               -DENABLE_QT=${{ (needs.what-to-make.outputs.make-qt == 'true') && 'ON' || 'OFF' }} \
               -DENABLE_TESTS=${{ (needs.what-to-make.outputs.make-tests == 'true') && 'ON' || 'OFF' }} \
               -DENABLE_UTILS=${{ (needs.what-to-make.outputs.make-utils == 'true') && 'ON' || 'OFF' }} \
-              -DREBUILD_WEB=OFF `# Installing esbuild via npm is not supported on DragonFlyBSD, the full list of supported platforms can be found at https://esbuild.github.io/getting-started/#download-a-build` \
+              -DREBUILD_WEB=OFF \
               -DENABLE_DEPRECATED=ON \
               -DENABLE_WERROR=ON \
               -DRUN_CLANG_TIDY=OFF \


### PR DESCRIPTION
esbuild is flaky on BSD, especially on arm64.

Example:

```
/home/runner/work/transmission/transmission/src/web/src src && /usr/pkg/bin/npm ci --no-audit --no-fund --no-progress && /usr/pkg/bin/npm run build
  npm warn deprecated lodash.get@4.4.2: This package is deprecated. Use the optional chaining (?.) operator instead.
  npm error code 1
  npm error path /home/runner/work/transmission/transmission/obj/web/node_modules/esbuild
  npm error command failed
  npm error command sh -c node install.js
  npm error node:internal/errors:998
  npm error   const err = new Error(message);
  npm error               ^
  npm error
  npm error Error: Command failed: /home/runner/work/transmission/transmission/obj/web/node_modules/esbuild/bin/esbuild --version
  npm error SIGILL: illegal instruction
  npm error PC=0x1ec700 m=0 sigcode=4
  npm error instruction bytes: 0x80 0x4 0x38 0xd5 0xe0 0x7 0x0 0xf9 0xc0 0x3 0x5f 0xd6 0x0 0x0 0x0 0x0
  npm error
  npm error goroutine 1 gp=0x40000021c0 m=0 mp=0x942480 [running, locked to thread]:
  npm error vendor/golang.org/x/sys/cpu.getzfr0()
  npm error 	vendor/golang.org/x/sys/cpu/cpu_arm64.s:37 fp=0x4000084db0 sp=0x4000084db0 pc=0x1ec700
  npm error vendor/golang.org/x/sys/cpu.parseARM64SystemRegisters(0x58ddd6?, 0x2?, 0x6633c8?)
  npm error 	vendor/golang.org/x/sys/cpu/cpu_arm64.go:169 +0x228 fp=0x4000084dd0 sp=0x4000084db0 pc=0x1ebe18
  npm error vendor/golang.org/x/sys/cpu.doinit()
  npm error 	vendor/golang.org/x/sys/cpu/cpu_netbsd_arm64.go:170 +0x5c fp=0x4000084e00 sp=0x4000084dd0 pc=0x1ec67c
  npm error vendor/golang.org/x/sys/cpu.archInit(...)
  npm error 	vendor/golang.org/x/sys/cpu/cpu_arm64.go:49
  npm error vendor/golang.org/x/sys/cpu.init.0()
  npm error 	vendor/golang.org/x/sys/cpu/cpu.go:203 +0x20 fp=0x4000084e10 sp=0x4000084e00 pc=0x1eb390
  npm error runtime.doInit1(0x8f18d0)
  npm error 	runtime/proc.go:7348 +0xd4 fp=0x4000084f40 sp=0x4000084e10 pc=0x571f4
  npm error runtime.doInit(...)
  npm error 	runtime/proc.go:7315
  npm error runtime.main()
  npm error 	runtime/proc.go:254 +0x344 fp=0x4000084fd0 sp=0x4000084f40 pc=0x477b4
  npm error runtime.goexit({})
  npm error 	runtime/asm_arm64.s:1223 +0x4 fp=0x4000084fd0 sp=0x4000084fd0 pc=0x84dd4
  npm error
  npm error goroutine 2 gp=0x4000002700 m=nil [force gc (idle)]:
  npm error runtime.gopark(0x0?, 0x0?, 0x0?, 0x0?, 0x0?)
  npm error 	runtime/proc.go:424 +0xc8 fp=0x4000054f90 sp=0x4000054f70 pc=0x7d068
  npm error runtime.goparkunlock(...)
  npm error 	runtime/proc.go:430
  npm error runtime.forcegchelper()
  npm error 	runtime/proc.go:337 +0xb8 fp=0x4000054fd0 sp=0x4000054f90 pc=0x47a58
  npm error runtime.goexit({})
  npm error 	runtime/asm_arm64.s:1223 +0x4 fp=0x4000054fd0 sp=0x4000054fd0 pc=0x84dd4
  npm error created by runtime.init.7 in goroutine 1
  npm error 	runtime/proc.go:325 +0x24
  npm error
  npm error goroutine 3 gp=0x4000002c40 m=nil [GC sweep wait]:
  npm error runtime.gopark(0x0?, 0x0?, 0x0?, 0x0?, 0x0?)
  npm error 	runtime/proc.go:424 +0xc8 fp=0x4000055760 sp=0x4000055740 pc=0x7d068
  npm error runtime.goparkunlock(...)
  npm error 	runtime/proc.go:430
  npm error runtime.bgsweep(0x4000028100)
  npm error 	runtime/mgcsweep.go:277 +0xa0 fp=0x40000557b0 sp=0x4000055760 pc=0x318e0
  npm error runtime.gcenable.gowrap1()
  npm error 	runtime/mgc.go:204 +0x28 fp=0x40000557d0 sp=0x40000557b0 pc=0x25928
  npm error runtime.goexit({})
  npm error 	runtime/asm_arm64.s:1223 +0x4 fp=0x40000557d0 sp=0x40000557d0 pc=0x84dd4
  npm error created by runtime.gcenable in goroutine 1
  npm error 	runtime/mgc.go:204 +0x6c
  npm error
  npm error goroutine 4 gp=0x4000002e00 m=nil [GC scavenge wait]:
  npm error runtime.gopark(0x4000028100?, 0x6631a0?, 0x1?, 0x0?, 0x4000002e00?)
  npm error 	runtime/proc.go:424 +0xc8 fp=0x4000055f60 sp=0x4000055f40 pc=0x7d068
  npm error runtime.goparkunlock(...)
  npm error 	runtime/proc.go:430
  npm error runtime.(*scavengerState).park(0x941960)
  npm error 	runtime/mgcscavenge.go:425 +0x5c fp=0x4000055f90 sp=0x4000055f60 pc=0x2f30c
  npm error runtime.bgscavenge(0x4000028100)
  npm error 	runtime/mgcscavenge.go:653 +0x44 fp=0x4000055fb0 sp=0x4000055f90 pc=0x2f834
  npm error runtime.gcenable.gowrap2()
  npm error 	runtime/mgc.go:205 +0x28 fp=0x4000055fd0 sp=0x4000055fb0 pc=0x258c8
  npm error runtime.goexit({})
  npm error 	runtime/asm_arm64.s:1223 +0x4 fp=0x4000055fd0 sp=0x4000055fd0 pc=0x84dd4
  npm error created by runtime.gcenable in goroutine 1
  npm error 	runtime/mgc.go:205 +0xac
  npm error
  npm error goroutine 5 gp=0x4000003340 m=nil [finalizer wait]:
  npm error runtime.gopark(0x40000545b8?, 0x191e0c?, 0xa0?, 0x0?, 0x557980?)
  npm error 	runtime/proc.go:424 +0xc8 fp=0x4000054580 sp=0x4000054560 pc=0x7d068
  npm error runtime.runfinq()
  npm error 	runtime/mfinal.go:193 +0x108 fp=0x40000547d0 sp=0x4000054580 pc=0x24a28
  npm error runtime.goexit({})
  npm error 	runtime/asm_arm64.s:1223 +0x4 fp=0x40000547d0 sp=0x40000547d0 pc=0x84dd4
  npm error created by runtime.createfing in goroutine 1
  npm error 	runtime/mfinal.go:163 +0x80
  npm error
  npm error goroutine 6 gp=0x40000ca8c0 m=nil [chan receive]:
  npm error runtime.gopark(0x0?, 0x0?, 0x0?, 0x0?, 0x0?)
  npm error 	runtime/proc.go:424 +0xc8 fp=0x40000566f0 sp=0x40000566d0 pc=0x7d068
  npm error runtime.chanrecv(0x400002e380, 0x0, 0x1)
  npm error 	runtime/chan.go:639 +0x414 fp=0x4000056770 sp=0x40000566f0 pc=0x159a4
  npm error runtime.chanrecv1(0x0?, 0x0?)
  npm error 	runtime/chan.go:489 +0x14 fp=0x40000567a0 sp=0x4000056770 pc=0x15554
  npm error runtime.unique_runtime_registerUniqueMapCleanup.func1(...)
  npm error 	runtime/mgc.go:1782
  npm error runtime.unique_runtime_registerUniqueMapCleanup.gowrap1()
  npm error 	runtime/mgc.go:1785 +0x3c fp=0x40000567d0 sp=0x40000567a0 pc=0x288bc
  npm error runtime.goexit({})
  npm error 	runtime/asm_arm64.s:1223 +0x4 fp=0x40000567d0 sp=0x40000567d0 pc=0x84dd4
  npm error created by unique.runtime_registerUniqueMapCleanup in goroutine 1
  npm error 	runtime/mgc.go:1780 +0xa0
  npm error
  npm error r0      0x1
  npm error r1      0x11111101211052
  npm error r2      0x1201001121110022
  npm error r3      0x1
  npm error r4      0x1
  npm error r5      0x4000002258
  npm error r6      0x1
  npm error r7      0x88
  npm error r8      0xfffffbeca188
  npm error r9      0x90
  npm error r10     0x40000ae090
  npm error r11     0x0
  npm error r12     0x0
  npm error r13     0x90
  npm error r14     0x1
  npm error r15     0x2
  npm error r16     0x40000843a0
  npm error r17     0xca
  npm error r18     0x0
  npm error r19     0x8d6dd8b5d3e2f3f4
  npm error r20     0x4000034180
  npm error r21     0x4000084cac
  npm error r22     0x13
  npm error r23     0x3cb9d69707
  npm error r24     0x8e41dc0be9fcd734
  npm error r25     0xbe71521dac
  npm error r26     0xffff0001bed80c30
  npm error r27     0x969000
  npm error r28     0x40000021c0
  npm error r29     0x4000084da8
  npm error lr      0x1ebe18
  npm error sp      0x4000084db0
  npm error pc      0x1ec700
  npm error fault   0x1ec700
  npm error
  npm error     at genericNodeError (node:internal/errors:998:15)
  npm error     at wrappedFn (node:internal/errors:543:14)
  npm error     at checkExecSyncError (node:child_process:925:11)
  npm error     at Object.execFileSync (node:child_process:961:15)
  npm error     at validateBinaryVersion (/home/runner/work/transmission/transmission/obj/web/node_modules/esbuild/install.js:102:28)
  npm error     at /home/runner/work/transmission/transmission/obj/web/node_modules/esbuild/install.js:287:5 {
  npm error   status: 2,
  npm error   signal: null,
  npm error   output: [
  npm error     null,
  npm error     Buffer(0) [Uint8Array] [],
  npm error     Buffer(4795) [Uint8Array] [
  npm error        83,  73,  71,  73,  76,  76,  58,  32, 105, 108, 108, 101,
  npm error       103,  97, 108,  32, 105, 110, 115, 116, 114, 117,  99, 116,
  npm error       105, 111, 110,  10,  80,  67,  61,  48, 120,  49, 101,  99,
  npm error        55,  48,  48,  32, 109,  61,  48,  32, 115, 105, 103,  99,
  npm error       111, 100, 101,  61,  52,  10, 105, 110, 115, 116, 114, 117,
  npm error        99, 116, 105, 111, 110,  32,  98, 121, 116, 101, 115,  58,
  npm error        32,  48, 120,  56,  48,  32,  48, 120,  52,  32,  48, 120,
  npm error        51,  56,  32,  48, 120, 100,  53,  32,  48, 120, 101,  48,
  npm error        32,  48, 120,  55,
  npm error       ... 4695 more items
  npm error     ]
  npm error   ],
  npm error   pid: 14169,
  npm error   stdout: Buffer(0) [Uint8Array] [],
  npm error   stderr: Buffer(4795) [Uint8Array] [
  npm error      83,  73,  71,  73,  76,  76,  58,  32, 105, 108, 108, 101,
  npm error     103,  97, 108,  32, 105, 110, 115, 116, 114, 117,  99, 116,
  npm error     105, 111, 110,  10,  80,  67,  61,  48, 120,  49, 101,  99,
  npm error      55,  48,  48,  32, 109,  61,  48,  32, 115, 105, 103,  99,
  npm error     111, 100, 101,  61,  52,  10, 105, 110, 115, 116, 114, 117,
  npm error      99, 116, 105, 111, 110,  32,  98, 121, 116, 101, 115,  58,
  npm error      32,  48, 120,  56,  48,  32,  48, 120,  52,  32,  48, 120,
  npm error      51,  56,  32,  48, 120, 100,  53,  32,  48, 120, 101,  48,
  npm error      32,  48, 120,  55,
  npm error     ... 4695 more items
  npm error   ]
  npm error }
  npm error
  npm error Node.js v25.2.1
  npm error A complete log of this run can be found in: /root/.npm/_logs/2026-02-15T23_00_21_349Z-debug-0.log
```