### PR TITLE
fix: eliminate torrents list retain cycles

### DIFF
--- a/macosx/TorrentCell.h
+++ b/macosx/TorrentCell.h
@@ -24,6 +24,6 @@
 
 @property(nonatomic) IBOutlet NSView* fTorrentProgressBarView;
 
-@property(nonatomic) TorrentTableView* fTorrentTableView;
+@property(nonatomic, weak) TorrentTableView* fTorrentTableView;
 
 @end

--- a/macosx/TorrentCellActionButton.mm
+++ b/macosx/TorrentCellActionButton.mm
@@ -11,7 +11,7 @@
 @property(nonatomic) NSTrackingArea* fTrackingArea;
 @property(nonatomic) NSImage* fImage;
 @property(nonatomic) NSImage* fAlternativeImage;
-@property(nonatomic) IBOutlet TorrentCell* torrentCell;
+@property(nonatomic, weak) IBOutlet TorrentCell* torrentCell;
 @property(nonatomic, readonly) TorrentTableView* torrentTableView;
 @property(nonatomic) NSUserDefaults* fDefaults;
 @end

--- a/macosx/TorrentCellControlButton.mm
+++ b/macosx/TorrentCellControlButton.mm
@@ -10,7 +10,7 @@
 @interface TorrentCellControlButton ()
 @property(nonatomic) NSTrackingArea* fTrackingArea;
 @property(nonatomic, copy) NSString* controlImageSuffix;
-@property(nonatomic) IBOutlet TorrentCell* torrentCell;
+@property(nonatomic, weak) IBOutlet TorrentCell* torrentCell;
 @property(nonatomic, readonly) TorrentTableView* torrentTableView;
 @end
 

--- a/macosx/TorrentCellRevealButton.mm
+++ b/macosx/TorrentCellRevealButton.mm
@@ -9,7 +9,7 @@
 @interface TorrentCellRevealButton ()
 @property(nonatomic) NSTrackingArea* fTrackingArea;
 @property(nonatomic, copy) NSString* revealImageString;
-@property(nonatomic) IBOutlet TorrentCell* torrentCell;
+@property(nonatomic, weak) IBOutlet TorrentCell* torrentCell;
 @property(nonatomic, readonly) TorrentTableView* torrentTableView;
 @end
 


### PR DESCRIPTION
Surprisingly these are retain cycles.

I thought that cell reuse policy will work here.

### How to catch on main branch

1. Run Transmission
2. Choose compact view mode.
3. Press Cmd + W to close main window.
4. Open app from dock ( reveal main window ).
5. Repeat 3 and 4 ten times or more. 

At this point open memory debugger.

Now you can observe 50+ SmallTorrentCells even if you have nearly 10 or 20 torrents.
Repeat more and gain more.

---

@ckerr edit:

- `TorrentCell` -- `TorrentTableView` retain cycle introduced in #5147 
- `TorrentCell` -- `Button` cycles introduced in #6207 

Notes: Fixed `4.1.0` memory leak in macOS UI.