### PR TITLE
fix(macos): Fix torrent inspector window focus on double-click

### DIFF
--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -2317,7 +2317,7 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
     else
     {
         [self.fInfoController updateInfoStats];
-        [self.fInfoController.window orderFront:nil];
+        [self.fInfoController.window makeKeyAndOrderFront:nil];
 
         if (self.fInfoController.canQuickLook && [QLPreviewPanel sharedPreviewPanelExists] &&
             [QLPreviewPanel sharedPreviewPanel].visible)


### PR DESCRIPTION
Fixes #8040 

Notes: Fixes Torrent Inspector not gaining focus on double-click