### PR TITLE
fix: don't overwrite `*_enabled` if `preferred_transports` is not in `settings.json`

### DIFF
--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -470,6 +470,21 @@ tr_variant tr_sessionGetDefaultSettings()
     ret.merge(tr_rpc_server::Settings{}.save());
     ret.merge(tr_session_alt_speeds::Settings{}.save());
     ret.merge(tr_session::Settings{}.save());
+
+    // TODO(5.0.0): remove this if block
+    if (auto* const map = ret.get_if<tr_variant::Map>())
+    {
+        // N.B. Because `tr_session::Settings::load()` calls
+        // `tr_session::Settings::fixup_to_preferred_transports()`,
+        // the defaults of `preferred_transports` essentially
+        // just repeats `utp_enabled` + `tcp_enabled`.
+        //
+        // Erase `preferred_transports` from the defaults to avoid
+        // overwriting `utp_enabled` and `tcp_enabled` that is set
+        // by the user.
+        map->erase(TR_KEY_preferred_transports);
+    }
+
     return ret;
 }
 


### PR DESCRIPTION
Fixes #8643.

Documenting the cases I tested to make sure I got this right:

| `tcp_enabled` | `utp_enabled` | `preferred_transports` | Result |
| :--- | :--- | :--- | :--- |
| `true` | `false` | Undefined | `"preferred_transports": ["tcp"], "tcp_enabled": true, "utp_enabled": false` |
| `true` | `true` | Undefined | `"preferred_transports": ["utp", "tcp"], "tcp_enabled": true, "utp_enabled": true` |
| `true` | `false` | `["tcp", "utp" ]` | `"preferred_transports": ["tcp", "utp"], "tcp_enabled": true, "utp_enabled": true` |
| `true` | `true` | `["tcp" ]` | `"preferred_transports": ["tcp"], "tcp_enabled": true, "utp_enabled": false` |
| `false` | `true` | `["tcp" ]` | `"preferred_transports": ["tcp"], "tcp_enabled": true, "utp_enabled": false` |

Notes: Fixed `4.1.0` bug where upgrading from `4.0.x` overwrites `utp_enabled` and `tcp_enabled` values in `settings.json`.