### PR TITLE
refactor: remove unused tr_ctorSetFilePriorities()

### DIFF
--- a/libtransmission/torrent-ctor.cc
+++ b/libtransmission/torrent-ctor.cc
@@ -111,20 +111,6 @@ std::optional<std::string> tr_ctorGetSourceFile(tr_ctor const* const ctor)
     return {};
 }
 
-void tr_ctorSetFilePriorities(
-    tr_ctor* const ctor,
-    tr_file_index_t const* const files,
-    tr_file_index_t const n_files,
-    tr_priority_t const priority)
-{
-    ctor->set_file_priorities(files, n_files, priority);
-}
-
-void tr_ctorSetFilesWanted(tr_ctor* ctor, tr_file_index_t const* const files, tr_file_index_t const n_files, bool const wanted)
-{
-    ctor->set_files_wanted(files, n_files, wanted);
-}
-
 void tr_ctorSetDeleteSource(tr_ctor* const ctor, bool const delete_source)
 {
     ctor->set_should_delete_source_file(delete_source);

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -618,12 +618,6 @@ bool tr_ctorGetPaused(tr_ctor const* ctor, tr_ctorMode mode, bool* setme_is_paus
   (Default: not paused) */
 void tr_ctorSetPaused(tr_ctor* ctor, tr_ctorMode mode, bool is_paused);
 
-/** @brief Set the priorities for files in a torrent */
-void tr_ctorSetFilePriorities(tr_ctor* ctor, tr_file_index_t const* files, tr_file_index_t n_files, tr_priority_t priority);
-
-/** @brief Set the download flag for files in a torrent */
-void tr_ctorSetFilesWanted(tr_ctor* ctor, tr_file_index_t const* files, tr_file_index_t n_files, bool wanted);
-
 /** @brief Get the torrent file that this ctor's metainfo came from,
            or empty if `tr_ctorSetMetainfoFromFile()` wasn't used */
 std::optional<std::string> tr_ctorGetSourceFile(tr_ctor const* ctor);


### PR DESCRIPTION
Remove unused methods:

- `tr_ctorSetFilePriorities()`
- `tr_ctorSetFilesWanted()`