### PR TITLE
fix: fail when encountering invalid benc character

### DIFF
--- a/libtransmission/benc.h
+++ b/libtransmission/benc.h
@@ -386,8 +386,9 @@ bool parse(
             }
             break;
 
-        default: // invalid bencoded text... march past it
-            benc.remove_prefix(1);
+        default:
+            err = EILSEQ;
+            error->set(err, "Malformed benc? invalid bencoded text");
             break;
         }
 

--- a/tests/libtransmission/torrent-metainfo-test.cc
+++ b/tests/libtransmission/torrent-metainfo-test.cc
@@ -51,7 +51,7 @@ TEST_F(TorrentMetainfoTest, magnetLink)
 #define BEFORE_PATH \
     "d10:created by25:Transmission/2.82 (14160)13:creation datei1402280218e8:encoding5:UTF-84:infod5:filesld6:lengthi2e4:pathl"
 #define AFTER_PATH \
-    "eed6:lengthi2e4:pathl5:b.txteee4:name3:foo12:piece lengthi32768e6:pieces20:ÞÉ`âMs¡Å;Ëº¬.åÂà7:privatei0eee"
+    "eed6:lengthi2e4:pathl5:b.txteee4:name3:foo12:piece lengthi32768e6:pieces20:aaaaaaaaaaaaaaaaaaaa7:privatei0eee"
 
 // FIXME: split these into parameterized tests?
 TEST_F(TorrentMetainfoTest, bucket)
@@ -62,7 +62,7 @@ TEST_F(TorrentMetainfoTest, bucket)
         bool expected_parse_result;
     };
 
-    auto const tests = std::array<LocalTest, 9>{ {
+    static auto constexpr Tests = std::array<LocalTest, 12U>{ {
         { BEFORE_PATH "5:a.txt" AFTER_PATH, true },
         // allow empty components, but not =all= empty components, see bug #5517
         { BEFORE_PATH "0:5:a.txt" AFTER_PATH, true },
@@ -75,16 +75,21 @@ TEST_F(TorrentMetainfoTest, bucket)
         // allow ".." components (replaced with "__")
         { BEFORE_PATH "2:..5:a.txt" AFTER_PATH, true },
         { BEFORE_PATH "5:a.txt2:.." AFTER_PATH, true },
+        // fail when coming across an invalid character
+        { "dhe", false },
+        { "d10:longer than 10 characterse", false },
+        // fail when string is too short
+        { "d10:short", false },
         // fail on empty string
         { "", false },
     } };
 
     tr_logSetLevel(TR_LOG_OFF);
 
-    for (auto const& test : tests)
+    for (auto const& [benc, expected_parse_result] : Tests)
     {
         auto metainfo = tr_torrent_metainfo{};
-        EXPECT_EQ(test.expected_parse_result, metainfo.parse_benc(test.benc));
+        EXPECT_EQ(expected_parse_result, metainfo.parse_benc(benc));
     }
 }
 


### PR DESCRIPTION
Cherry-pick #8573.

Notes: Reject benc data that has invalid characters.