### PR TITLE
fix: time display in press dropdown

### DIFF
--- a/web/src/prefs-dialog.js
+++ b/web/src/prefs-dialog.js
@@ -15,7 +15,7 @@ import {
 export class PrefsDialog extends EventTarget {
   static _initTimeDropDown(e) {
     for (let index = 0; index < 24 * 4; ++index) {
-      const hour = index / 4;
+      const hour = (index / 4) | 0;
       const mins = (index % 4) * 15;
       const value = index * 15;
       const content = `${hour}:${mins || '00'}`;


### PR DESCRIPTION
Cherry-pick #8588 for `4.1.x`.

Notes: Fixed a `4.1.0` bug that displayed timestamps in some dropdowns as `6.75:45` instead of `6:45`
