### PR TITLE
ci: faster clang tidy

### DIFF
--- a/.github/actions/prepare-deps-win32/action.yml
+++ b/.github/actions/prepare-deps-win32/action.yml
@@ -1,4 +1,5 @@
 name: Prepare Win32 build dependencies
+description: Prepare and cache Windows build dependencies for configured architecture and dependency set.
 inputs:
   arch:
     description: Architecture (x86, x64)

--- a/.github/scripts/clang-tidy-gate.ps1
+++ b/.github/scripts/clang-tidy-gate.ps1
@@ -1,0 +1,274 @@
+# disclaimer: slop
+
+$ErrorActionPreference = 'Stop'
+
+if ($Env:TR_CLANG_TIDY_ENABLE -ne '1') {
+    exit 0
+}
+
+$clangTidyBin = $args[0]
+if (-not $clangTidyBin) {
+    Write-Error 'clang-tidy binary path was not provided'
+}
+
+$clangTidyArgs = @()
+if ($args.Count -gt 1) {
+    $clangTidyArgs = @($args[1..($args.Count - 1)])
+}
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path.Replace('\', '/')
+$workspaceRoot = ($repoRoot | Split-Path -Parent)
+$buildRoot = $null
+try {
+    $buildCandidate = [System.IO.Path]::GetFullPath((Join-Path $workspaceRoot 'obj'))
+    if (Test-Path $buildCandidate) {
+        $buildRoot = $buildCandidate.Replace('\\', '/')
+    }
+}
+catch {
+}
+$thirdPartyRoot = Join-Path $repoRoot 'third-party'
+$objThirdPartyRoot = $null
+try {
+    $objThirdPartyCandidate = [System.IO.Path]::GetFullPath((Join-Path $workspaceRoot 'obj/third-party'))
+    if (Test-Path $objThirdPartyCandidate) {
+        $objThirdPartyRoot = $objThirdPartyCandidate
+    }
+}
+catch {
+}
+$depsIncludeDir = $null
+if (-not [string]::IsNullOrWhiteSpace($Env:DEPS_PREFIX)) {
+    $depsIncludeDir = ([System.IO.Path]::GetFullPath((Join-Path $Env:DEPS_PREFIX 'include'))).Replace('\\', '/')
+}
+
+$normalizedArgs = @()
+$stdArg = '/std:c++20'
+$externalIncludeDirs = @()
+$skipNext = $false
+for ($i = 0; $i -lt $clangTidyArgs.Count; ++$i) {
+    if ($skipNext) {
+        $skipNext = $false
+        continue
+    }
+
+    $arg = $clangTidyArgs[$i]
+
+    if ($arg -eq '-std' -or $arg -eq '/std') {
+        if ($i + 1 -lt $clangTidyArgs.Count) {
+            $stdValue = $clangTidyArgs[$i + 1]
+            if (-not [string]::IsNullOrWhiteSpace($stdValue)) {
+                $stdArg = "/std:$stdValue"
+            }
+        }
+        $skipNext = $true
+        continue
+    }
+
+    if ($arg -like '-std:*' -or $arg -like '/std:*' -or $arg -like '-std=*' -or $arg -like '/std=*') {
+        $separatorIndex = $arg.IndexOf(':')
+        if ($separatorIndex -lt 0) {
+            $separatorIndex = $arg.IndexOf('=')
+        }
+
+        if ($separatorIndex -ge 0 -and $separatorIndex + 1 -lt $arg.Length) {
+            $stdValue = $arg.Substring($separatorIndex + 1)
+            if (-not [string]::IsNullOrWhiteSpace($stdValue)) {
+                $stdArg = "/std:$stdValue"
+            }
+        }
+        continue
+    }
+
+    if ($arg -eq '-external') {
+        continue
+    }
+
+    if ($arg -eq '-I' -or $arg -eq '/I' -or $arg -eq '-isystem' -or $arg -eq '/imsvc') {
+        if ($i + 1 -lt $clangTidyArgs.Count) {
+            $normalizedArgs += $arg
+            $normalizedArgs += $clangTidyArgs[$i + 1]
+            $skipNext = $true
+        }
+        continue
+    }
+
+    if ($arg -like '-I*' -or $arg -like '/I*' -or $arg -like '-isystem*' -or $arg -like '/imsvc*') {
+        $normalizedArgs += $arg
+        continue
+    }
+
+    if ($arg -like '-external:*') {
+        $externalValue = $arg.Substring(10)
+        if ($externalValue -match '^W\d+$') {
+            continue
+        }
+
+        if ($externalValue -like 'I*') {
+            $includePath = $externalValue.Substring(1).Replace('\\', '/')
+            $externalIncludeDirs += $includePath
+            continue
+        }
+
+        continue
+    }
+
+    if ($arg -like '-DPACKAGE_DATA_DIR=*') {
+        continue
+    }
+
+    $normalizedArgs += $arg
+}
+
+$fallbackIncludeDirs = @()
+if (Test-Path $thirdPartyRoot) {
+    foreach ($dir in (Get-ChildItem -Path $thirdPartyRoot -Directory)) {
+        $includeDir = Join-Path $dir.FullName 'include'
+        if (Test-Path $includeDir) {
+            $fallbackIncludeDirs += ((Resolve-Path $includeDir).Path.Replace('\\', '/'))
+        }
+
+        $sourceDir = Join-Path $dir.FullName 'source'
+        if (Test-Path $sourceDir) {
+            $fallbackIncludeDirs += ((Resolve-Path $sourceDir).Path.Replace('\\', '/'))
+        }
+    }
+
+    $madlerRoot = Join-Path $thirdPartyRoot 'madler-crcany'
+    if (Test-Path $madlerRoot) {
+        $fallbackIncludeDirs += ((Resolve-Path $madlerRoot).Path.Replace('\\', '/'))
+    }
+}
+
+if (-not [string]::IsNullOrWhiteSpace($objThirdPartyRoot)) {
+    foreach ($includeDir in (Get-ChildItem -Path $objThirdPartyRoot -Directory -Recurse | Where-Object { $_.Name -eq 'include' })) {
+        $fallbackIncludeDirs += ($includeDir.FullName.Replace('\\', '/'))
+    }
+}
+
+# Some third-party packages keep headers at the root (e.g., madler-crcany).
+# If a directory has any .h/.hpp/.hh files, include the directory itself.
+if (Test-Path $thirdPartyRoot) {
+    foreach ($dir in (Get-ChildItem -Path $thirdPartyRoot -Directory)) {
+        $hasHeadersAtRoot = Get-ChildItem -Path $dir.FullName -Include *.h,*.hpp,*.hh -File -ErrorAction SilentlyContinue | Select-Object -First 1
+        if ($null -ne $hasHeadersAtRoot) {
+            $fallbackIncludeDirs += ((Resolve-Path $dir.FullName).Path.Replace('\\', '/'))
+        }
+    }
+}
+
+$fallbackIncludeDirs = @($fallbackIncludeDirs | Sort-Object -Unique)
+$fallbackIncludeArgs = @()
+$fallbackIncludeArgs += @($fallbackIncludeDirs | ForEach-Object { "--extra-arg-before=/imsvc$_" })
+$fallbackIncludeArgs += @($fallbackIncludeDirs | ForEach-Object { "--extra-arg-before=-I$_" })
+
+$externalIncludeDirs = @($externalIncludeDirs | Sort-Object -Unique)
+$externalIncludeArgs = @($externalIncludeDirs | ForEach-Object { "--extra-arg-before=/imsvc$_" })
+# Keep a non-system include variant for directories that may contain generated headers or
+# project headers that appear in quoted includes.
+$externalIncludeArgs += @($externalIncludeDirs | ForEach-Object { "--extra-arg-before=-I$_" })
+
+$depsIncludeArgs = @()
+if (-not [string]::IsNullOrWhiteSpace($depsIncludeDir)) {
+    $depsIncludeArgs = @("--extra-arg-before=/imsvc$depsIncludeDir")
+}
+
+# Ensure generated headers reachable from the build tree (CMake configure writes version.h etc.).
+$buildIncludeArgs = @()
+if (-not [string]::IsNullOrWhiteSpace($buildRoot)) {
+    $buildIncludeArgs += "--extra-arg-before=-I$buildRoot"
+}
+# The cmake `__run_co_compile` helper passes clang-tidy args followed by `--` and the
+# compiler's command line. Preserve this split exactly; otherwise compiler options (like -I)
+# get eaten by clang-tidy and you see "unknown argument: -external" et al.
+function Split-ClangTidyArgs {
+    param([string[]]$Args)
+    $sentinelIndex = [Array]::IndexOf($Args, '--')
+    if ($sentinelIndex -ge 0) {
+        $clangArgs = if ($sentinelIndex -gt 0) { @($Args[0..($sentinelIndex - 1)]) } else { @() }
+        $compilerArgs = if ($sentinelIndex + 1 -lt $Args.Count) { @($Args[($sentinelIndex + 1)..($Args.Count - 1)]) } else { @() }
+    }
+    else {
+        $clangArgs = $Args
+        $compilerArgs = @()
+    }
+    return ,@($clangArgs, $compilerArgs, $sentinelIndex)
+}
+
+function Extract-Sources {
+    param([string[]]$Args)
+    $sources = @()
+    $remaining = @()
+    foreach ($arg in $Args) {
+        if ($arg -like '--source=*') {
+            $val = $arg.Substring(9)
+            if (-not [string]::IsNullOrWhiteSpace($val)) {
+                $sources += $val
+            }
+            continue
+        }
+        # Some CMake versions may pass '--source' as a token followed by the path (rare)
+        if ($arg -eq '--source') {
+            $remaining += $arg
+            continue
+        }
+        $remaining += $arg
+    }
+    return ,@($remaining, $sources)
+}
+
+$split = Split-ClangTidyArgs -Args $clangTidyArgs
+$clangArgs = $split[0]
+$compilerArgs = $split[1]
+$sentinelIndex = $split[2]
+
+$extract = Extract-Sources -Args $clangArgs
+$clangArgs = $extract[0]
+$sources = $extract[1]
+
+# Passthrough mode (parity with POSIX gate). Useful for debugging or when normalization is at fault.
+if ($Env:TR_CLANG_TIDY_PASSTHRU -eq '1') {
+    $normalizedArgs = @($clangArgs + $sources)
+    if ($sentinelIndex -ge 0 -and $compilerArgs.Count -gt 0) {
+        $normalizedArgs += @('--') + $compilerArgs
+    }
+
+    if ($Env:TR_CLANG_TIDY_DEBUG -eq '1') {
+        Write-Host "[clang-tidy-gate] PASSTHRU repoRoot=$repoRoot buildRoot=$buildRoot"
+        Write-Host "[clang-tidy-gate] rawArgs:`n$($args -join "`n")"
+        Write-Host "[clang-tidy-gate] clangArgs:`n$($clangArgs -join "`n")"
+        Write-Host "[clang-tidy-gate] sources:`n$($sources -join "`n")"
+        Write-Host "[clang-tidy-gate] compilerArgs:`n$($compilerArgs -join "`n")"
+    }
+
+    & $clangTidyBin @normalizedArgs
+    exit $LASTEXITCODE
+}
+
+$prefixArgs = @(
+    "--extra-arg-before=-I$repoRoot"
+) + $buildIncludeArgs + $depsIncludeArgs + $fallbackIncludeArgs + $externalIncludeArgs + @(
+    "--extra-arg-before=$stdArg",
+    '--extra-arg-before=--driver-mode=cl'
+)
+
+# Assemble final arguments:
+#   clang-tidy [options + prefixArgs] [sources] -- [compilerArgs]
+$normalizedArgs = @($clangArgs + $prefixArgs + $sources)
+if ($sentinelIndex -ge 0 -and $compilerArgs.Count -gt 0) {
+    $normalizedArgs += @('--') + $compilerArgs
+}
+
+# Optional debug logging for CI investigations
+if ($Env:TR_CLANG_TIDY_DEBUG -eq '1') {
+    Write-Host "[clang-tidy-gate] repoRoot=$repoRoot buildRoot=$buildRoot"
+    Write-Host "[clang-tidy-gate] rawArgs:`n$($args -join "`n")"
+    Write-Host "[clang-tidy-gate] clangArgs:`n$($clangArgs -join "`n")"
+    Write-Host "[clang-tidy-gate] prefixArgs:`n$($prefixArgs -join "`n")"
+    Write-Host "[clang-tidy-gate] sources:`n$($sources -join "`n")"
+    Write-Host "[clang-tidy-gate] compilerArgs:`n$($compilerArgs -join "`n")"
+    Write-Host "[clang-tidy-gate] normalizedArgs:`n$($normalizedArgs -join "`n")"
+}
+
+& $clangTidyBin @normalizedArgs
+exit $LASTEXITCODE

--- a/.github/scripts/clang-tidy-gate.sh
+++ b/.github/scripts/clang-tidy-gate.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+clang_tidy_bin="$1"
+shift
+
+if [ "${TR_CLANG_TIDY_ENABLE:-0}" != "1" ]; then
+  exit 0
+fi
+
+exec "$clang_tidy_bin" "$@"

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -55,7 +55,13 @@ jobs:
         run: |
           set +e
           cd src
-          MERGE_BASE=`git merge-base origin/main HEAD`
+          if [ "$GITHUB_EVENT_NAME" = 'pull_request' ]; then
+            BASE_BRANCH="$GITHUB_BASE_REF"
+          else
+            BASE_BRANCH="$GITHUB_REF_NAME"
+          fi
+          git fetch --no-tags origin "$BASE_BRANCH"
+          MERGE_BASE=$(git merge-base "origin/$BASE_BRANCH" HEAD)
           function get_changes() { # name, paths...
             local name="$1"
             shift

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -428,9 +428,14 @@ jobs:
           set -euo pipefail
           if grep 'warning:' makelog; then exit 1; fi
 
-  clang-tidy-libtransmission-win32:
+  clang-tidy-win32:
     runs-on: windows-2025
     needs: what-to-make
+    env:
+      MAKE_TESTS: ${{ needs.what-to-make.outputs.make-tests }}
+      CHANGED_CPP_FILES: ${{ needs.what-to-make.outputs.changed-cpp-files }}
+      CLANG_CONFIG_CHANGED: ${{ needs.what-to-make.outputs.clang-config-changed }}
+      CLANG_TIDY_FULL_RUN: ${{ ((github.event_name == 'push' && github.ref_name == 'main') || needs.what-to-make.outputs.clang-config-changed == '1') && '1' || '0' }}
     defaults:
       run:
         shell: pwsh
@@ -447,7 +452,7 @@ jobs:
         with:
           submodules: recursive
           path: src
-      - name: Prepare Build Deps
+      - name: Get Dependencies
         uses: ./src/.github/actions/prepare-deps-win32
         with:
           arch: x64
@@ -461,22 +466,73 @@ jobs:
             -G Ninja `
             -DCMAKE_BUILD_TYPE=Debug `
             -DCMAKE_PREFIX_PATH="${Env:DEPS_PREFIX}" `
-            -DENABLE_TESTS=${{ needs.what-to-make.outputs.make-tests == 'true' && 'ON' || 'OFF' }} `
-            -DRUN_CLANG_TIDY=ON `
+            -DCMAKE_INSTALL_PREFIX='C:/transmission' `
+            -DENABLE_TESTS=${{ env.MAKE_TESTS == 'true' && 'ON' || 'OFF' }} `
+            -DRUN_CLANG_TIDY=OFF `
+            -DCMAKE_CXX_CLANG_TIDY="pwsh;-File;${{ github.workspace }}\src\.github\scripts\clang-tidy-gate.ps1;clang-tidy" `
             -DUSE_SYSTEM_DEFAULT=OFF
-      - name: Make (Core)
+      - name: Determine clang-tidy mode
+        run: |
+          echo "CLANG_TIDY_FULL_RUN=${Env:CLANG_TIDY_FULL_RUN}"
+      - name: Determine clang-tidy targets
+        id: compute-targets
+        run: |
+          $jobs = [Environment]::ProcessorCount
+          if ($jobs -gt 8) { $jobs = 8 }
+
+          # Prime objects quickly before incremental clang-tidy pass.
+          $targets = @('transmission', 'transmission-app')
+          if ($Env:MAKE_TESTS -eq 'true') {
+            $targets += 'libtransmission-test'
+          }
+
+          "jobs=$jobs" | Out-File $Env:GITHUB_OUTPUT -Append
+          'targets<<EOF' | Out-File $Env:GITHUB_OUTPUT -Append
+          $targets | Out-File $Env:GITHUB_OUTPUT -Append
+          'EOF' | Out-File $Env:GITHUB_OUTPUT -Append
+      - name: Make (No clang-tidy)
+        if: ${{ env.CLANG_TIDY_FULL_RUN != '1' }}
         run: |
           Import-VisualStudioVars -VisualStudioVersion 2022 -Architecture x64
-          cmake --build obj --config Debug --target transmission 2>&1 | tee makelog
-      - name: Make (App)
+          $Env:TR_CLANG_TIDY_ENABLE = '0'
+          '' | Set-Content makelog
+
+          $jobs = '${{ steps.compute-targets.outputs.jobs }}'
+          $targets = '${{ steps.compute-targets.outputs.targets }}' -split "`r?`n" | Where-Object { $_ -ne '' }
+
+          cmake --build obj --config Debug --parallel $jobs --target $targets 2>&1 | tee -a makelog
+      - name: Touch changed files for incremental clang-tidy
+        if: ${{ env.CLANG_TIDY_FULL_RUN != '1' }}
+        run: |
+          # Touch changed files so only affected code is rebuilt/tidied.
+          $changedFiles = @()
+          if (-not [string]::IsNullOrWhiteSpace($Env:CHANGED_CPP_FILES)) {
+            $changedFiles = $Env:CHANGED_CPP_FILES -split "`r?`n" |
+              Where-Object { $_ -ne '' } |
+              ForEach-Object { Join-Path 'src' $_ } |
+              Where-Object { Test-Path $_ }
+          }
+
+          if ($changedFiles.Count -gt 0) {
+            cmake -E touch_nocreate @changedFiles
+          }
+
+          echo 'Touched files for clang-tidy:'
+          $changedFiles.Count | ForEach-Object { echo $_ }
+          $changedFiles | ForEach-Object { echo $_ }
+      - name: Make (clang-tidy)
         run: |
           Import-VisualStudioVars -VisualStudioVersion 2022 -Architecture x64
-          cmake --build obj --config Debug --target transmission-app 2>&1 | tee -a makelog
-      - name: Make (Tests)
-        if: needs.what-to-make.outputs.make-tests == 'true'
-        run: |
-          Import-VisualStudioVars -VisualStudioVersion 2022 -Architecture x64
-          cmake --build obj --config Debug --target libtransmission-test 2>&1 | tee -a makelog
+          $Env:TR_CLANG_TIDY_ENABLE = '1'
+
+          if (-not (Test-Path makelog)) {
+            '' | Set-Content makelog
+          }
+
+          $jobs = '${{ steps.compute-targets.outputs.jobs }}'
+          $targets = '${{ steps.compute-targets.outputs.targets }}' -split "`r?`n" | Where-Object { $_ -ne '' }
+
+          cmake --build obj --config Debug --parallel $jobs --target $targets 2>&1 | tee -a makelog
       - name: Test for warnings
         run: |
           if (Select-String -Path makelog -Pattern 'warning:') { exit 1 }

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -252,15 +252,48 @@ jobs:
           enable-sanitizers: true
 
   clang-tidy-posix:
-    runs-on: ubuntu-latest
+    name: clang-tidy-posix (${{ matrix.label }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: core
+            kind: core
+            gtk: 'false'
+            qt: 'false'
+          - label: gtk3
+            kind: gtk
+            gtk: 'gtk3'
+            qt: 'false'
+          - label: gtk4
+            kind: gtk
+            gtk: 'gtk4'
+            qt: 'false'
+          - label: qt5
+            kind: qt
+            gtk: 'false'
+            qt: 'qt5'
+          - label: qt6
+            kind: qt
+            gtk: 'false'
+            qt: 'qt6'
+    runs-on: ubuntu-24.04
     needs: what-to-make
-    if: needs.what-to-make.outputs.make-core == 'true' ||
-        needs.what-to-make.outputs.make-gtk == 'true' ||
-        needs.what-to-make.outputs.make-qt == 'true' ||
-        needs.what-to-make.outputs.make-tests == 'true'
+    if: ${{ (needs.what-to-make.outputs.make-core == 'true' ||
+         needs.what-to-make.outputs.make-gtk == 'true' ||
+         needs.what-to-make.outputs.make-qt == 'true' ||
+          needs.what-to-make.outputs.make-tests == 'true') }}
+    env:
+      MAKE_GTK: ${{ needs.what-to-make.outputs.make-gtk }}
+      MAKE_QT: ${{ needs.what-to-make.outputs.make-qt }}
+      MAKE_TESTS: ${{ needs.what-to-make.outputs.make-tests }}
+      CHANGED_CPP_FILES: ${{ needs.what-to-make.outputs.changed-cpp-files }}
+      CLANG_CONFIG_CHANGED: ${{ needs.what-to-make.outputs.clang-config-changed }}
+      CLANG_TIDY_FULL_RUN: ${{ ((github.event_name == 'push' && github.ref_name == 'main') || needs.what-to-make.outputs.clang-config-changed == '1') && '1' || '0' }}
     steps:
       - name: Show Configuration
         run: |
+          set -euo pipefail
           echo '${{ toJSON(needs) }}'
           echo '${{ toJSON(runner) }}'
           echo "RUNNER_OS=${RUNNER_OS}"
@@ -271,15 +304,44 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+      - name: Determine variant enablement
+        id: variant
+        env:
+          VARIANT_KIND: ${{ matrix.kind }}
+          MAKE_GTK: ${{ needs.what-to-make.outputs.make-gtk }}
+          MAKE_QT: ${{ needs.what-to-make.outputs.make-qt }}
+        run: |
+          set -euo pipefail
+          enabled=0
+          case "${VARIANT_KIND}" in
+            core)
+              if [ "${MAKE_GTK}" != 'true' ] && [ "${MAKE_QT}" != 'true' ]; then
+                enabled=1
+              fi
+              ;;
+            gtk)
+              if [ "${MAKE_GTK}" = 'true' ]; then
+                enabled=1
+              fi
+              ;;
+            qt)
+              if [ "${MAKE_QT}" = 'true' ]; then
+                enabled=1
+              fi
+              ;;
+          esac
+          echo "enabled=${enabled}" >> "$GITHUB_OUTPUT"
       - name: Get Dependencies
+        if: steps.variant.outputs.enabled == '1'
         uses: ./.github/actions/install-deps
         with:
           compiler: clang
           enable-clang-tidy: true
-          enable-gtk: ${{ needs.what-to-make.outputs.make-gtk == 'true' && 'gtk3' || 'false' }}
-          enable-qt: ${{ needs.what-to-make.outputs.make-qt == 'true' && 'qt5' || 'false' }}
+          enable-gtk: ${{ matrix.gtk }}
+          enable-qt: ${{ matrix.qt }}
           use-sudo: true
       - name: Configure
+        if: steps.variant.outputs.enabled == '1'
         run: |
           cmake \
             -S . \
@@ -289,9 +351,9 @@ jobs:
             -DCMAKE_CXX_COMPILER='clang++' \
             -DCMAKE_C_COMPILER='clang' \
             -DCMAKE_INSTALL_PREFIX=pfx \
-            -DENABLE_GTK=${{ needs.what-to-make.outputs.make-gtk == 'true' && 'ON' || 'OFF' }} \
-            -DENABLE_QT=${{ needs.what-to-make.outputs.make-qt == 'true' && 'ON' || 'OFF' }} \
-            -DENABLE_TESTS=${{ needs.what-to-make.outputs.make-tests == 'true' && 'ON' || 'OFF' }} \
+            -DENABLE_GTK=${{ matrix.gtk != 'false' && 'ON' || 'OFF' }} \
+            -DENABLE_QT=${{ matrix.qt != 'false' && 'ON' || 'OFF' }} \
+            -DENABLE_TESTS=${{ env.MAKE_TESTS == 'true' && 'ON' || 'OFF' }} \
             -DRUN_CLANG_TIDY=OFF \
             -DCMAKE_CXX_CLANG_TIDY="bash;$PWD/.github/scripts/clang-tidy-gate.sh;clang-tidy-20" \
             -DUSE_SYSTEM_DEFAULT=ON \
@@ -300,54 +362,53 @@ jobs:
             -DUSE_SYSTEM_SMALL=OFF `# Not packaged in Ubuntu` \
             -DUSE_SYSTEM_UTP=OFF `# Not packaged in Ubuntu` \
             -DUSE_SYSTEM_WIDE_INTEGER=OFF `# Not packaged in Ubuntu`
-      - name: Determine clang-tidy scope
+      - name: Determine clang-tidy mode
+        if: steps.variant.outputs.enabled == '1'
         run: |
-          # Run clang-tidy on everything when pushing to main or when .clang-tidy config changes.
-          # Otherwise, run clang-tidy only on changed C/C++ files.
-          if [ "$GITHUB_EVENT_NAME" = 'push' ] && [ "$GITHUB_REF_NAME" = 'main' ]; then
-            full_run=1
-          elif [ '${{ needs.what-to-make.outputs.clang-config-changed }}' = '1' ]; then
-            full_run=1
-          else
-            full_run=0
-          fi
-          echo "CLANG_TIDY_FULL_RUN=${full_run}" >> "$GITHUB_ENV"
-
           set -euo pipefail
+          echo "CLANG_TIDY_FULL_RUN=${CLANG_TIDY_FULL_RUN}"
+
+      - name: Determine clang-tidy targets
+        id: compute-targets
+        if: steps.variant.outputs.enabled == '1'
+        run: |
+          set -euo pipefail
+
           jobs="$(nproc)"
           if [ "$jobs" -gt 8 ]; then jobs=8; fi
 
           # Prime objects quickly before incremental clang-tidy pass.
           targets=(transmission transmission-app)
-          if [ '${{ needs.what-to-make.outputs.make-tests }}' = 'true' ]; then
+          if [ "${MAKE_TESTS}" = 'true' ]; then
             targets+=(libtransmission-test)
           fi
-          if [ '${{ needs.what-to-make.outputs.make-gtk }}' = 'true' ]; then
+          if [ '${{ matrix.gtk }}' != 'false' ]; then
             targets+=(transmission-gtk)
           fi
-          if [ '${{ needs.what-to-make.outputs.make-qt }}' = 'true' ]; then
+          if [ '${{ matrix.qt }}' != 'false' ]; then
             targets+=(transmission-qt qt-tests)
           fi
 
-          build_args=(--build obj --config Debug --parallel "$jobs" --target "${targets[@]}")
           {
-            echo 'CLANG_TIDY_BUILD_ARGS<<EOF'
-            printf '%s\n' "${build_args[@]}"
+            echo "jobs=${jobs}"
+            echo 'targets<<EOF'
+            printf '%s\n' "${targets[@]}"
             echo 'EOF'
-          } >> "$GITHUB_ENV"
+          } >> "$GITHUB_OUTPUT"
       - name: Make (No clang-tidy)
-        if: env.CLANG_TIDY_FULL_RUN != '1'
+        if: steps.variant.outputs.enabled == '1' && env.CLANG_TIDY_FULL_RUN != '1'
         run: |
           set -euo pipefail
           : > makelog
-          mapfile -t build_args < <(printf '%s\n' "$CLANG_TIDY_BUILD_ARGS" | sed '/^$/d')
-          TR_CLANG_TIDY_ENABLE=0 cmake "${build_args[@]}" 2>&1 | tee -a makelog
+          jobs='${{ steps.compute-targets.outputs.jobs }}'
+          mapfile -t targets < <(printf '%s\n' '${{ steps.compute-targets.outputs.targets }}' | sed '/^$/d')
+          TR_CLANG_TIDY_ENABLE=0 cmake --build obj --config Debug --parallel "$jobs" --target "${targets[@]}" 2>&1 | tee -a makelog
       - name: Touch changed files for incremental clang-tidy
-        if: env.CLANG_TIDY_FULL_RUN != '1'
+        if: steps.variant.outputs.enabled == '1' && env.CLANG_TIDY_FULL_RUN != '1'
         run: |
           set -euo pipefail
           # Touch changed files so only affected code is rebuilt/tidied.
-          changed_cpp_files='${{ needs.what-to-make.outputs.changed-cpp-files }}'
+          changed_cpp_files="${CHANGED_CPP_FILES}"
           mapfile -t changed_cpp_array < <(printf '%s\n' "$changed_cpp_files" | sed '/^$/d')
 
           if [ "${#changed_cpp_array[@]}" -gt 0 ]; then
@@ -358,12 +419,16 @@ jobs:
           printf '%s\n' "${#changed_cpp_array[@]}"
           printf '%s\n' "${changed_cpp_array[@]}"
       - name: Make (clang-tidy)
+        if: steps.variant.outputs.enabled == '1'
         run: |
           set -euo pipefail
-          mapfile -t build_args < <(printf '%s\n' "$CLANG_TIDY_BUILD_ARGS" | sed '/^$/d')
-          TR_CLANG_TIDY_ENABLE=1 cmake "${build_args[@]}" 2>&1 | tee -a makelog
+          jobs='${{ steps.compute-targets.outputs.jobs }}'
+          mapfile -t targets < <(printf '%s\n' '${{ steps.compute-targets.outputs.targets }}' | sed '/^$/d')
+          TR_CLANG_TIDY_ENABLE=1 cmake --build obj --config Debug --parallel "$jobs" --target "${targets[@]}" 2>&1 | tee -a makelog
       - name: Test for warnings
+        if: steps.variant.outputs.enabled == '1'
         run: |
+          set -euo pipefail
           if grep 'warning:' makelog; then exit 1; fi
 
   clang-tidy-libtransmission-win32:

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -285,7 +285,6 @@ jobs:
       MAKE_QT: ${{ needs.what-to-make.outputs.make-qt }}
       MAKE_TESTS: ${{ needs.what-to-make.outputs.make-tests }}
       CHANGED_CPP_FILES: ${{ needs.what-to-make.outputs.changed-cpp-files }}
-      CLANG_CONFIG_CHANGED: ${{ needs.what-to-make.outputs.clang-config-changed }}
       CLANG_TIDY_FULL_RUN: ${{ ((github.event_name == 'push' && github.ref_name == 'main') || needs.what-to-make.outputs.clang-config-changed == '1') && '1' || '0' }}
     steps:
       - name: Show Configuration
@@ -434,7 +433,6 @@ jobs:
     env:
       MAKE_TESTS: ${{ needs.what-to-make.outputs.make-tests }}
       CHANGED_CPP_FILES: ${{ needs.what-to-make.outputs.changed-cpp-files }}
-      CLANG_CONFIG_CHANGED: ${{ needs.what-to-make.outputs.clang-config-changed }}
       CLANG_TIDY_FULL_RUN: ${{ ((github.event_name == 'push' && github.ref_name == 'main') || needs.what-to-make.outputs.clang-config-changed == '1') && '1' || '0' }}
     defaults:
       run:

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -434,6 +434,9 @@ jobs:
   clang-tidy-libtransmission-win32:
     runs-on: windows-2025
     needs: what-to-make
+    defaults:
+      run:
+        shell: pwsh
     if: |
       needs.what-to-make.outputs.make-core == 'true' ||
       needs.what-to-make.outputs.make-tests == 'true'
@@ -685,6 +688,9 @@ jobs:
   windows:
     needs: [ what-to-make ]
     if: ${{ needs.what-to-make.outputs.make-cli == 'true' || needs.what-to-make.outputs.make-daemon == 'true' || needs.what-to-make.outputs.make-dist == 'true' || needs.what-to-make.outputs.make-qt == 'true' || needs.what-to-make.outputs.make-tests == 'true' || needs.what-to-make.outputs.make-utils == 'true' }}
+    defaults:
+      run:
+        shell: pwsh
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -31,6 +31,8 @@ jobs:
       make-utils: ${{ steps.check-main-push.outputs.is-main-push == '1' || steps.check-diffs.outputs.utils-changed == '1' || steps.check-diffs.outputs.tests-changed == '1' || steps.check-diffs.outputs.ci-actions-changed == '1' }}
       make-web: ${{ steps.check-main-push.outputs.is-main-push == '1' || steps.check-diffs.outputs.web-changed == '1' }}
       test-style: ${{ steps.check-main-push.outputs.is-main-push == '1' || steps.check-diffs.outputs.our-code-changed == '1' || steps.check-diffs.outputs.ci-actions-changed == '1' }}
+      clang-config-changed: ${{ steps.check-diffs.outputs.clang-config-changed }}
+      changed-cpp-files: ${{ steps.check-diffs.outputs.changed-cpp-files }}
     steps:
       - name: Check Push to Main Branch
         id: check-main-push
@@ -75,6 +77,20 @@ jobs:
           get_changes utils      CMakeLists.txt cmake third-party libtransmission utils
           get_changes web        CMakeLists.txt cmake web
           get_changes ci-actions .github/workflows/actions.yml .github/actions
+
+          git diff --name-only --diff-filter=AMR "$MERGE_BASE"...HEAD > changed-files.txt
+
+          if grep -Eq '(^|/)\.clang-[^/]+$' changed-files.txt; then
+            echo 'clang-config-changed=1' >> "$GITHUB_OUTPUT"
+          else
+            echo 'clang-config-changed=0' >> "$GITHUB_OUTPUT"
+          fi
+
+          grep -E '\.(c|cc|cpp|cxx|h|hh|hpp|hxx|ipp|tpp)$' changed-files.txt > changed-cpp-files.txt || true
+          echo 'changed-cpp-files<<EOF' >> "$GITHUB_OUTPUT"
+          cat changed-cpp-files.txt >> "$GITHUB_OUTPUT"
+          echo 'EOF' >> "$GITHUB_OUTPUT"
+
           cat "$GITHUB_OUTPUT"
 
   code-style:
@@ -235,32 +251,33 @@ jobs:
           build-config: Debug
           enable-sanitizers: true
 
-  clang-tidy-libtransmission:
-    runs-on: ubuntu-24.04
+  clang-tidy-posix:
+    runs-on: ubuntu-latest
     needs: what-to-make
-    if: needs.what-to-make.outputs.make-core == 'true'
+    if: needs.what-to-make.outputs.make-core == 'true' ||
+        needs.what-to-make.outputs.make-gtk == 'true' ||
+        needs.what-to-make.outputs.make-qt == 'true' ||
+        needs.what-to-make.outputs.make-tests == 'true'
     steps:
       - name: Show Configuration
         run: |
           echo '${{ toJSON(needs) }}'
           echo '${{ toJSON(runner) }}'
-          cat /etc/os-release
-      - name: Cache project files
-        id: cache-project-files
-        uses: actions/cache@v5
-        with:
-          key: clang-tidy-${{ github.sha }}
-          path: .
+          echo "RUNNER_OS=${RUNNER_OS}"
+          echo "ImageOS=${ImageOS:-unknown}"
+          echo "ImageVersion=${ImageVersion:-unknown}"
       - name: Get Source
-        if: steps.cache-project-files.outputs.cache-hit != 'true'
         uses: actions/checkout@v6
         with:
+          fetch-depth: 0
           submodules: recursive
       - name: Get Dependencies
         uses: ./.github/actions/install-deps
         with:
           compiler: clang
           enable-clang-tidy: true
+          enable-gtk: ${{ needs.what-to-make.outputs.make-gtk == 'true' && 'gtk3' || 'false' }}
+          enable-qt: ${{ needs.what-to-make.outputs.make-qt == 'true' && 'qt5' || 'false' }}
           use-sudo: true
       - name: Configure
         run: |
@@ -272,129 +289,79 @@ jobs:
             -DCMAKE_CXX_COMPILER='clang++' \
             -DCMAKE_C_COMPILER='clang' \
             -DCMAKE_INSTALL_PREFIX=pfx \
-            -DRUN_CLANG_TIDY=ON \
+            -DENABLE_GTK=${{ needs.what-to-make.outputs.make-gtk == 'true' && 'ON' || 'OFF' }} \
+            -DENABLE_QT=${{ needs.what-to-make.outputs.make-qt == 'true' && 'ON' || 'OFF' }} \
+            -DENABLE_TESTS=${{ needs.what-to-make.outputs.make-tests == 'true' && 'ON' || 'OFF' }} \
+            -DRUN_CLANG_TIDY=OFF \
+            -DCMAKE_CXX_CLANG_TIDY="bash;$PWD/.github/scripts/clang-tidy-gate.sh;clang-tidy-20" \
             -DUSE_SYSTEM_DEFAULT=ON \
             -DUSE_SYSTEM_DHT=OFF `# Not packaged in Ubuntu` \
             -DUSE_SYSTEM_SIGSLOT=OFF `# Not packaged in Ubuntu` \
             -DUSE_SYSTEM_SMALL=OFF `# Not packaged in Ubuntu` \
             -DUSE_SYSTEM_UTP=OFF `# Not packaged in Ubuntu` \
             -DUSE_SYSTEM_WIDE_INTEGER=OFF `# Not packaged in Ubuntu`
-      - name: Make (Core)
+      - name: Determine clang-tidy scope
         run: |
-          set -euo pipefail
-          cmake --build obj --config Debug --target transmission 2>&1 | tee makelog
-      - name: Make (App)
-        run: |
-          set -euo pipefail
-          cmake --build obj --config Debug --target transmission-app 2>&1 | tee -a makelog
-      - name: Test for warnings
-        run: |
-          if grep 'warning:' makelog; then exit 1; fi
+          # Run clang-tidy on everything when pushing to main or when .clang-tidy config changes.
+          # Otherwise, run clang-tidy only on changed C/C++ files.
+          if [ "$GITHUB_EVENT_NAME" = 'push' ] && [ "$GITHUB_REF_NAME" = 'main' ]; then
+            full_run=1
+          elif [ '${{ needs.what-to-make.outputs.clang-config-changed }}' = '1' ]; then
+            full_run=1
+          else
+            full_run=0
+          fi
+          echo "CLANG_TIDY_FULL_RUN=${full_run}" >> "$GITHUB_ENV"
 
-  what-to-clang-tidy:
-    runs-on: ubuntu-latest
-    needs: [ what-to-make, clang-tidy-libtransmission ]
-    if: |
-      needs.what-to-make.outputs.make-gtk == 'true' ||
-      needs.what-to-make.outputs.make-qt == 'true' ||
-      needs.what-to-make.outputs.make-tests == 'true'
-    outputs:
-      matrix: ${{ steps.generate-matrix.outputs.matrix }}
-    steps:
-      - name: Generate clang-tidy matrix
-        id: generate-matrix
-        run: |
-          set -exuo pipefail
+          set -euo pipefail
+          jobs="$(nproc)"
+          if [ "$jobs" -gt 8 ]; then jobs=8; fi
 
-          # Generate elements in the include array
-          jobs=()
+          # Prime objects quickly before incremental clang-tidy pass.
+          targets=(transmission transmission-app)
+          if [ '${{ needs.what-to-make.outputs.make-tests }}' = 'true' ]; then
+            targets+=(libtransmission-test)
+          fi
           if [ '${{ needs.what-to-make.outputs.make-gtk }}' = 'true' ]; then
-            jobs+=("$(
-              jq -nc '$ARGS.named' \
-                --arg target transmission-gtk \
-                --arg enable-gtk gtk3 \
-                --argjson enable-qt false \
-                --argjson enable-tests false
-            )")
+            targets+=(transmission-gtk)
           fi
           if [ '${{ needs.what-to-make.outputs.make-qt }}' = 'true' ]; then
-            jobs+=("$(
-              jq -nc '$ARGS.named' \
-                --arg target transmission-qt \
-                --argjson enable-gtk false \
-                --arg enable-qt qt6 \
-                --argjson enable-tests false
-            )"
-            "$(
-              jq -nc '$ARGS.named' \
-                --arg target transmission-qt \
-                --argjson enable-gtk false \
-                --arg enable-qt qt5 \
-                --argjson enable-tests false
-            )")
-          fi
-          if [ '${{ needs.what-to-make.outputs.make-tests }}' = 'true' ]; then
-            jobs+=("$(
-              jq -nc '$ARGS.named' \
-                --arg target libtransmission-test \
-                --argjson enable-gtk false \
-                --argjson enable-qt '${{ needs.what-to-make.outputs.make-qt == 'true' && '"qt6"' || 'false' }}' \
-                --argjson enable-tests true
-            )")
+            targets+=(transmission-qt qt-tests)
           fi
 
