### PR TITLE
fixup! fix: show translated logging level strings (#8609)

### DIFF
--- a/gtk/MessageLogWindow.cc
+++ b/gtk/MessageLogWindow.cc
@@ -44,7 +44,9 @@
 #include <ranges>
 #include <utility>
 
-#define LOGGING_LEVEL_CONTEXT "Logging level"
+namespace
+{
+static auto LoggingLevelContext = "Logging level";
 
 class MessageLogColumnsModel : public Gtk::TreeModelColumnRecord
 {
@@ -64,6 +66,8 @@ public:
 };
 
 MessageLogColumnsModel const message_log_cols;
+
+} // namespace
 
 class MessageLogWindow::Impl
 {
@@ -105,11 +109,11 @@ private:
     sigc::connection refresh_tag_;
 
     static auto constexpr level_names_ = std::array<std::pair<tr_log_level, char const*>, 5U>{ {
-        { TR_LOG_CRITICAL, NC_(LOGGING_LEVEL_CONTEXT, "Critical") },
-        { TR_LOG_ERROR, NC_(LOGGING_LEVEL_CONTEXT, "Error") },
-        { TR_LOG_WARN, NC_(LOGGING_LEVEL_CONTEXT, "Warning") },
-        { TR_LOG_INFO, NC_(LOGGING_LEVEL_CONTEXT, "Information") },
-        { TR_LOG_DEBUG, NC_(LOGGING_LEVEL_CONTEXT, "Debug") },
+        { TR_LOG_CRITICAL, NC_(LoggingLevelContext, "Critical") },
+        { TR_LOG_ERROR, NC_(LoggingLevelContext, "Error") },
+        { TR_LOG_WARN, NC_(LoggingLevelContext, "Warning") },
+        { TR_LOG_INFO, NC_(LoggingLevelContext, "Information") },
+        { TR_LOG_DEBUG, NC_(LoggingLevelContext, "Debug") },
     } };
 };
 
@@ -182,7 +186,7 @@ void MessageLogWindow::Impl::level_combo_init(Gtk::ComboBox* level_combo)
     items.reserve(std::size(level_names_));
     for (auto const& [level, name] : level_names_)
     {
-        items.emplace_back(g_dpgettext2(nullptr, LOGGING_LEVEL_CONTEXT, name), level);
+        items.emplace_back(g_dpgettext2(nullptr, LoggingLevelContext, name), level);
         has_pref_level |= level == pref_level;
     }
 
@@ -235,7 +239,7 @@ void MessageLogWindow::Impl::doSave(std::string const& filename)
                 level_names_,
                 [key = node->level](auto const& item) { return item.first == key; });
             auto const level_str = iter != std::ranges::end(level_names_) ?
-                Glib::ustring(g_dpgettext2(nullptr, LOGGING_LEVEL_CONTEXT, iter->second)) :
+                Glib::ustring(g_dpgettext2(nullptr, LoggingLevelContext, iter->second)) :
                 Glib::ustring("???");
 
             fmt::print(stream, "{}\t{}\t{}\t{}\n", date, level_str, node->name, node->message);


### PR DESCRIPTION
fix new clang-tidy warning that landed yesterday in #8609