### PR TITLE
Extract group cell from xib.

### DIFF
--- a/macosx/GroupCell.mm
+++ b/macosx/GroupCell.mm
@@ -6,6 +6,106 @@
 
 @implementation GroupCell
 
+- (instancetype)initWithFrame:(NSRect)frameRect
+{
+    if (self = [super initWithFrame:frameRect])
+    {
+        [self configureViews];
+        [self setupConstraints];
+    }
+
+    return self;
+}
+
+- (void)configureViews
+{
+    __auto_type indicatorView = [[NSImageView alloc] init];
+    indicatorView.imageScaling = NSImageScaleProportionallyDown;
+    self.fGroupIndicatorView = indicatorView;
+
+    __auto_type titleField = [[NSTextField alloc] init];
+    titleField.textColor = NSColor.secondaryLabelColor;
+    titleField.backgroundColor = NSColor.controlColor;
+    titleField.lineBreakMode = NSLineBreakByTruncatingMiddle;
+    self.fGroupTitleField = titleField;
+
+    __auto_type downloadView = [[NSImageView alloc] init];
+    downloadView.imageScaling = NSImageScaleProportionallyDown;
+    self.fGroupDownloadView = downloadView;
+
+    __auto_type downloadField = [[NSTextField alloc] init];
+    downloadField.textColor = NSColor.secondaryLabelColor;
+    downloadField.backgroundColor = NSColor.textBackgroundColor;
+    downloadField.lineBreakMode = NSLineBreakByClipping;
+    self.fGroupDownloadField = downloadField;
+
+    __auto_type uploadAndRatioView = [[NSImageView alloc] init];
+    uploadAndRatioView.imageScaling = NSImageScaleProportionallyDown;
+    self.fGroupUploadAndRatioView = uploadAndRatioView;
+
+    __auto_type uploadAndRatioField = [[NSTextField alloc] init];
+    uploadAndRatioField.textColor = NSColor.secondaryLabelColor;
+    uploadAndRatioField.backgroundColor = NSColor.textBackgroundColor;
+    uploadAndRatioField.lineBreakMode = NSLineBreakByClipping;
+    self.fGroupUploadAndRatioField = uploadAndRatioField;
+
+    for (NSTextField* view in @[ titleField, downloadField, uploadAndRatioField ])
+    {
+        view.editable = NO;
+        view.selectable = NO;
+        view.bordered = NO;
+        view.font = [NSFont systemFontOfSize:11.0 weight:NSFontWeightBold];
+        view.drawsBackground = NO;
+    }
+
+    for (NSView* view in @[ indicatorView, titleField, downloadView, downloadField, uploadAndRatioView, uploadAndRatioField ])
+    {
+        view.translatesAutoresizingMaskIntoConstraints = false;
+        [self addSubview:view];
+    }
+}
+
+- (void)setupConstraints
+{
+    [NSLayoutConstraint activateConstraints:@[
+        // IndicatorView
+        [self.fGroupIndicatorView.leadingAnchor constraintEqualToAnchor:self.leadingAnchor constant:11],
+        [self.fGroupIndicatorView.centerYAnchor constraintEqualToAnchor:self.centerYAnchor],
+        [self.fGroupIndicatorView.widthAnchor constraintEqualToConstant:14],
+        [self.fGroupIndicatorView.heightAnchor constraintEqualToConstant:14],
+
+        // TitleField
+        [self.fGroupTitleField.leadingAnchor constraintEqualToAnchor:self.fGroupIndicatorView.trailingAnchor constant:5],
+        [self.fGroupTitleField.centerYAnchor constraintEqualToAnchor:self.centerYAnchor],
+
+        // DownloadView
+        [self.fGroupTitleField.trailingAnchor constraintEqualToAnchor:self.fGroupDownloadView.leadingAnchor],
+        [self.fGroupDownloadView.centerYAnchor constraintEqualToAnchor:self.centerYAnchor],
+        [self.fGroupDownloadView.widthAnchor constraintEqualToConstant:16],
+        [self.fGroupDownloadView.heightAnchor constraintEqualToConstant:16],
+
+        // DownloadField
+        [self.fGroupDownloadView.trailingAnchor constraintEqualToAnchor:self.fGroupDownloadField.leadingAnchor],
+        [self.fGroupDownloadField.centerYAnchor constraintEqualToAnchor:self.centerYAnchor],
+        [self.fGroupDownloadField.widthAnchor constraintGreaterThanOrEqualToConstant:60],
+
+        // UploadAndRatioView
+        [self.fGroupDownloadField.trailingAnchor constraintEqualToAnchor:self.fGroupUploadAndRatioView.leadingAnchor],
+        [self.fGroupUploadAndRatioView.centerYAnchor constraintEqualToAnchor:self.centerYAnchor],
+        [self.fGroupUploadAndRatioView.widthAnchor constraintEqualToConstant:16],
+        [self.fGroupUploadAndRatioView.heightAnchor constraintEqualToConstant:16],
+
+        // UploadAndRatioField
+        [self.fGroupUploadAndRatioView.trailingAnchor constraintEqualToAnchor:self.fGroupUploadAndRatioField.leadingAnchor],
+        [self.fGroupUploadAndRatioField.trailingAnchor constraintEqualToAnchor:self.trailingAnchor constant:-5],
+        [self.fGroupUploadAndRatioField.centerYAnchor constraintEqualToAnchor:self.centerYAnchor],
+        [self.fGroupUploadAndRatioField.widthAnchor constraintGreaterThanOrEqualToConstant:60],
+    ]];
+
+    [self.fGroupDownloadField setContentHuggingPriority:251 forOrientation:NSLayoutConstraintOrientationHorizontal];
+    [self.fGroupUploadAndRatioField setContentHuggingPriority:251 forOrientation:NSLayoutConstraintOrientationHorizontal];
+}
+
 - (void)setBackgroundStyle:(NSBackgroundStyle)backgroundStyle
 {
     [super setBackgroundStyle:backgroundStyle];

--- a/macosx/TorrentTableView.mm
+++ b/macosx/TorrentTableView.mm
@@ -360,7 +360,12 @@ static NSTimeInterval const kToggleProgressSeconds = 0.175;
     else
     {
         TorrentGroup* group = (TorrentGroup*)item;
-        GroupCell* groupCell = [outlineView makeViewWithIdentifier:@"GroupCell" owner:self];
+        GroupCell* groupCell = [outlineView makeViewWithIdentifier:@"NewGroupCell" owner:self];
+        if (!groupCell)
+        {
+            groupCell = [[GroupCell alloc] initWithFrame:NSZeroRect];
+            groupCell.identifier = @"NewGroupCell";
+        }
 
         NSInteger groupIndex = group.groupIndex;
 


### PR DESCRIPTION
To increase flexibility when editing group cell.

Extracting the group cell from the XIB unlocks:
1. Encapsulating static data inside the cell (e.g., `NSLocalizedString` or custom colors).
2. Moving away from heavy, fragile XML-based XIB files, making future code reviews and layout modifications easier.
3. Preventing unexpected memory issues and layouts bugs caused by repetitive `awakeFromNib` calls.

### Results

This PR fixes a critical side-effect where `awakeFromNib` is invoked multiple times in `TorrentTableView` according to the [Apple documentation](https://apple.com).

Previously, `makeView(withIdentifier:owner:)` was called with `owner: self` (the table view itself). This caused `[TorrentTableView awakeFromNib]` to trigger repeatedly every time a new cell was instantiated (e.g., when the pool of cells was insufficient or when toggling between Compact and Small view settings). 

Removing the cell from the XIB completely solves these unexpected multiple invocations.