-          # Combine the include array elements into a JSON string and output
-          echo "matrix=$(printf "%s\n" "${jobs[@]}" | jq -sc '{include: .}')" >> "$GITHUB_OUTPUT"
-
-  clang-tidy:
-    runs-on: ubuntu-24.04
-    needs: what-to-clang-tidy
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJSON(needs.what-to-clang-tidy.outputs.matrix) }}
-    steps:
-      - name: Show Configuration
-        run: |
-          echo '${{ toJSON(needs) }}'
-          echo '${{ toJSON(runner) }}'
-          cat /etc/os-release
-      - name: Get cached project files
-        uses: actions/cache/restore@v5
-        with:
-          key: clang-tidy-${{ github.sha }}
-          path: .
-          fail-on-cache-miss: true
-      - name: Get Dependencies
-        uses: ./.github/actions/install-deps
-        with:
-          compiler: clang
-          enable-clang-tidy: true
-          use-sudo: true
-          enable-gtk: ${{ matrix.enable-gtk }}
-          enable-qt: ${{ matrix.enable-qt }}
-      - name: Configure
-        run: |
-          cmake \
-            -S . \
-            -B obj \
-            -G Ninja \
-            -DCMAKE_BUILD_TYPE=Debug \
-            -DCMAKE_CXX_COMPILER='clang++' \
-            -DCMAKE_C_COMPILER='clang' \
-            -DCMAKE_INSTALL_PREFIX=pfx \
-            -DENABLE_GTK=${{ matrix.enable-gtk && 'ON' || 'OFF' }} \
-            -DENABLE_QT=${{ matrix.enable-qt && 'ON' || 'OFF' }} \
-            -DENABLE_TESTS=${{ matrix.enable-tests && 'ON' || 'OFF' }} \
-            -DRUN_CLANG_TIDY=ON \
-            -DUSE_SYSTEM_DEFAULT=ON \
-            -DUSE_SYSTEM_DHT=OFF `# Not packaged in Ubuntu` \
-            -DUSE_SYSTEM_SMALL=OFF `# Not packaged in Ubuntu` \
-            -DUSE_SYSTEM_UTP=OFF `# Not packaged in Ubuntu` \
-            -DUSE_SYSTEM_WIDE_INTEGER=OFF `# Not packaged in Ubuntu`
-      - name: Make
+          build_args=(--build obj --config Debug --parallel "$jobs" --target "${targets[@]}")
+          {
+            echo 'CLANG_TIDY_BUILD_ARGS<<EOF'
+            printf '%s\n' "${build_args[@]}"
+            echo 'EOF'
+          } >> "$GITHUB_ENV"
+      - name: Make (No clang-tidy)
+        if: env.CLANG_TIDY_FULL_RUN != '1'
         run: |
           set -euo pipefail
