### PR TITLE
fix: time display in press dropdown

### DIFF
--- a/web/src/prefs-dialog.js
+++ b/web/src/prefs-dialog.js
@@ -15,7 +15,7 @@ import {
 export class PrefsDialog extends EventTarget {
   static _initTimeDropDown(e) {
     for (let index = 0; index < 24 * 4; ++index) {
-      const hour = index / 4;
+      const hour = (index / 4) | 0;
       const mins = (index % 4) * 15;
       const value = index * 15;
       const content = `${hour}:${mins || '00'}`;


### PR DESCRIPTION
Notes: Fixed the Time dropdowns displaying 6:45 as 6.75:45

<img width="379" height="383" alt="image" src="https://github.com/user-attachments/assets/99c3e9dd-a593-4abd-9bd8-51040e552862" />
