### PR TITLE
refactor: add `tr_torrent_metainfo::rename_path()`

### DIFF
--- a/libtransmission/torrent-metainfo.cc
+++ b/libtransmission/torrent-metainfo.cc
@@ -765,3 +765,187 @@ void tr_torrent_metainfo::remove_file(
     filename = make_filename(dirname, name, info_hash_string, BasenameFormat::Hash, suffix);
     tr_sys_path_remove(filename, nullptr);
 }
+
+// --- rename
+
+namespace
+{
+namespace rename_helpers
+{
+bool renameArgsAreValid(tr_torrent_files const& files, std::string_view oldpath, std::string_view newname)
+{
+    if (std::empty(oldpath) || std::empty(newname) || newname == "."sv || newname == ".."sv || tr_strv_contains(newname, '/'))
+    {
+        return false;
+    }
+
+    auto const newpath = tr_strv_contains(oldpath, '/') ? tr_pathbuf{ tr_sys_path_dirname(oldpath), '/', newname } :
+                                                          tr_pathbuf{ newname };
+
+    if (newpath == oldpath)
+    {
+        return true;
+    }
+
+    auto const newpath_as_dir = tr_pathbuf{ newpath, '/' };
+    auto const n_files = files.file_count();
+
+    for (tr_file_index_t i = 0; i < n_files; ++i)
+    {
+        auto const& name = files.path(i);
+        if (newpath == name || tr_strv_starts_with(name, newpath_as_dir))
+        {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+auto renameFindAffectedFiles(tr_torrent_files const& files, std::string_view oldpath)
+{
+    auto indices = std::vector<tr_file_index_t>{};
+    auto const oldpath_as_dir = tr_pathbuf{ oldpath, '/' };
+    auto const n_files = files.file_count();
+
+    for (tr_file_index_t i = 0; i < n_files; ++i)
+    {
+        auto const& name = files.path(i);
+        if (name == oldpath || tr_strv_starts_with(name, oldpath_as_dir))
+        {
+            indices.push_back(i);
+        }
+    }
+
+    return indices;
+}
+
+int renamePath(std::string_view const base, std::string_view const oldpath, std::string_view const newname)
+{
+    int err = 0;
+
+    auto src = tr_pathbuf{ base, '/', oldpath };
+
+    if (!tr_sys_path_exists(src)) /* check for it as a partial */
+    {
+        src += tr_torrent_files::PartialFileSuffix;
+    }
+
+    if (tr_sys_path_exists(src))
+    {
+        auto const parent = tr_sys_path_dirname(src);
+        auto const tgt = tr_strv_ends_with(src, tr_torrent_files::PartialFileSuffix) ?
+            tr_pathbuf{ parent, '/', newname, tr_torrent_files::PartialFileSuffix } :
+            tr_pathbuf{ parent, '/', newname };
+
+        auto tmp = errno;
+        bool const tgt_exists = tr_sys_path_exists(tgt);
+        errno = tmp;
+
+        if (!tgt_exists)
+        {
+            tmp = errno;
+
+            if (auto error = tr_error{}; !tr_sys_path_rename(src, tgt, &error))
+            {
+                err = error.code();
+            }
+
+            errno = tmp;
+        }
+    }
+
+    return err;
+}
+
+void renameTorrentFileString(
+    tr_torrent_files& files,
+    std::string_view const oldpath,
+    std::string_view const newname,
+    tr_file_index_t const file_index)
+{
+    auto name = std::string{};
+    auto const subpath = std::string_view{ files.path(file_index) };
+    auto const oldpath_len = std::size(oldpath);
+
+    if (!tr_strv_contains(oldpath, '/'))
+    {
+        if (oldpath_len >= std::size(subpath))
+        {
+            name = newname;
+        }
+        else
+        {
+            name = fmt::format("{:s}/{:s}"sv, newname, subpath.substr(oldpath_len + 1));
+        }
+    }
+    else
+    {
+        auto const tmp = tr_sys_path_dirname(oldpath);
+
+        if (std::empty(tmp))
+        {
+            return;
+        }
+
+        if (oldpath_len >= std::size(subpath))
+        {
+            name = fmt::format("{:s}/{:s}"sv, tmp, newname);
+        }
+        else
+        {
+            name = fmt::format("{:s}/{:s}/{:s}"sv, tmp, newname, subpath.substr(oldpath_len + 1));
+        }
+    }
+
+    if (subpath != name)
+    {
+        files.set_path(file_index, name);
+    }
+}
+
+} // namespace rename_helpers
+} // namespace
+
+void tr_torrent_metainfo::rename_path(
+    std::string_view const base,
+    std::string_view const oldpath,
+    std::string_view const newname,
+    tr_error* error)
+{
+    using namespace rename_helpers;
+
+    auto errnum = 0;
+
+    if (!renameArgsAreValid(files_, oldpath, newname))
+    {
+        errnum = EINVAL;
+    }
+    else if (auto const file_indices = renameFindAffectedFiles(files_, oldpath); std::empty(file_indices))
+    {
+        errnum = EINVAL;
+    }
+    else
+    {
+        errnum = renamePath(base, oldpath, newname);
+
+        if (errnum == 0)
+        {
+            // update files_
+            for (auto const& file_index : file_indices)
+            {
+                renameTorrentFileString(files_, oldpath, newname, file_index);
+            }
+
+            /* update tr_info.name if user changed the toplevel */
+            if (std::size(file_indices) == file_count() && !tr_strv_contains(oldpath, '/'))
+            {
+                set_name(newname);
+            }
+        }
+    }
+    if (error != nullptr)
+    {
+        error->set_from_errno(errnum);
+    }
+}

--- a/libtransmission/torrent-metainfo.h
+++ b/libtransmission/torrent-metainfo.h
@@ -35,6 +35,8 @@ public:
     // load multiple files.
     bool parse_torrent_file(std::string_view benc_filename, std::vector<char>* contents = nullptr, tr_error* error = nullptr);
 
+    void rename_path(std::string_view base, std::string_view oldpath, std::string_view newname, tr_error* error = nullptr);
+
     // FILES
 
     [[nodiscard]] constexpr auto const& files() const noexcept

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -2295,199 +2295,26 @@ void tr_torrent::refresh_current_dir()
     current_dir_ = dir;
 }
 
-// --- RENAME
-
-namespace
-{
-namespace rename_helpers
-{
-bool renameArgsAreValid(tr_torrent_files const& files, std::string_view oldpath, std::string_view newname)
-{
-    if (std::empty(oldpath) || std::empty(newname) || newname == "."sv || newname == ".."sv || tr_strv_contains(newname, '/'))
-    {
-        return false;
-    }
-
-    auto const newpath = tr_strv_contains(oldpath, '/') ? tr_pathbuf{ tr_sys_path_dirname(oldpath), '/', newname } :
-                                                          tr_pathbuf{ newname };
-
-    if (newpath == oldpath)
-    {
-        return true;
-    }
-
-    auto const newpath_as_dir = tr_pathbuf{ newpath, '/' };
-    auto const n_files = files.file_count();
-
-    for (tr_file_index_t i = 0; i < n_files; ++i)
-    {
-        auto const& name = files.path(i);
-        if (newpath == name || tr_strv_starts_with(name, newpath_as_dir))
-        {
-            return false;
-        }
-    }
-
-    return true;
-}
-
-auto renameFindAffectedFiles(tr_torrent_files const& files, std::string_view oldpath)
-{
-    auto indices = std::vector<tr_file_index_t>{};
-    auto const oldpath_as_dir = tr_pathbuf{ oldpath, '/' };
-    auto const n_files = files.file_count();
-
-    for (tr_file_index_t i = 0; i < n_files; ++i)
-    {
-        auto const& name = files.path(i);
-        if (name == oldpath || tr_strv_starts_with(name, oldpath_as_dir))
-        {
-            indices.push_back(i);
-        }
-    }
-
-    return indices;
-}
-
-int renamePath(std::string_view const base, std::string_view const oldpath, std::string_view const newname)
-{
-    int err = 0;
-
-    auto src = tr_pathbuf{ base, '/', oldpath };
-
-    if (!tr_sys_path_exists(src)) /* check for it as a partial */
-    {
-        src += tr_torrent_files::PartialFileSuffix;
-    }
-
-    if (tr_sys_path_exists(src))
-    {
-        auto const parent = tr_sys_path_dirname(src);
-        auto const tgt = tr_strv_ends_with(src, tr_torrent_files::PartialFileSuffix) ?
-            tr_pathbuf{ parent, '/', newname, tr_torrent_files::PartialFileSuffix } :
-            tr_pathbuf{ parent, '/', newname };
-
-        auto tmp = errno;
-        bool const tgt_exists = tr_sys_path_exists(tgt);
-        errno = tmp;
-
-        if (!tgt_exists)
-        {
-            tmp = errno;
-
-            if (auto error = tr_error{}; !tr_sys_path_rename(src, tgt, &error))
-            {
-                err = error.code();
-            }
-
-            errno = tmp;
-        }
-    }
-
-    return err;
-}
-
-void renameTorrentFileString(
-    tr_torrent_metainfo& metainfo,
-    std::string_view const oldpath,
-    std::string_view const newname,
-    tr_file_index_t const file_index)
-{
-    auto name = std::string{};
-    auto const subpath = std::string_view{ metainfo.file_subpath(file_index) };
-    auto const oldpath_len = std::size(oldpath);
-
-    if (!tr_strv_contains(oldpath, '/'))
-    {
-        if (oldpath_len >= std::size(subpath))
-        {
-            name = newname;
-        }
-        else
-        {
-            name = fmt::format("{:s}/{:s}"sv, newname, subpath.substr(oldpath_len + 1));
-        }
-    }
-    else
-    {
-        auto const tmp = tr_sys_path_dirname(oldpath);
-
-        if (std::empty(tmp))
-        {
-            return;
-        }
-
-        if (oldpath_len >= std::size(subpath))
-        {
-            name = fmt::format("{:s}/{:s}"sv, tmp, newname);
-        }
-        else
-        {
-            name = fmt::format("{:s}/{:s}/{:s}"sv, tmp, newname, subpath.substr(oldpath_len + 1));
-        }
-    }
-
-    if (subpath != name)
-    {
-        metainfo.set_file_subpath(file_index, name);
-    }
-}
-
-} // namespace rename_helpers
-} // namespace
-
 void tr_torrent::rename_path_in_session_thread(
     std::string_view const oldpath,
     std::string_view const newname,
     tr_torrent_rename_done_func const& callback)
 {
-    using namespace rename_helpers;
+    auto err = tr_error{};
+    auto const base = is_done() || std::empty(incomplete_dir()) ? download_dir() : incomplete_dir();
+    metainfo_.rename_path(base, oldpath, newname, &err);
 
-    auto error = 0;
-
-    if (!renameArgsAreValid(files(), oldpath, newname))
+    if (!err)
     {
-        error = EINVAL;
-    }
-    else if (auto const file_indices = renameFindAffectedFiles(files(), oldpath); std::empty(file_indices))
-    {
-        error = EINVAL;
-    }
-    else
-    {
-        auto const base = is_done() || std::empty(incomplete_dir()) ? download_dir() : incomplete_dir();
-        error = renamePath(base, oldpath, newname);
-
-        if (error == 0)
-        {
-            /* update tr_info.files */
-            for (auto const& file_index : file_indices)
-            {
-                renameTorrentFileString(metainfo_, oldpath, newname, file_index);
-            }
-
-            /* update tr_info.name if user changed the toplevel */
-            if (std::size(file_indices) == file_count() && !tr_strv_contains(oldpath, '/'))
-            {
-                set_name(newname);
-            }
-
-            mark_edited();
-            set_dirty();
-        }
+        mark_edited();
+        set_dirty();
     }
 
     mark_changed();
 
-    if (callback != nullptr)
+    if (callback)
     {
-        auto rename_error = tr_error{};
-        if (error != 0)
-        {
-            rename_error.set_from_errno(error);
-        }
-
-        callback(id(), oldpath, newname, rename_error);
+        callback(id(), oldpath, newname, err);
     }
 }
 


### PR DESCRIPTION
Move the implementation of `tr_torrent::rename_path()` up into `tr_torrent_metainfo`.

