### PR TITLE
perf: prune unused interned strings

### DIFF
--- a/qt/Application.cc
+++ b/qt/Application.cc
@@ -54,6 +54,7 @@ auto const FDONotificationsInterfaceName = QStringLiteral("org.freedesktop.Notif
 auto constexpr StatsRefreshIntervalMsec = 3000;
 auto constexpr SessionRefreshIntervalMsec = 3000;
 auto constexpr ModelRefreshIntervalMsec = 3000;
+auto constexpr InternRefreshIntervalMsec = 5 * 60 * 1000;
 
 bool loadTranslation(QTranslator& translator, QString const& name, QLocale const& locale, QStringList const& search_directories)
 {
@@ -126,6 +127,16 @@ QAccessibleInterface* accessibleFactory(QString const& className, QObject* objec
 #endif // QT_CONFIG(accessibility)
 
 } // namespace
+
+void Application::pruneInternedStrings()
+{
+    std::erase_if(interned_strings_, [](QString const& str) { return str.isDetached(); });
+}
+
+QString Application::intern(QString const& in)
+{
+    return *interned_strings_.insert(in).first;
+}
 
 Application::Application(
     Prefs& prefs,
@@ -201,6 +212,12 @@ Application::Application(
     connect(timer, &QTimer::timeout, session_.get(), &Session::refreshSessionInfo);
     timer->setSingleShot(false);
     timer->setInterval(SessionRefreshIntervalMsec);
+    timer->start();
+
+    timer = &intern_timer_;
+    connect(timer, &QTimer::timeout, this, &Application::pruneInternedStrings);
+    timer->setSingleShot(false);
+    timer->setInterval(InternRefreshIntervalMsec);
     timer->start();
 
     maybeUpdateBlocklist();

--- a/qt/Application.h
+++ b/qt/Application.h
@@ -54,10 +54,7 @@ public:
     void raise() const;
     bool notifyApp(QString const& title, QString const& body, QStringList const& actions = {}) const;
 
-    QString const& intern(QString const& in)
-    {
-        return *interned_strings_.insert(in).first;
-    }
+    QString intern(QString const& in);
 
     [[nodiscard]] QPixmap find_favicon(QString const& sitename) const
     {
@@ -94,6 +91,7 @@ private slots:
     void onTorrentsCompleted(torrent_ids_t const& torrent_ids) const;
     void onTorrentsEdited(torrent_ids_t const& torrent_ids) const;
     void onTorrentsNeedInfo(torrent_ids_t const& torrent_ids) const;
+    void pruneInternedStrings();
     void refreshPref(int key) const;
     void refreshTorrents();
     void saveGeometry() const;
@@ -117,6 +115,7 @@ private:
     QTimer model_timer_;
     QTimer stats_timer_;
     QTimer session_timer_;
+    QTimer intern_timer_;
     time_t last_full_update_time_ = {};
     QTranslator qt_translator_;
     QTranslator app_translator_;


### PR DESCRIPTION
Alternative to https://github.com/transmission/transmission/pull/8649.

We have a `std::unordered_set<QString> Application::interned_strings_` container that holds an interned string to try and reduce memory overhead, e.g. if you have multiple torrents from the same tracker, we use a shared instance of the announce URL.

However, if Transmission runs for a long time and has a high torrent turnover rate, we might hold interned strings from old torrents that were removed.

This PR has a timer that kicks every 5 minutes. It looks for interned strings that have a refcount of 1, ie strings that nobody is using outside of `interned_strings_`. It removes these strings to free up that memory.