### PR TITLE
fix: `modernize-use-ranges` in `peer-*.cc`

### DIFF
--- a/libtransmission/net.cc
+++ b/libtransmission/net.cc
@@ -602,16 +602,26 @@ std::optional<unsigned> tr_address::to_interface_index() const noexcept
     return {};
 }
 
-int tr_address::compare(tr_address const& that) const noexcept // <=>
+std::strong_ordering tr_address::operator<=>(tr_address const& that) const noexcept
 {
     // IPv6 addresses are always "greater than" IPv4
-    if (auto const val = tr_compare_3way(this->type, that.type); val != 0)
+    if (auto const val = this->type <=> that.type; val != 0)
     {
         return val;
     }
 
-    return this->is_ipv4() ? memcmp(&this->addr.addr4, &that.addr.addr4, sizeof(this->addr.addr4)) :
-                             memcmp(&this->addr.addr6.s6_addr, &that.addr.addr6.s6_addr, sizeof(this->addr.addr6.s6_addr));
+    auto const val = this->is_ipv4() ?
+        memcmp(&this->addr.addr4, &that.addr.addr4, sizeof(this->addr.addr4)) :
+        memcmp(&this->addr.addr6.s6_addr, &that.addr.addr6.s6_addr, sizeof(this->addr.addr6.s6_addr));
+    if (val < 0)
+    {
+        return std::strong_ordering::less;
+    }
+    if (val > 0)
+    {
+        return std::strong_ordering::greater;
+    }
+    return std::strong_ordering::equal;
 }
 
 // https://en.wikipedia.org/wiki/Reserved_IP_addresses

--- a/libtransmission/peer-mgr.h
+++ b/libtransmission/peer-mgr.h
@@ -649,19 +649,14 @@ struct tr_pex
         return socket_address.display_name();
     }
 
-    [[nodiscard]] int compare(tr_pex const& that) const noexcept // <=>
+    [[nodiscard]] auto operator<=>(tr_pex const& that) const noexcept
     {
-        return socket_address.compare(that.socket_address);
+        return socket_address <=> that.socket_address;
     }
 
     [[nodiscard]] bool operator==(tr_pex const& that) const noexcept
     {
-        return compare(that) == 0;
-    }
-
-    [[nodiscard]] bool operator<(tr_pex const& that) const noexcept
-    {
-        return compare(that) < 0;
+        return (*this <=> that) == 0;
     }
 
     [[nodiscard]] bool is_valid() const noexcept

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -1042,20 +1042,10 @@ void tr_peerMsgsImpl::send_ut_pex()
         auto new_pex = tr_peerMgrGetPeers(&tor_, ip_type, TR_PEERS_CONNECTED, MaxPexPeerCount);
         auto added = std::vector<tr_pex>{};
         added.reserve(std::size(new_pex));
-        std::set_difference(
-            std::begin(new_pex),
-            std::end(new_pex),
-            std::begin(old_pex),
-            std::end(old_pex),
-            std::back_inserter(added));
+        std::ranges::set_difference(new_pex, old_pex, std::back_inserter(added));
         auto dropped = std::vector<tr_pex>{};
         dropped.reserve(std::size(old_pex));
-        std::set_difference(
-            std::begin(old_pex),
-            std::end(old_pex),
-            std::begin(new_pex),
-            std::end(new_pex),
-            std::back_inserter(dropped));
+        std::ranges::set_difference(old_pex, new_pex, std::back_inserter(dropped));
 
         // Some peers give us error messages if we send
         // more than this many peers in a single pex message.

--- a/tests/libtransmission/net-test.cc
+++ b/tests/libtransmission/net-test.cc
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <array>
+#include <compare>
 #include <cstddef> // std::byte, size_t
 #include <string_view>
 #include <tuple>
@@ -921,14 +922,14 @@ TEST_F(NetTest, isIPv6Multicast)
 TEST_F(NetTest, ipCompare)
 {
     static constexpr auto IpPairs = std::array{
-        std::tuple{ "223.18.245.229"sv, "8.8.8.8"sv, 1 },
-        std::tuple{ "0.0.0.0"sv, "255.255.255.255"sv, -1 },
-        std::tuple{ "8.8.8.8"sv, "8.8.8.8"sv, 0 },
-        std::tuple{ "8.8.8.8"sv, "2001:0:0eab:dead::a0:abcd:4e"sv, -1 },
-        std::tuple{ "2001:1890:1112:1::20"sv, "2001:0:0eab:dead::a0:abcd:4e"sv, 1 },
-        std::tuple{ "2001:1890:1112:1::20"sv, "[2001:0:0eab:dead::a0:abcd:4e]"sv, 1 },
-        std::tuple{ "2001:1890:1112:1::20"sv, "2001:1890:1112:1::20"sv, 0 },
-        std::tuple{ "2001:1890:1112:1::20"sv, "[2001:1890:1112:1::20]"sv, 0 },
+        std::tuple{ "223.18.245.229"sv, "8.8.8.8"sv, std::strong_ordering::greater },
+        std::tuple{ "0.0.0.0"sv, "255.255.255.255"sv, std::strong_ordering::less },
+        std::tuple{ "8.8.8.8"sv, "8.8.8.8"sv, std::strong_ordering::equal },
+        std::tuple{ "8.8.8.8"sv, "2001:0:0eab:dead::a0:abcd:4e"sv, std::strong_ordering::less },
+        std::tuple{ "2001:1890:1112:1::20"sv, "2001:0:0eab:dead::a0:abcd:4e"sv, std::strong_ordering::greater },
+        std::tuple{ "2001:1890:1112:1::20"sv, "[2001:0:0eab:dead::a0:abcd:4e]"sv, std::strong_ordering::greater },
+        std::tuple{ "2001:1890:1112:1::20"sv, "2001:1890:1112:1::20"sv, std::strong_ordering::equal },
+        std::tuple{ "2001:1890:1112:1::20"sv, "[2001:1890:1112:1::20]"sv, std::strong_ordering::equal },
     };
 
     for (auto const& [sv1, sv2, res] : IpPairs)
@@ -936,12 +937,13 @@ TEST_F(NetTest, ipCompare)
         auto const ip1 = *tr_address::from_string(sv1);
         auto const ip2 = *tr_address::from_string(sv2);
 
-        EXPECT_EQ(ip1.compare(ip2) < 0, res < 0) << sv1 << ' ' << sv2;
-        EXPECT_EQ(ip1.compare(ip2) > 0, res > 0) << sv1 << ' ' << sv2;
-        EXPECT_EQ(ip1.compare(ip2) == 0, res == 0) << sv1 << ' ' << sv2;
+        EXPECT_EQ(ip1 <=> ip2, res) << sv1 << ' ' << sv2;
         EXPECT_EQ(ip1 < ip2, res < 0) << sv1 << ' ' << sv2;
+        EXPECT_EQ(ip1 <= ip2, res <= 0) << sv1 << ' ' << sv2;
         EXPECT_EQ(ip1 > ip2, res > 0) << sv1 << ' ' << sv2;
+        EXPECT_EQ(ip1 >= ip2, res >= 0) << sv1 << ' ' << sv2;
         EXPECT_EQ(ip1 == ip2, res == 0) << sv1 << ' ' << sv2;
+        EXPECT_EQ(ip1 != ip2, res != 0) << sv1 << ' ' << sv2;
     }
 }
 


### PR DESCRIPTION
Similar to #8594, splitting out these changes from fixing `modernize-use-ranges` everywhere else because the fixes are not trivial.

Notes: Moved from C++17 to C++20.