### PR TITLE
PoC. Layer backed badge view.

### DIFF
--- a/macosx/BadgeView.h
+++ b/macosx/BadgeView.h
@@ -4,6 +4,12 @@
 
 #import <AppKit/AppKit.h>
 
+@interface BadgeView2 : NSView
+
+- (BOOL)setRatesWithDownload:(CGFloat)downloadRate upload:(CGFloat)uploadRate;
+
+@end
+
 @interface BadgeView : NSView
 
 - (BOOL)setRatesWithDownload:(CGFloat)downloadRate upload:(CGFloat)uploadRate;


### PR DESCRIPTION
`drawInRect` doesn't utilize GPU and it is very CPU-unfriendly.
Layer-backed views are a lot more performant.

In this example:

```
/// Old BadgeView with drawInRect.
Old Update Happened: 0.011314
Old Update Happened: 0.002114
Old Update Happened: 0.001836
Old Update Happened: 0.002104
Old Update Happened: 0.001878

/// New BadgeView with layers.
New Update happened: 0.000007
New Update happened: 0.000004
New Update happened: 0.000012
New Update happened: 0.000003
New Update happened: 0.000003
New Update happened: 0.000004
```

The same approach can be used in other views with heavy computations like ProgressBar in TorrentCell.

N.B.

This code is written by A.I. ( mostly ) so it is not very... good.