### PR TITLE
fix: `modernize-use-integer-sign-comparison`

### DIFF
--- a/libtransmission/.clang-tidy
+++ b/libtransmission/.clang-tidy
@@ -3,7 +3,6 @@ HeaderFilterRegex: .*/libtransmission/.*
 
 # TODO: Enable `portability-template-virtual-member-function` after https://github.com/llvm/llvm-project/issues/139031 is fixed
 # TODO: Enable `cppcoreguidelines-pro-bounds-pointer-arithmetic` after converting all pointers to std::span
-# TODO: Enable `modernize-use-integer-sign-comparison` (P0586R2) after GCC >= 10.1, clang >= 13
 #
 # PRs welcome to fix & re-enable any of these explicitly-disabled checks
 Checks:
@@ -42,7 +41,6 @@ Checks:
   - -misc-no-recursion
   - -misc-non-private-member-variables-in-classes
   - modernize-*
-  - -modernize-use-integer-sign-comparison
   - -modernize-use-trailing-return-type
   - performance-*
   - -performance-move-const-arg

--- a/libtransmission/torrent-magnet.cc
+++ b/libtransmission/torrent-magnet.cc
@@ -101,7 +101,7 @@ void tr_torrent::maybe_start_metadata_transfer(int64_t const size) noexcept
     using size_type = std::remove_cv_t<decltype(info_dict_size)>;
     TR_ASSERT(info_dict_size > 0);
     if (auto const n_pieces = std::max(size_type{ 1 }, n_metadata_pieces(info_dict_size));
-        piece < 0 || static_cast<size_type>(piece) >= n_pieces)
+        piece < 0 || std::cmp_greater_equal(piece, n_pieces))
     {
         return {};
     }


### PR DESCRIPTION
Notes: Moved from C++17 to C++20.