### PR TITLE
fix: reset metainfo before parsing new benc

### DIFF
--- a/libtransmission/torrent-metainfo.cc
+++ b/libtransmission/torrent-metainfo.cc
@@ -652,6 +652,10 @@ private:
 
 bool tr_torrent_metainfo::parse_benc(std::string_view benc, tr_error* error)
 {
+    // Reset the object to avoid accidentally failing checks
+    // because of the old data
+    *this = tr_torrent_metainfo{};
+
     auto stack = tr::benc::ParserStack<MaxBencDepth>{};
     auto handler = MetainfoHandler{ *this };
 


### PR DESCRIPTION
Fixes #8587.

Notes: Fixed a bug during the startup sequence where if one torrent failed to parse, all subsequent torrents will also fail with a bogus error.