### PR TITLE
feat: bound-checked `tr_variant::value_if()` for smaller integer types

### DIFF
--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -248,7 +248,7 @@ void tr_rpc_idle_done(struct tr_rpc_idle_data* data, JsonRpc::Error::Code code, 
     {
         tr_torrent* tor = nullptr;
 
-        if (auto const val = var.value_if<int64_t>())
+        if (auto const val = var.value_if<tr_torrent_id_t>())
         {
             tor = torrents.get(*val);
         }

--- a/libtransmission/variant.cc
+++ b/libtransmission/variant.cc
@@ -88,7 +88,7 @@ template<typename T>
 // but aren't because https://gcc.gnu.org/bugzilla/show_bug.cgi?id=85282
 
 template<>
-[[nodiscard]] std::optional<int64_t> tr_variant::value_if() noexcept
+[[nodiscard]] std::optional<int64_t> tr_variant::value_if() const noexcept
 {
     switch (index())
     {
@@ -104,7 +104,7 @@ template<>
 }
 
 template<>
-[[nodiscard]] std::optional<bool> tr_variant::value_if() noexcept
+[[nodiscard]] std::optional<bool> tr_variant::value_if() const noexcept
 {
     switch (index())
     {
@@ -138,7 +138,7 @@ template<>
 }
 
 template<>
-[[nodiscard]] std::optional<double> tr_variant::value_if() noexcept
+[[nodiscard]] std::optional<double> tr_variant::value_if() const noexcept
 {
     switch (index())
     {
@@ -164,7 +164,7 @@ template<>
 }
 
 template<>
-[[nodiscard]] std::optional<std::string_view> tr_variant::value_if() noexcept
+[[nodiscard]] std::optional<std::string_view> tr_variant::value_if() const noexcept
 {
     switch (index())
     {

--- a/libtransmission/variant.h
+++ b/libtransmission/variant.h
@@ -9,6 +9,7 @@
 #include <cstddef> // size_t
 #include <cstdint> // int64_t
 #include <functional> // std::invoke
+#include <limits>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -338,7 +339,7 @@ public:
     }
 
     template<typename Val>
-    [[nodiscard]] constexpr std::optional<Val> value_if() noexcept
+    [[nodiscard]] constexpr std::optional<Val> value_if() const noexcept
     {
         if (auto const* const val = get_if<Val>())
         {
@@ -348,11 +349,8 @@ public:
         return {};
     }
 
-    template<typename Val>
-    [[nodiscard]] std::optional<Val> value_if() const noexcept
-    {
-        return const_cast<tr_variant*>(this)->value_if<Val>();
-    }
+    template<std::integral Val>
+    [[nodiscard]] std::optional<Val> value_if() const noexcept;
 
     template<typename Val>
     [[nodiscard]] constexpr bool holds_alternative() const noexcept
@@ -399,13 +397,27 @@ private:
 };
 
 template<>
-[[nodiscard]] std::optional<int64_t> tr_variant::value_if() noexcept;
+[[nodiscard]] std::optional<int64_t> tr_variant::value_if() const noexcept;
 template<>
-[[nodiscard]] std::optional<bool> tr_variant::value_if() noexcept;
+[[nodiscard]] std::optional<bool> tr_variant::value_if() const noexcept;
 template<>
-[[nodiscard]] std::optional<double> tr_variant::value_if() noexcept;
+[[nodiscard]] std::optional<double> tr_variant::value_if() const noexcept;
 template<>
-[[nodiscard]] std::optional<std::string_view> tr_variant::value_if() noexcept;
+[[nodiscard]] std::optional<std::string_view> tr_variant::value_if() const noexcept;
+
+template<std::integral Val>
+[[nodiscard]] std::optional<Val> tr_variant::value_if() const noexcept
+{
+    static_assert(!std::is_same_v<Val, bool>);
+    static_assert(!std::is_same_v<Val, int64_t>);
+    if (auto val = value_if<int64_t>(); val && std::cmp_greater_equal(*val, std::numeric_limits<Val>::lowest()) &&
+        std::cmp_less_equal(*val, std::numeric_limits<Val>::max()))
+    {
+        return val;
+    }
+
+    return {};
+}
 
 // --- Strings
 

--- a/tests/libtransmission/variant-test.cc
+++ b/tests/libtransmission/variant-test.cc
@@ -7,6 +7,7 @@
 #include <cerrno>
 #include <cstddef> // size_t
 #include <cstdint> // int64_t
+#include <limits>
 #include <map>
 #include <string>
 #include <string_view>
@@ -97,6 +98,53 @@ TEST_F(VariantTest, getType)
     sv = v.value_if<std::string_view>();
     ASSERT_TRUE(sv);
     EXPECT_EQ(strkey, *sv);
+}
+
+template<typename T>
+using VariantIntTest = ::testing::Test;
+using TestTypes = ::testing::Types<int8_t, uint8_t, int16_t, uint16_t, int32_t, uint32_t, int64_t, uint64_t>;
+TYPED_TEST_SUITE(VariantIntTest, TestTypes);
+
+TYPED_TEST(VariantIntTest, getIntTypes)
+{
+    auto v = tr_variant{};
+    auto const test = [&v](auto const expected)
+    {
+        v = expected;
+        if (std::cmp_greater_equal(expected, std::numeric_limits<TypeParam>::lowest()) &&
+            std::cmp_less_equal(expected, std::numeric_limits<TypeParam>::max()))
+        {
+            EXPECT_EQ(expected, v.value_if<TypeParam>());
+        }
+        else
+        {
+            EXPECT_EQ(std::nullopt, v.value_if<TypeParam>());
+        }
+    };
+
+    test(0);
+    test(-1);
+    test(30);
+    test(std::numeric_limits<int8_t>::lowest());
+    test(std::numeric_limits<int8_t>::lowest() - int16_t{ 1 });
+    test(std::numeric_limits<int8_t>::max());
+    test(std::numeric_limits<int8_t>::max() + int16_t{ 1 });
+    test(std::numeric_limits<int16_t>::lowest());
+    test(std::numeric_limits<int16_t>::lowest() - int32_t{ 1 });
+    test(std::numeric_limits<int16_t>::max());
+    test(std::numeric_limits<int16_t>::max() + int32_t{ 1 });
+    test(std::numeric_limits<int32_t>::lowest());
+    test(std::numeric_limits<int32_t>::lowest() - int64_t{ 1 });
+    test(std::numeric_limits<int32_t>::max());
+    test(std::numeric_limits<int32_t>::max() + int64_t{ 1 });
+    test(std::numeric_limits<int64_t>::lowest());
+    test(std::numeric_limits<int64_t>::max());
+    test(std::numeric_limits<uint8_t>::max());
+    test(std::numeric_limits<uint8_t>::max() + uint16_t{ 1 });
+    test(std::numeric_limits<uint16_t>::max());
+    test(std::numeric_limits<uint16_t>::max() + uint32_t{ 1 });
+    test(std::numeric_limits<uint32_t>::max());
+    test(std::numeric_limits<uint32_t>::max() + uint64_t{ 1 });
 }
 
 TEST_F(VariantTest, mergeStringsTakesOwnership)


### PR DESCRIPTION
1. New overload of `tr_variant::value_if()` that accepts integer types other than `int64_t`, which only returns a non-empty optional when the value in the variant is within the range of the data type.
2. Trivial example of where the new overload is useful, where the `ids` key in RPC will now ignore integer values outside the range of `tr_torrent_id_t`.