### PR TITLE
fix: FTBFS with glibmm 2.68

### DIFF
--- a/gtk/Torrent.cc
+++ b/gtk/Torrent.cc
@@ -247,7 +247,7 @@ Torrent::ChangeFlags Torrent::Impl::update_cache()
     auto const has_seed_ratio = tr_torrentGetSeedRatio(raw_torrent_, &seed_ratio);
     auto const view = tr_torrentView(raw_torrent_);
 
-    update_cache_value(cache_.name, view.name, result, ChangeFlag::NAME);
+    update_cache_value(cache_.name, Glib::ustring{ view.name }, result, ChangeFlag::NAME);
     update_cache_value(cache_.speed_up, stats.piece_upload_speed, result, ChangeFlag::SPEED_UP);
     update_cache_value(cache_.speed_down, stats.piece_download_speed, result, ChangeFlag::SPEED_DOWN);
     update_cache_value(cache_.active_peers_up, stats.peers_getting_from_us, result, ChangeFlag::ACTIVE_PEERS_UP);
@@ -277,7 +277,7 @@ Torrent::ChangeFlags Torrent::Impl::update_cache()
     update_cache_value(cache_.queue_position, stats.queue_position, result, ChangeFlag::QUEUE_POSITION);
     update_cache_value(cache_.trackers, build_torrent_trackers_hash(*raw_torrent_), result, ChangeFlag::TRACKERS);
     update_cache_value(cache_.error_code, stats.error, result, ChangeFlag::ERROR_CODE);
-    update_cache_value(cache_.error_message, stats.error_string, result, ChangeFlag::ERROR_MESSAGE);
+    update_cache_value(cache_.error_message, Glib::ustring{ stats.error_string }, result, ChangeFlag::ERROR_MESSAGE);
     update_cache_value(
         cache_.active_peer_count,
         stats.peers_sending_to_us + stats.peers_getting_from_us + stats.webseeds_sending_to_us,


### PR DESCRIPTION
fix FTBFS  found by https://build.transmissionbt.com/job/trunk-linux/lastFailedBuild/console

```
15:09:07 In file included from /usr/include/giomm-2.68/giomm/icon.h:8,
15:09:07                  from /home/fedora/jenkins/workspace/trunk-linux/transmission-4.1.0-beta.5+r1b1ccc08dc/gtk/Torrent.h:13,
15:09:07                  from /home/fedora/jenkins/workspace/trunk-linux/transmission-4.1.0-beta.5+r1b1ccc08dc/gtk/Torrent.cc:6:
15:09:07 /usr/include/glibmm-2.68/glibmm/ustring.h: In instantiation of ‘bool Glib::operator!=(const ustring&, const T&) [with T = std::__cxx11::basic_string<char>; <template-parameter-1-2> = void]’:
15:09:07 /home/fedora/jenkins/workspace/trunk-linux/transmission-4.1.0-beta.5+r1b1ccc08dc/gtk/Torrent.cc:43:15:   required from ‘void {anonymous}::update_cache_value(T&, U&&, Torrent::ChangeFlags&, Torrent::ChangeFlag) [with T = Glib::ustring; U = const std::__cxx11::basic_string<char>&; Torrent::ChangeFlags = Flags<Torrent::ChangeFlag>]’
15:09:07    43 |     if (value != new_value)
15:09:07       |         ~~~~~~^~~~~~~~~~~~
15:09:07 /home/fedora/jenkins/workspace/trunk-linux/transmission-4.1.0-beta.5+r1b1ccc08dc/gtk/Torrent.cc:280:23:   required from here
15:09:07   280 |     update_cache_value(cache_.error_message, stats.error_string, result, ChangeFlag::ERROR_MESSAGE);
15:09:07       |     ~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
15:09:07 /usr/include/glibmm-2.68/glibmm/ustring.h:1516:22: error: no matching function for call to ‘Glib::ustring::compare(const std::__cxx11::basic_string<char>&) const’
15:09:07  1516 |   return (lhs.compare(rhs) != 0);
15:09:07       |           ~~~~~~~~~~~^~~~~
15:09:07 /usr/include/glibmm-2.68/glibmm/ustring.h:541:18: note: candidate: ‘int Glib::ustring::compare(Glib::UStringView) const’
15:09:07   541 |   GLIBMM_API int compare(UStringView rhs) const;`
```

```
14:45:05 -- Checking for modules 'gtkmm-4.0>=4.11.1;glibmm-2.68>=2.60.0;giomm-2.68>=2.26.0'
14:45:05 --   Found gtkmm-4.0, version 4.14.0
14:45:05 --   Found glibmm-2.68, version 2.80.0
14:45:05 --   Found giomm-2.68, version 2.80.0
```
