### PR TITLE
Fix crash in checkForFiles

### DIFF
--- a/macosx/Torrent.mm
+++ b/macosx/Torrent.mm
@@ -1608,6 +1608,10 @@ bool trashDataFile(std::string_view const filename, tr_error* error)
 - (NSControlStateValue)checkForFiles:(NSIndexSet*)indexSet
 {
     BOOL onState = NO, offState = NO;
+    if (!self.fHandle)
+    {
+        return NSControlStateValueOff;
+    }
     for (NSUInteger index = indexSet.firstIndex; index != NSNotFound; index = [indexSet indexGreaterThanIndex:index])
     {
         auto const file = tr_torrentFile(self.fHandle, index);


### PR DESCRIPTION
Fix #7801 
Fix #8494

Notes: fix crash when clicking after removing a torrent.