-          cmake --build obj --config Debug --target ${{ matrix.target }} 2>&1 | tee makelog
+          : > makelog
+          mapfile -t build_args < <(printf '%s\n' "$CLANG_TIDY_BUILD_ARGS" | sed '/^$/d')
+          TR_CLANG_TIDY_ENABLE=0 cmake "${build_args[@]}" 2>&1 | tee -a makelog
+      - name: Touch changed files for incremental clang-tidy
+        if: env.CLANG_TIDY_FULL_RUN != '1'
+        run: |
+          set -euo pipefail
+          # Touch changed files so only affected code is rebuilt/tidied.
+          changed_cpp_files='${{ needs.what-to-make.outputs.changed-cpp-files }}'
+          mapfile -t changed_cpp_array < <(printf '%s\n' "$changed_cpp_files" | sed '/^$/d')
+
+          if [ "${#changed_cpp_array[@]}" -gt 0 ]; then
+            cmake -E touch_nocreate "${changed_cpp_array[@]}"
+          fi
+
+          echo 'Touched files for clang-tidy:'
+          printf '%s\n' "${#changed_cpp_array[@]}"
+          printf '%s\n' "${changed_cpp_array[@]}"
+      - name: Make (clang-tidy)
+        run: |
+          set -euo pipefail
+          mapfile -t build_args < <(printf '%s\n' "$CLANG_TIDY_BUILD_ARGS" | sed '/^$/d')
+          TR_CLANG_TIDY_ENABLE=1 cmake "${build_args[@]}" 2>&1 | tee -a makelog
       - name: Test for warnings
         run: |
           if grep 'warning:' makelog; then exit 1; fi

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -251,6 +251,7 @@ jobs:
           build-config: Debug
           enable-sanitizers: true
 
