### PR TITLE
fix: crash when removing a torrent that the inspector is showing (#8496)

### DIFF
--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -340,6 +340,8 @@ static void removeKeRangerRansomware()
 @property(nonatomic) NSView* fPositioningView;
 @property(nonatomic) BOOL fSoundPlaying;
 
+- (void)removeTorrentsImpl:(NSArray<Torrent*>*)torrents deleteData:(BOOL)deleteData;
+
 @end
 
 @implementation Controller
@@ -1369,7 +1371,7 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
     }
     else
     {
-        [torrent closeRemoveTorrent:NO];
+        [self removeTorrentsImpl:@[ torrent ] deleteData:NO];
     }
 
     [self.fAddWindows removeObject:addController];
@@ -1463,7 +1465,7 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
     }
     else
     {
-        [torrent closeRemoveTorrent:NO];
+        [self removeTorrentsImpl:@[ torrent ] deleteData:NO];
     }
 
     [self.fAddWindows removeObject:addController];
@@ -1940,6 +1942,16 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
     [self confirmRemoveTorrents:torrents deleteData:deleteData];
 }
 
+- (void)removeTorrentsImpl:(NSArray<Torrent*>*)torrents deleteData:(BOOL)deleteData
+{
+    [self.fInfoController removeTorrentsFromInfo:torrents];
+
+    for (Torrent* torrent in torrents)
+    {
+        [torrent closeRemoveTorrent:deleteData];
+    }
+}
+
 - (void)confirmRemoveTorrents:(NSArray<Torrent*>*)torrents deleteData:(BOOL)deleteData
 {
     //miscellaneous
@@ -1997,10 +2009,7 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
 
                 //we can't closeRemoveTorrent: until it's no longer in the GUI at all
                 NSAnimationContext.currentContext.completionHandler = ^{
-                    for (Torrent* torrent in torrents)
-                    {
-                        [torrent closeRemoveTorrent:deleteData];
-                    }
+                    [self removeTorrentsImpl:torrents deleteData:deleteData];
 
                     [self fullUpdateUI];
                 };
@@ -2040,10 +2049,7 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
     if (!beganUpdate)
     {
         //do here if we're not doing it at the end of the animation
-        for (Torrent* torrent in torrents)
-        {
-            [torrent closeRemoveTorrent:deleteData];
-        }
+        [self removeTorrentsImpl:torrents deleteData:deleteData];
     }
 }
 

--- a/macosx/InfoWindowController.h
+++ b/macosx/InfoWindowController.h
@@ -12,6 +12,7 @@
 @property(nonatomic, readonly) BOOL canQuickLook;
 
 - (void)setInfoForTorrents:(NSArray<Torrent*>*)torrents;
+- (void)removeTorrentsFromInfo:(NSArray<Torrent*>*)torrents;
 - (void)updateInfoStats;
 - (void)updateOptions;
 

--- a/macosx/InfoWindowController.mm
+++ b/macosx/InfoWindowController.mm
@@ -208,6 +208,18 @@ typedef NS_ENUM(NSUInteger, TabTag) {
     [self resetInfo];
 }
 
+- (void)removeTorrentsFromInfo:(NSArray<Torrent*>*)torrents
+{
+    if (self.fTorrents.count == 0 || torrents.count == 0)
+    {
+        return;
+    }
+
+    NSMutableArray<Torrent*>* remaining = [self.fTorrents mutableCopy];
+    [remaining removeObjectsInArray:torrents];
+    [self setInfoForTorrents:remaining];
+}
+
 - (NSRect)windowWillUseStandardFrame:(NSWindow*)window defaultFrame:(NSRect)defaultFrame
 {
     NSRect windowRect = window.frame;


### PR DESCRIPTION
Cherry-pick #8496 for `main`.

Fixes #7801.
Fixes #8494.