### PR TITLE
fix: eliminate torrents list retain cycles  4.1.x

### DIFF
--- a/macosx/TorrentCell.h
+++ b/macosx/TorrentCell.h
@@ -24,6 +24,6 @@
 
 @property(nonatomic) IBOutlet NSView* fTorrentProgressBarView;
 
-@property(nonatomic) TorrentTableView* fTorrentTableView;
+@property(nonatomic, weak) TorrentTableView* fTorrentTableView;
 
 @end

--- a/macosx/TorrentCellActionButton.mm
+++ b/macosx/TorrentCellActionButton.mm
@@ -11,7 +11,7 @@
 @property(nonatomic) NSTrackingArea* fTrackingArea;
 @property(nonatomic) NSImage* fImage;
 @property(nonatomic) NSImage* fAlternativeImage;
-@property(nonatomic) IBOutlet TorrentCell* torrentCell;
+@property(nonatomic, weak) IBOutlet TorrentCell* torrentCell;
 @property(nonatomic, readonly) TorrentTableView* torrentTableView;
 @property(nonatomic) NSUserDefaults* fDefaults;
 @end

--- a/macosx/TorrentCellControlButton.mm
+++ b/macosx/TorrentCellControlButton.mm
@@ -10,7 +10,7 @@
 @interface TorrentCellControlButton ()
 @property(nonatomic) NSTrackingArea* fTrackingArea;
 @property(nonatomic, copy) NSString* controlImageSuffix;
-@property(nonatomic) IBOutlet TorrentCell* torrentCell;
+@property(nonatomic, weak) IBOutlet TorrentCell* torrentCell;
 @property(nonatomic, readonly) TorrentTableView* torrentTableView;
 @end
 

--- a/macosx/TorrentCellRevealButton.mm
+++ b/macosx/TorrentCellRevealButton.mm
@@ -9,7 +9,7 @@
 @interface TorrentCellRevealButton ()
 @property(nonatomic) NSTrackingArea* fTrackingArea;
 @property(nonatomic, copy) NSString* revealImageString;
-@property(nonatomic) IBOutlet TorrentCell* torrentCell;
+@property(nonatomic, weak) IBOutlet TorrentCell* torrentCell;
 @property(nonatomic, readonly) TorrentTableView* torrentTableView;
 @end
 


### PR DESCRIPTION
Cherry-pick #8603 to `4.1.x`.

Notes: Fixed a `4.1.0` memory leak.