### PR TITLE
fix: show translated logging level strings

### DIFF
--- a/gtk/MessageLogWindow.cc
+++ b/gtk/MessageLogWindow.cc
@@ -44,6 +44,8 @@
 #include <ranges>
 #include <utility>
 
+#define LOGGING_LEVEL_CONTEXT "Logging level"
+
 class MessageLogColumnsModel : public Gtk::TreeModelColumnRecord
 {
 public:
@@ -102,13 +104,12 @@ private:
     bool isPaused_ = false;
     sigc::connection refresh_tag_;
 
-    // NOLINTNEXTLINE(cert-err58-cpp)
-    static auto inline const level_names_ = std::array<std::pair<tr_log_level, char const*>, 5U>{ {
-        { TR_LOG_CRITICAL, C_("Logging level", "Critical") },
-        { TR_LOG_ERROR, C_("Logging level", "Error") },
-        { TR_LOG_WARN, C_("Logging level", "Warning") },
-        { TR_LOG_INFO, C_("Logging level", "Information") },
-        { TR_LOG_DEBUG, C_("Logging level", "Debug") },
+    static auto constexpr level_names_ = std::array<std::pair<tr_log_level, char const*>, 5U>{ {
+        { TR_LOG_CRITICAL, NC_(LOGGING_LEVEL_CONTEXT, "Critical") },
+        { TR_LOG_ERROR, NC_(LOGGING_LEVEL_CONTEXT, "Error") },
+        { TR_LOG_WARN, NC_(LOGGING_LEVEL_CONTEXT, "Warning") },
+        { TR_LOG_INFO, NC_(LOGGING_LEVEL_CONTEXT, "Information") },
+        { TR_LOG_DEBUG, NC_(LOGGING_LEVEL_CONTEXT, "Debug") },
     } };
 };
 
@@ -181,7 +182,7 @@ void MessageLogWindow::Impl::level_combo_init(Gtk::ComboBox* level_combo)
     items.reserve(std::size(level_names_));
     for (auto const& [level, name] : level_names_)
     {
-        items.emplace_back(name, level);
+        items.emplace_back(g_dpgettext2(nullptr, LOGGING_LEVEL_CONTEXT, name), level);
         has_pref_level |= level == pref_level;
     }
 
@@ -233,7 +234,9 @@ void MessageLogWindow::Impl::doSave(std::string const& filename)
             auto const iter = std::ranges::find_if(
                 level_names_,
                 [key = node->level](auto const& item) { return item.first == key; });
-            auto const* const level_str = iter != std::ranges::end(level_names_) ? iter->second : "???";
+            auto const level_str = iter != std::ranges::end(level_names_) ?
+                Glib::ustring(g_dpgettext2(nullptr, LOGGING_LEVEL_CONTEXT, iter->second)) :
+                Glib::ustring("???");
 
             fmt::print(stream, "{}\t{}\t{}\t{}\n", date, level_str, node->name, node->message);
         }


### PR DESCRIPTION
Fixes #8604.

Breadcrumbs to my future self: tested manually with

```sh
$ ninja transmission-gtk-po
$ ninja install
$ LANG=de_DE.UTF-8 LANGUAGE=de_DE:de LC_MESSAGES=de_DE.UTF-8 path/to//installed/transmission-gtk
```

Notes: Fixed `4.1.0` bug that did not show translated logging level strings.