### PR TITLE
perf: constexpr `tr_variant::value_if()` specialisations

### DIFF
--- a/libtransmission/variant.cc
+++ b/libtransmission/variant.cc
@@ -110,22 +110,6 @@ template<>
     return {};
 }
 
-template<>
-[[nodiscard]] std::optional<std::string_view> tr_variant::value_if() const noexcept
-{
-    switch (index())
-    {
-    case StringIndex:
-        return *std::get_if<std::string>(&val_);
-
-    case StringViewIndex:
-        return *std::get_if<std::string_view>(&val_);
-
-    default:
-        return {};
-    }
-}
-
 // ---
 
 tr_variant tr_variant::clone() const

--- a/libtransmission/variant.h
+++ b/libtransmission/variant.h
@@ -400,6 +400,22 @@ private:
 // but aren't because https://gcc.gnu.org/bugzilla/show_bug.cgi?id=85282
 
 template<>
+[[nodiscard]] constexpr std::optional<std::string_view> tr_variant::value_if() const noexcept
+{
+    switch (index())
+    {
+    case StringIndex:
+        return *std::get_if<std::string>(&val_);
+
+    case StringViewIndex:
+        return *std::get_if<std::string_view>(&val_);
+
+    default:
+        return {};
+    }
+}
+
+template<>
 [[nodiscard]] constexpr std::optional<int64_t> tr_variant::value_if() const noexcept
 {
     switch (index())
@@ -451,8 +467,6 @@ template<>
 
 template<>
 [[nodiscard]] std::optional<double> tr_variant::value_if() const noexcept;
-template<>
-[[nodiscard]] std::optional<std::string_view> tr_variant::value_if() const noexcept;
 
 template<std::integral Val>
 [[nodiscard]] constexpr std::optional<Val> tr_variant::value_if() const noexcept


### PR DESCRIPTION
There should be no change in behaviour.

Move some specialisations of `tr_variant::value_if()` to the header and make them constexpr.