### PR TITLE
UTF8-clean torrent 'path' (#8328)

### DIFF
--- a/libtransmission/torrent-metainfo.cc
+++ b/libtransmission/torrent-metainfo.cc
@@ -93,6 +93,7 @@ struct MetainfoHandler final : public transmission::benc::BasicHandler<MaxBencDe
 
     bool StartDict(Context const& context) override
     {
+        // TODO Bittorrent v2. For now just parse and throw away.
         if (state_ == State::FileTree)
         {
             auto const path_element = currentKey();
@@ -105,7 +106,7 @@ struct MetainfoHandler final : public transmission::benc::BasicHandler<MaxBencDe
             {
                 file_subpath_ += '/';
             }
-            tr_torrent_files::sanitize_subpath(*path_element, file_subpath_);
+            tr_torrent_files::sanitize_subpath(tr_strv_convert_utf8(*path_element), file_subpath_);
         }
         else if (pathIs(InfoKey))
         {
@@ -304,7 +305,8 @@ struct MetainfoHandler final : public transmission::benc::BasicHandler<MaxBencDe
                 {
                     file_subpath_ += '/';
                 }
-                tr_torrent_files::sanitize_subpath(value, file_subpath_);
+                // BEP-3 says strings are UTF-8, so mask non-conformant path strings
+                tr_torrent_files::sanitize_subpath(tr_strv_convert_utf8(value), file_subpath_);
             }
             else if (current_key == AttrKey)
             {

--- a/tests/libtransmission/assets/bad-utf8-path.torrent
+++ b/tests/libtransmission/assets/bad-utf8-path.torrent
@@ -1,0 +1,1 @@
+d10:created by31:Transmission/4.1.0 (cb18ca04e2)13:creation datei1770235224e8:encoding5:UTF-84:infod5:filesld6:lengthi12e4:pathl19:Ï€file.ğŸ˜€ğŸ˜€ğŸ˜€eed6:lengthi12e4:pathl9:file€.fooeee4:name13:bad-utf8-path12:piece lengthi16384e6:pieces20:N×ŸÜ¨!fF{ó¯|vÃÔİ£ee

--- a/tests/libtransmission/torrent-metainfo-test.cc
+++ b/tests/libtransmission/torrent-metainfo-test.cc
@@ -216,4 +216,32 @@ TEST_F(TorrentMetainfoTest, parseBencPiecesSize)
     EXPECT_EQ(error.message(), "invalid 'pieces' size: 119"sv);
 }
 
+TEST_F(TorrentMetainfoTest, pathKeyTest)
+{
+    static auto constexpr BadTorrents = std::array{ "dup-files.torrent"sv };
+
+    for (auto const& name : BadTorrents)
+    {
+        auto tm = tr_torrent_metainfo{};
+        auto const path = tr_pathbuf{ LIBTRANSMISSION_TEST_ASSETS_DIR, '/', name };
+        EXPECT_FALSE(tm.parse_torrent_file(path));
+    }
+}
+
+TEST_F(TorrentMetainfoTest, utf8Test)
+{
+// MacOS implementation uses non-deterministic conversion for illegal UTF-8
+#if (defined(__APPLE__) && defined(__clang__))
+    GTEST_SKIP();
+#endif
+    auto const src_filename = tr_pathbuf{ LIBTRANSMISSION_TEST_ASSETS_DIR "/bad-utf8-path.torrent"sv };
+    auto tm = tr_torrent_metainfo{};
+    EXPECT_TRUE(tm.parse_torrent_file(src_filename));
+
+    // good name: bad-utf8-path/πfile.😀😀😀
+    EXPECT_EQ("bad-utf8-path/\u03C0file.\U0001F600\U0001F600\U0001F600", tm.file_subpath(0));
+    // bad name, gets masked to: bad-utf8-path/file�.foo
+    EXPECT_EQ("bad-utf8-path/file\uFFFD.foo", tm.file_subpath(1));
+}
+
 } // namespace libtransmission::test


### PR DESCRIPTION
cherry-pick #8328 

Notes: Fixed 'Illegal byte sequence' error that could occur when a torrent's list of files contained invalid UTF-8. UTF-8 is required by the [BitTorrent spec](https://www.bittorrent.org/beps/bep_0003.html). Transmission now coerces filenames into that format.