### PR TITLE
ci: run fewer redundant jobs

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1026,8 +1026,6 @@ jobs:
     needs: [ make-source-tarball, what-to-make ]
     if: ${{ needs.what-to-make.outputs.make-core == 'true' }}
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
     steps:
       - name: Show Configuration
         run: |


### PR DESCRIPTION
We are getting _hammered_ by running a zillion CI jobs -- PRs take forever to make it through the CI pipeline. This PR tries to remove or kill redundant jobs.

- move crypto tests into their own matrix -- we only need to test each crypto lib once
    - only build libs + tests in crypto jobs -- the apps don't have any crypto-specific code
- replace the utp_enable/disabled matrix with just 'utp_disabled'. We already test it enabled everywhere else.
    - only build libs + tests in the utp_disabled job -- the apps don't have any utp-specific code
- cancel currently-running CI runs when at new commit is pushed up to trigger a new CI run

Also included is a side cleanup to avoid hardcoding some distro version numbers:

- replace fedora version numbers with `fedora-latest` + `fedora-rawhide`
- replace debian-11 with `debian:oldoldstable` which roughly means "oldest supported stable"
- use the default versions of dragonflybsd, freebsd, netbsd, openbsd from the [vmactions config](https://github.com/vmactions)