+  # todo(ckerr): add gtk4 once 26.04 is released
   clang-tidy-posix:
     name: clang-tidy-posix (${{ matrix.label }})
     strategy:
@@ -264,10 +265,6 @@ jobs:
           - label: gtk3
             kind: gtk
             gtk: 'gtk3'
-            qt: 'false'
-          - label: gtk4
-            kind: gtk
-            gtk: 'gtk4'
             qt: 'false'
           - label: qt5
             kind: qt

--- a/cmake/TrMacros.cmake
+++ b/cmake/TrMacros.cmake
@@ -21,7 +21,8 @@ macro(tr_setup_gtest_target TARGET_NAME TEST_PREFIX)
 
     if(NOT CMAKE_CROSSCOMPILING OR CMAKE_CROSSCOMPILING_EMULATOR)
         gtest_discover_tests(${TARGET_NAME}
-            TEST_PREFIX "${TEST_PREFIX}")
+            TEST_PREFIX "${TEST_PREFIX}"
+            DISCOVERY_MODE PRE_TEST)
     else()
         add_test(
             NAME ${TARGET_NAME}

--- a/libtransmission/string-utils.h
+++ b/libtransmission/string-utils.h
@@ -44,7 +44,7 @@ template <typename T> [[nodiscard]] std::string tr_strupper(T in)
 [[nodiscard]] bool tr_wildmat(char const* text, char const* pattern);
 
 // c++23 (P1679R3), GCC 11.1, clang 12
-template <typename T> [[nodiscard]] constexpr bool tr_strv_contains(std::string_view sv, T key) noexcept
+template <typename T> [[nodiscard]] constexpr bool tr_strv_contains(std::string_view sv, T const& key) noexcept
 {
     return sv.find(key) != std::string_view::npos;
 }


### PR DESCRIPTION
~~This is an experiment to try & speed up clang-tidy jobs. I'm marking this as 'draft' because I haven't tested it yet, but feedback on the idea & impl are both welcomed.~~ **edit:** ready for review

The basic idea is this:

1. Add a wrapper script to invoke the compiler. In this script, check an environment variable to decide whether or not to use clang-tidy. This script lets us toggle clang-tidy on and off without changing the CMake rules.
2. Run cmake with clang-tidy turned off. This should give us a fast build for the project.
3. Touch the files that were changed/added in the PR
4. Run cmake again with clang-tidy turned on. This gives us a clang-tidy pass on changed files + files that include a changed header.

Special case: if `.clang-tidy` config files change, we run clang-tidy on everything.