### PR TITLE
fix: potential fd leak when running scripts  4.1.x

### DIFF
--- a/libtransmission/subprocess-posix.cc
+++ b/libtransmission/subprocess-posix.cc
@@ -153,6 +153,8 @@ bool tr_spawn_async(
     if (child_pid == -1)
     {
         set_system_error(error, errno, "Call to fork()");
+        close(pipe_fds[0]);
+        close(pipe_fds[1]);
         return false;
     }
 


### PR DESCRIPTION
Notes: Fixed potential file descriptor leak when launching scripts on POSIX systems.

Cherry-pick #8524 for 4.1.x.