### PR TITLE
ci: run big-endian tests in GitHub Actions

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -244,39 +244,59 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: recursive
-      - name: Set up QEMU (s390x)
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: s390x
-      - name: Configure, Build, and Test (big-endian emulation)
+      - name: Get VM Dependencies
         run: |
-          docker run --rm --platform linux/s390x \
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            cloud-image-utils \
+            openssh-client \
+            qemu-system-misc \
+            qemu-utils
+      - name: Cross-compile for s390x
+        run: |
+          docker run --rm \
             -v "$PWD":/src \
             -w /src \
             debian:stable-slim \
             bash -lc '
               set -eux
               export DEBIAN_FRONTEND=noninteractive
+              dpkg --add-architecture s390x
               apt-get update
               apt-get install -y --no-install-recommends \
                 ca-certificates \
                 cmake \
-                g++ \
+                crossbuild-essential-s390x \
                 gettext \
-                libcurl4-openssl-dev \
-                libdeflate-dev \
-                libevent-dev \
-                libssl-dev \
+                libcurl4-openssl-dev:s390x \
+                libssl-dev:s390x \
                 ninja-build \
+                pkg-config \
                 python3 \
-                pkg-config
-              test "$(dpkg --print-architecture)" = "s390x"
-              python3 -c "import sys; assert sys.byteorder == \"big\""
+                qemu-user-static
+              printf "\n" | s390x-linux-gnu-gcc -dM -E - | grep -q "^#define __s390x__ 1$"
+              printf "%s\n" \
+                "#include <stdio.h>" \
+                "int main(void) {" \
+                "  unsigned int x = 1;" \
+                "  return *((unsigned char*)&x) == 0 ? 0 : 1;" \
+                "}" >/tmp/endian-check.c
+              s390x-linux-gnu-gcc /tmp/endian-check.c -o /tmp/endian-check
+              qemu-s390x-static -L /usr/s390x-linux-gnu /tmp/endian-check
+
+              export PKG_CONFIG_LIBDIR=/usr/lib/s390x-linux-gnu/pkgconfig:/usr/share/pkgconfig
+              export PKG_CONFIG_PATH=
+
               cmake \
                 -S . \
                 -B obj \
                 -G Ninja \
                 -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+                -DCMAKE_SYSTEM_NAME=Linux \
+                -DCMAKE_SYSTEM_PROCESSOR=s390x \
+                -DCMAKE_C_COMPILER=s390x-linux-gnu-gcc \
+                -DCMAKE_CXX_COMPILER=s390x-linux-gnu-g++ \
+                -DCMAKE_CROSSCOMPILING_EMULATOR="/usr/bin/qemu-s390x-static;-L;/usr/s390x-linux-gnu" \
                 -DCMAKE_INSTALL_PREFIX=pfx \
                 -DENABLE_CLI=OFF \
                 -DENABLE_DAEMON=OFF \
@@ -292,8 +312,93 @@ jobs:
                 -DHAVE_SENDFILE64:BOOL=OFF \
                 -DUSE_SYSTEM_DEFAULT=OFF
               cmake --build obj --config RelWithDebInfo --target all-tests
-              cmake -E chdir obj ctest -j 2 --build-config RelWithDebInfo --output-on-failure
             '
+      - name: Cache s390x cloud image
+        id: s390x-image-cache
+        uses: actions/cache@v4
+        with:
+          path: /tmp/debian-s390x.qcow2
+          key: debian-12-genericcloud-s390x-qcow2-v1
+      - name: Download and verify s390x cloud image
+        if: steps.s390x-image-cache.outputs.cache-hit != 'true'
+        run: |
+          set -eux
+          image_name='debian-12-genericcloud-s390x.qcow2'
+          image_url_base='https://cloud.debian.org/images/cloud/bookworm/latest'
+          curl -fL --retry 5 --retry-delay 3 -o "/tmp/${image_name}" "${image_url_base}/${image_name}"
+          curl -fL --retry 5 --retry-delay 3 -o /tmp/SHA512SUMS "${image_url_base}/SHA512SUMS"
+          (cd /tmp && grep " ${image_name}$" SHA512SUMS | sha512sum -c -)
+      - name: Run tests in qemu-system-s390x guest
+        run: |
+          set -eux
+
+          # Build generated gtest files contain a cross-emulator wrapper.
+          # Remove it so tests run natively inside the s390x guest.
+          find obj/tests -type f -name '*_tests.cmake' -print0 | xargs -0 perl -i -pe \
+            's/\[=*\[\/usr\/bin\/qemu-s390x-static\]=*\]\s+\[=*\[-L\]=*\]\s+\[=*\[\/usr\/s390x-linux-gnu\]=*\]\s+//g'
+
+          tar --exclude=.git -czf /tmp/transmission-src.tgz .
+
+          ssh-keygen -q -t ed25519 -N '' -f /tmp/s390x_ci_key
+          cat > /tmp/user-data <<EOF
+#cloud-config
+users:
+  - name: ci
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    shell: /bin/bash
+    ssh_authorized_keys:
+      - $(cat /tmp/s390x_ci_key.pub)
+ssh_pwauth: false
+EOF
+          cat > /tmp/meta-data <<EOF
+instance-id: transmission-big-endian
+local-hostname: transmission-s390x
+EOF
+          cloud-localds /tmp/seed.iso /tmp/user-data /tmp/meta-data
+
+          qemu-system-s390x \
+            -machine s390-ccw-virtio \
+            -cpu max \
+            -m 4096 \
+            -smp 2 \
+            -nographic \
+            -drive if=virtio,format=qcow2,file=/tmp/debian-s390x.qcow2 \
+            -drive if=virtio,format=raw,file=/tmp/seed.iso \
+            -netdev user,id=vmnic,hostfwd=tcp::2222-:22 \
+            -device virtio-net-ccw,netdev=vmnic \
+            -device virtio-rng-ccw \
+            > /tmp/qemu-s390x.log 2>&1 &
+          qemu_pid=$!
+          trap 'kill ${qemu_pid} || true' EXIT
+
+          for _ in $(seq 1 180); do
+            if ssh -o BatchMode=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i /tmp/s390x_ci_key -p 2222 ci@127.0.0.1 true; then
+              break
+            fi
+            sleep 5
+          done
+
+          scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i /tmp/s390x_ci_key -P 2222 \
+            /tmp/transmission-src.tgz ci@127.0.0.1:/tmp/transmission-src.tgz
+
+          ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i /tmp/s390x_ci_key -p 2222 ci@127.0.0.1 '
+            set -eux
+            sudo apt-get update
+            sudo apt-get install -y --no-install-recommends \
+              ca-certificates \
+              cmake \
+              gettext \
+              libcurl4-openssl-dev \
+              libssl-dev
+            sudo mkdir -p /src
+            sudo tar -xzf /tmp/transmission-src.tgz -C /src
+            sudo chown -R ci:ci /src
+            cd /src/obj
+            ctest -j 2 --build-config RelWithDebInfo --output-on-failure
+          '
+
+          kill ${qemu_pid} || true
+          wait ${qemu_pid} || true
 
   clang-tidy-libtransmission:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Related to https://github.com/transmission/transmission/issues/8493.

s390x is the remaining target on build.transmissionbt.com's sanity tests, and we use it in order to run our tests on a big-endian system. This PR uses QEMU to do this, same as build.transmissionbt.com does.