### PR TITLE
fix: add timeout to session shutdown to prevent deadlock on quit

### DIFF
--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -1479,16 +1479,39 @@ void tr_sessionClose(tr_session* session, double const timeout_secs)
     TR_ASSERT(session != nullptr);
     TR_ASSERT(!session->am_in_session_thread());
 
+    using namespace std::chrono_literals;
+
     tr_logAddInfo(
         fmt::format(fmt::runtime(_("Transmission version {version} shutting down")), fmt::arg("version", LONG_VERSION_STRING)));
 
-    auto closed_promise = std::promise<void>{};
-    auto closed_future = closed_promise.get_future();
+    // The promise lives on the heap: on the timeout path below, the session
+    // thread may still fulfil it later, so it must be able to outlive this
+    // function's stack frame.
+    auto closed_promise = std::make_unique<std::promise<void>>();
+    auto closed_future = closed_promise->get_future();
     auto const deadline = std::chrono::steady_clock::now() +
         std::chrono::milliseconds{ static_cast<int64_t>(timeout_secs * 1000.0) };
-    session->run_in_session_thread([&closed_promise, deadline, session]()
-                                   { session->closeImplPart1(&closed_promise, deadline); });
-    closed_future.wait();
+    session->run_in_session_thread([promise = closed_promise.get(), deadline, session]()
+                                   { session->closeImplPart1(promise, deadline); });
+
+    // Use wait_for() instead of wait() to prevent the main thread from
+    // blocking indefinitely when the session thread is stuck in a kernel
+    // call (e.g., connect() on macOS with ECN-incompatible peers or
+    // uninterruptible I/O on external drives).
+    auto const wait_limit = std::chrono::milliseconds{ static_cast<int64_t>(timeout_secs * 1000.0) } + 5s;
+    if (closed_future.wait_for(wait_limit) == std::future_status::timeout)
+    {
+        // The session thread is still stuck in a blocking kernel call and may
+        // dereference `session` or fulfil the promise later. Freeing either
+        // one would be a use-after-free, so intentionally leak both: the
+        // process is exiting anyway.
+        tr_logAddWarn(
+            fmt::format(
+                fmt::runtime(_("Session shutdown timed out after {seconds} seconds; exiting without final cleanup")),
+                fmt::arg("seconds", timeout_secs + 5.0)));
+        [[maybe_unused]] auto* const leaked_promise = closed_promise.release();
+        return;
+    }
 
     delete session;
 }


### PR DESCRIPTION
## Summary

Replace `closed_future.wait()` with `closed_future.wait_for()` in `tr_sessionClose()` to prevent the main thread from blocking indefinitely during application shutdown.

## Problem

When quitting Transmission on macOS, the main thread calls `tr_sessionClose()` which posts a shutdown task to the session thread and then calls `closed_future.wait()` — an unconditional, indefinite wait. If the session thread is stuck in a blocking kernel call, the future is never fulfilled and the application hangs.

**Observed scenarios:**

1. **macOS Tahoe/Sequoia with ECN enabled** (default `net.inet.tcp.ecn_initiate_out=1`): TCP `connect()` calls to peers that don't support ECN can block for 75+ seconds in the kernel (`lck_mtx_sleep` in `__connect`). Multiple simultaneous connections compound the issue.
2. **External USB/Thunderbolt drives**: Disk I/O operations can become uninterruptible when macOS puts external drives to sleep (`disksleep=10`), blocking the session thread in kernel I/O wait.
3. **UPnP shutdown**: `UPNP_GetValidIGD()` performs a blocking HTTP request that can hang for 30+ seconds (ref #4759).

In all cases, the session thread cannot reach `closeImplPart1`/`closeImplPart2` to fulfill the promise, and the main thread waits forever.

**Evidence from hang reports** (macOS spindump):
```
Thread 0 (Main):    applicationWillTerminate: → tr_sessionClose() → std::future::wait()
Thread 3 (Session): __connect() → lck_mtx_sleep [blocked 26+ seconds]
```

## Fix

Wait with `wait_for(timeout_secs + 5s)` instead of `wait()`. On timeout, log a warning and return **without freeing the session or the promise**:

```cpp
auto const wait_limit = std::chrono::milliseconds{ static_cast<int64_t>(timeout_secs * 1000.0) } + 5s;
if (closed_future.wait_for(wait_limit) == std::future_status::timeout)
{
    // The session thread is still stuck in a blocking kernel call and may
    // dereference `session` or fulfil the promise later. Freeing either
    // one would be a use-after-free, so intentionally leak both: the
    // process is exiting anyway.
    tr_logAddWarn(...);
    [[maybe_unused]] auto* const leaked_promise = closed_promise.release();
    return;
}

delete session;
```

Design notes:

- **The stuck session thread may still dereference `session` or fulfil the promise after the timeout.** Freeing either object would be a use-after-free, so on the timeout path both are intentionally leaked. The leak is bounded and harmless: this code path only runs when the process is about to exit.
- The promise is heap-allocated (`std::unique_ptr`) and handed to the session thread as a raw pointer, so it can outlive `tr_sessionClose()`'s stack frame on the timeout path. No signature changes to `closeImplPart1`/`closeImplPart2`.
- The normal shutdown path is unchanged: `wait_for()` returns as soon as the promise is fulfilled, and both objects are freed exactly as before.
- The timeout is `timeout_secs + 5s` (default: 20s total), giving the internal shutdown phases their full deadline plus a grace period. The internal deadline mechanism in `closeImplPart1`/`closeImplPart2` already handles graceful degradation (skipping pending announces, web requests, etc.); this change only adds a safety net for when the session thread itself is blocked before reaching that code.

## Testing

- Original timeout approach verified on macOS Tahoe 26.4 Beta 2 → 26.6, Mac15,6 (M4 Pro), Transmission 4.1.1: quit completes in <20s vs hanging indefinitely before.
- Current revision compile-tested against `main` (`libtransmission` target, clang, macOS arm64) and formatted with clang-format-20.
- Normal quit path unaffected — `wait_for()` returns immediately when the promise is fulfilled.

## Related Issues

- Fixes #7642 — Stall on quit (labeled "pr welcome")
- Ref #7784 — macOS Tahoe frozen by quit
- Ref #4759 — Appears to hang in UPNP_GetValidIGD() while quitting
- Ref #6654 — Hangs and cannot be force quit if using USB drives
- Ref #5243 — 4.0.2 freezes when quitting on macOS
- Ref #5625 — Failed to quit after hanging