### PR TITLE
refactor: use char8_t as underlying type of `tr_interned_string`

### DIFF
--- a/libtransmission/announce-list.h
+++ b/libtransmission/announce-list.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include <compare>
 #include <cstddef> // size_t
 #include <optional>
 #include <string>
@@ -31,29 +32,19 @@ public:
         tr_tracker_tier_t tier = 0;
         tr_tracker_id_t id = 0;
 
-        [[nodiscard]] constexpr int compare(tracker_info const& that) const noexcept // <=>
+        [[nodiscard]] constexpr auto operator<=>(tracker_info const& that) const noexcept
         {
-            if (this->tier != that.tier)
+            if (auto const res = this->tier <=> that.tier; res != 0)
             {
-                return this->tier < that.tier ? -1 : 1;
+                return res;
             }
 
-            if (int const i{ this->announce.compare(that.announce) }; i != 0)
-            {
-                return i;
-            }
-
-            return 0;
-        }
-
-        [[nodiscard]] constexpr bool operator<(tracker_info const& that) const noexcept
-        {
-            return compare(that) < 0;
+            return this->announce <=> that.announce;
         }
 
         [[nodiscard]] constexpr bool operator==(tracker_info const& that) const noexcept
         {
-            return compare(that) == 0;
+            return (*this <=> that) == 0;
         }
     };
 
@@ -91,11 +82,6 @@ public:
     [[nodiscard]] TR_CONSTEXPR_VEC bool operator==(tr_announce_list const& that) const
     {
         return trackers_ == that.trackers_;
-    }
-
-    [[nodiscard]] TR_CONSTEXPR_VEC bool operator!=(tr_announce_list const& that) const
-    {
-        return trackers_ != that.trackers_;
     }
 
     void add_to_map(tr_variant::Map& setme) const;


### PR DESCRIPTION
Closes #8538.

Notes: Moved from C++17 to C++20.