### PR TITLE
fix: Use pre-clang-format-21 syntax

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -34,8 +34,7 @@ PenaltyBreakBeforeFirstCallParameter: 0
 PenaltyReturnTypeOnItsOwnLine: 1000
 PointerAlignment: Left
 ReflowComments: Never
-SortIncludes:
-  Enabled: false
+SortIncludes: Never
 SpaceAfterCStyleCast: false
 SpacesBeforeTrailingComments: 1
 SpacesInAngles: Never


### PR DESCRIPTION
Revert to pre-clang-format-21 syntax to fix an error.

```
/home/runner/work/transmission/transmission/./.clang-format:38:3: error: unknown enumerated scalar
  Enabled: false
  ^
```