### PR TITLE
fix: FTBFS with glibmm-2.68

### DIFF
--- a/gtk/DetailsDialog.cc
+++ b/gtk/DetailsDialog.cc
@@ -970,10 +970,10 @@ void DetailsDialog::Impl::refreshInfo(std::vector<tr_torrent*> const& torrents)
     }
     else
     {
-        auto const baseline = Glib::ustring(stats.front().error_string);
+        auto const& baseline = stats.front().error_string;
         bool const is_uniform = std::ranges::all_of(stats, [&baseline](auto const& st) { return baseline == st.error_string; });
 
-        str = is_uniform ? baseline : mixed;
+        str = is_uniform ? Glib::ustring{ baseline } : mixed;
     }
 
     if (str.empty())


### PR DESCRIPTION
Seen in [this log](https://build.transmissionbt.com/job/trunk-linux/lastFailedBuild/console):

- g++ GNU 14.2.1

- Checking for modules 'gtkmm-4.0>=4.11.1;glibmm-2.68>=2.60.0;giomm-2.68>=2.26.0'
13:30:21 --   Found gtkmm-4.0, version 4.14.0
13:30:21 --   Found glibmm-2.68, version 2.80.0
13:30:21 --   Found giomm-2.68, version 2.80.0

- -isystem /usr/include/giomm-2.68
  -isystem /usr/lib64/giomm-2.68/include
  -isystem /usr/include/glibmm-2.68
  -isystem /usr/lib64/glibmm-2.68/include
  -isystem /usr/include/glib-2.0
  -isystem /usr/lib64/glib-2.0/include
  -isystem /usr/include/sigc++-3.0
  -isystem /usr/lib64/sigc++-3.0/include


```
13:45:53 /home/fedora/jenkins/workspace/trunk-linux/transmission-4.1.0-beta.5+r6c92d06854/gtk/DetailsDialog.cc:974:52:   required from here
13:45:53   974 |         bool const is_uniform = std::ranges::all_of(stats, [&baseline](auto const& st) { return baseline == st.error_string; });
13:45:53       |                                 ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
13:45:53 /usr/include/glibmm-2.68/glibmm/ustring.h:1501:22: error: no matching function for call to ‘Glib::ustring::compare(const std::__cxx11::basic_string<char>&) const’
13:45:53  1501 |   return (lhs.compare(rhs) == 0);
13:45:53       |           ~~~~~~~~~~~^~~~~
```