### PR TITLE
Optimize cells reloading in hovering related events.

### DIFF
--- a/macosx/TorrentTableView.mm
+++ b/macosx/TorrentTableView.mm
@@ -52,17 +52,19 @@ static NSTimeInterval const kToggleProgressSeconds = 0.175;
 @end
 
 @interface TorrentTableViewHoveringData : NSObject<NSCopying>
-@property(nonatomic, nullable) NSNumber *hoveredRow;
-@property(nonatomic, nullable) NSString *statusText;
+@property(nonatomic, nullable) NSNumber* hoveredRow;
+@property(nonatomic, nullable) NSString* statusText;
 @property(nonatomic, readonly) BOOL isHovered;
 @end
 @implementation TorrentTableViewHoveringData
-- (BOOL)isHovered {
+- (BOOL)isHovered
+{
     return self.hoveredRow != nil && self.hoveredRow.integerValue != -1;
 }
 
-- (nonnull id)copyWithZone:(nullable NSZone *)zone {
-    __auto_type copy = (TorrentTableViewHoveringData *)[[self.class alloc] init];
+- (nonnull id)copyWithZone:(nullable NSZone*)zone
+{
+    __auto_type copy = (TorrentTableViewHoveringData*)[[self.class alloc] init];
     copy.hoveredRow = self.hoveredRow;
     copy.statusText = self.statusText;
     return copy;
@@ -88,7 +90,7 @@ static NSTimeInterval const kToggleProgressSeconds = 0.175;
 @property(nonatomic) BOOL fActionPopoverShown;
 @property(nonatomic) NSView* fPositioningView;
 
-@property(nonatomic) TorrentTableViewHoveringData *hoveringData;
+@property(nonatomic) TorrentTableViewHoveringData* hoveringData;
 
 @property(nonatomic) NSMutableIndexSet* fPendingSelectionReloadRows;
 
@@ -724,7 +726,7 @@ static NSTimeInterval const kToggleProgressSeconds = 0.175;
     NSInteger row = [self rowForView:view];
     Torrent* torrent = [self itemAtRow:row];
 
-    __auto_type previouslyHovered = (TorrentTableViewHoveringData *)[self.hoveringData copy];
+    __auto_type previouslyHovered = (TorrentTableViewHoveringData*)[self.hoveringData copy];
     BOOL minimal = [self.fDefaults boolForKey:@"SmallView"];
     if (minimal)
     {
@@ -778,13 +780,15 @@ static NSTimeInterval const kToggleProgressSeconds = 0.175;
         }
     }
 
-    if (previouslyHovered.isHovered) {
-        NSMutableIndexSet *indexSet = [[NSMutableIndexSet alloc] init];
+    if (previouslyHovered.isHovered)
+    {
+        NSMutableIndexSet* indexSet = [[NSMutableIndexSet alloc] init];
         [indexSet addIndex:previouslyHovered.hoveredRow.integerValue];
         [indexSet addIndex:row];
         [self reloadDataForRowIndexes:indexSet columnIndexes:[NSIndexSet indexSetWithIndex:0]];
     }
-    else {
+    else
+    {
         [self reloadDataForRowIndexes:[NSIndexSet indexSetWithIndex:row] columnIndexes:[NSIndexSet indexSetWithIndex:0]];
     }
 }
@@ -810,16 +814,18 @@ static NSTimeInterval const kToggleProgressSeconds = 0.175;
 
     if (update)
     {
-        __auto_type previouslyHovered = (TorrentTableViewHoveringData *)[self.hoveringData copy];
+        __auto_type previouslyHovered = (TorrentTableViewHoveringData*)[self.hoveringData copy];
         self.hoveringData.hoveredRow = nil;
         self.hoveringData.statusText = nil;
-        if (previouslyHovered.isHovered) {
-            NSMutableIndexSet *indexSet = [[NSMutableIndexSet alloc] init];
+        if (previouslyHovered.isHovered)
+        {
+            NSMutableIndexSet* indexSet = [[NSMutableIndexSet alloc] init];
             [indexSet addIndex:previouslyHovered.hoveredRow.integerValue];
             [indexSet addIndex:row];
             [self reloadDataForRowIndexes:indexSet columnIndexes:[NSIndexSet indexSetWithIndex:0]];
         }
-        else {
+        else
+        {
             [self reloadDataForRowIndexes:[NSIndexSet indexSetWithIndex:row] columnIndexes:[NSIndexSet indexSetWithIndex:0]];
         }
     }


### PR DESCRIPTION
### Description
This PR optimizes the cell reloading logic when handling hover-related events in the UI. Previously, hovering over elements triggered redundant or full cell redraws, leading to unnecessary CPU usage and potential UI stuttering in large torrent lists. 

### Changes
* Optimized the conditions under which cells are reloaded during mouse hover events.
* Reduced redundant cell updates to ensure smoother scrolling and UI interaction.
* Fixed unnecessary layout recalculations triggered by hover states.

### Impact
* **Performance:** Lower CPU consumption during list interactions.
* **UX:** Smoother hovering effect and more responsive scrolling, especially visible in configurations with hundreds of active torrents.

### Testing Done
* Verified that hover states (tooltips, highlights) still render correctly.
* Checked for regressions in cell selection and context menu triggers.

### Results

#### Before

https://github.com/user-attachments/assets/b4683a3a-050e-4039-ac75-c9c460dd453b

#### After

https://github.com/user-attachments/assets/03783f90-ec82-469b-b793-32bd12ced6b2