### PR TITLE
fix: preserve relative order in `queue_move_up` and `queue_move_down`

### DIFF
--- a/libtransmission/torrent-queue.h
+++ b/libtransmission/torrent-queue.h
@@ -11,9 +11,9 @@
 
 #include <cstddef>
 #include <string>
-#include <string_view>
 #include <vector>
 
+#include "libtransmission/tr-macros.h"
 #include "libtransmission/types.h"
 
 class tr_torrent_queue
@@ -42,6 +42,11 @@ public:
 
     [[nodiscard]] size_t get_pos(tr_torrent_id_t id);
     [[nodiscard]] std::vector<tr_torrent_id_t> set_pos(tr_torrent_id_t id, size_t new_pos);
+
+    [[nodiscard]] TR_CONSTEXPR_VEC auto size() const noexcept
+    {
+        return queue_.size();
+    }
 
     bool to_file(); // NOLINT(modernize-use-nodiscard)
     [[nodiscard]] std::vector<std::string> from_file();

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -512,11 +512,15 @@ void tr_torrent::queue_move_up(std::span<tr_torrent* const> const torrents_in)
 
     auto torrents = std::vector<tr_torrent*>(std::begin(torrents_in), std::end(torrents_in));
     std::ranges::sort(torrents, tr_torrent::CompareQueuePosition);
-    for (auto* const tor : torrents)
+    for (auto last_consecutive_pos = tr_torrent_queue::MinQueuePosition; auto* const tor : torrents)
     {
-        if (auto const pos = tor->queue_position(); pos > tr_torrent_queue::MinQueuePosition)
+        if (auto const pos = tor->queue_position(); pos != last_consecutive_pos)
         {
             tor->set_queue_position(pos - 1U);
+        }
+        else
+        {
+            ++last_consecutive_pos;
         }
     }
 }

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -57,7 +57,10 @@ using namespace tr::Values;
 #define tr_return_if_fail(expr) \
     do \
     { \
-        if (!(expr)) \
+        if (expr) [[likely]] \
+        { \
+        } \
+        else \
         { \
             tr_logAddWarn(#expr); \
             return; \
@@ -66,7 +69,10 @@ using namespace tr::Values;
 #define tr_return_val_if_fail(expr, val) \
     do \
     { \
-        if (!(expr)) \
+        if (expr) [[likely]] \
+        { \
+        } \
+        else \
         { \
             tr_logAddWarn(#expr); \
             return val; \

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -527,15 +527,21 @@ void tr_torrent::queue_move_up(std::span<tr_torrent* const> const torrents_in)
 
 void tr_torrent::queue_move_down(std::span<tr_torrent* const> const torrents_in)
 {
-    tr_return_if_fail(std::ranges::all_of(torrents_in, tr_isTorrent));
+    tr_return_if_fail(!torrents_in.empty() && std::ranges::all_of(torrents_in, tr_isTorrent));
 
     auto torrents = std::vector<tr_torrent*>(std::begin(torrents_in), std::end(torrents_in));
     std::ranges::sort(std::views::reverse(torrents), tr_torrent::CompareQueuePosition);
-    for (auto* const tor : torrents)
+    for (auto last_consecutive_pos =
+             torrents.front()->session->torrent_queue().size() - 1U + tr_torrent_queue::MinQueuePosition;
+         auto* const tor : torrents)
     {
-        if (auto const pos = tor->queue_position(); pos < tr_torrent_queue::MaxQueuePosition)
+        if (auto const pos = tor->queue_position(); pos != last_consecutive_pos)
         {
             tor->set_queue_position(pos + 1U);
+        }
+        else
+        {
+            --last_consecutive_pos;
         }
     }
 }

--- a/tests/libtransmission/CMakeLists.txt
+++ b/tests/libtransmission/CMakeLists.txt
@@ -55,6 +55,7 @@ target_sources(libtransmission-test
         torrent-magnet-test.cc
         torrent-metainfo-test.cc
         torrent-queue-test.cc
+        torrent-test.cc
         torrents-test.cc
         tr-peer-info-test.cc
         utils-test.cc

--- a/tests/libtransmission/test-fixtures.h
+++ b/tests/libtransmission/test-fixtures.h
@@ -479,6 +479,18 @@ protected:
         return tor;
     }
 
+    [[nodiscard]] tr_torrent* torrentInitFromFile(std::string_view filename)
+    {
+        auto* const ctor = tr_ctorNew(session_);
+
+        auto const path = tr_pathbuf{ LIBTRANSMISSION_TEST_ASSETS_DIR, '/', filename };
+        EXPECT_TRUE(ctor->set_metainfo_from_file(path));
+
+        auto* const tor = createTorrentAndWaitForVerifyDone(ctor);
+        tr_ctorFree(ctor);
+        return tor;
+    }
+
     void blockingTorrentVerify(tr_torrent* tor)
     {
         EXPECT_NE(nullptr, tor->session);

--- a/tests/libtransmission/torrent-test.cc
+++ b/tests/libtransmission/torrent-test.cc
@@ -3,6 +3,12 @@
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.
 
+#include <array>
+#include <cstddef>
+#include <ranges>
+
+#include <libtransmission/torrent.h>
+
 #include "test-fixtures.h"
 
 using TorrentTest = tr::test::SessionTest;
@@ -36,6 +42,32 @@ TEST_F(TorrentTest, queueMoveUp)
     }
 
     tr_torrent::queue_move_up(move_torrents);
+
+    for (size_t i = 0; i < ExpectedQueuePosition.size(); ++i)
+    {
+        EXPECT_EQ(ExpectedQueuePosition[i], torrents[i]->queue_position()) << i;
+    }
+}
+
+TEST_F(TorrentTest, queueMoveDown)
+{
+    static constexpr auto ExpectedQueuePosition = std::array{ 1, 0, 2, 3 };
+    auto ctor = tr_ctor{ session_ };
+    auto torrents = std::array<tr_torrent*, TorFilenames.size()>{};
+    std::ranges::transform(
+        TorFilenames,
+        torrents.begin(),
+        [this](auto const filename) { return torrentInitFromFile(filename); });
+    auto const move_torrents = std::array{ torrents[0], torrents[2], torrents[3] };
+
+    // Pre-test sanity checks
+    for (size_t i = 0; i < torrents.size(); ++i)
+    {
+        ASSERT_EQ(i, torrents[i]->queue_position());
+        ASSERT_EQ(i + 1U, torrents[i]->id());
+    }
+
+    tr_torrent::queue_move_down(move_torrents);
 
     for (size_t i = 0; i < ExpectedQueuePosition.size(); ++i)
     {

--- a/tests/libtransmission/torrent-test.cc
+++ b/tests/libtransmission/torrent-test.cc
@@ -1,0 +1,44 @@
+// This file Copyright © Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
+
+#include "test-fixtures.h"
+
+using TorrentTest = tr::test::SessionTest;
+
+namespace
+{
+auto constexpr TorFilenames = std::array{
+    "Android-x86 8.1 r6 iso.torrent"sv,
+    "debian-11.2.0-amd64-DVD-1.iso.torrent"sv,
+    "ubuntu-18.04.6-desktop-amd64.iso.torrent"sv,
+    "ubuntu-20.04.4-desktop-amd64.iso.torrent"sv,
+};
+}
+
+TEST_F(TorrentTest, queueMoveUp)
+{
+    static constexpr auto ExpectedQueuePosition = std::array{ 0, 1, 3, 2 };
+    auto ctor = tr_ctor{ session_ };
+    auto torrents = std::array<tr_torrent*, TorFilenames.size()>{};
+    std::ranges::transform(
+        TorFilenames,
+        torrents.begin(),
+        [this](auto const filename) { return torrentInitFromFile(filename); });
+    auto const move_torrents = std::array{ torrents[0], torrents[1], torrents[3] };
+
+    // Pre-test sanity checks
+    for (size_t i = 0; i < torrents.size(); ++i)
+    {
+        ASSERT_EQ(i, torrents[i]->queue_position());
+        ASSERT_EQ(i + 1U, torrents[i]->id());
+    }
+
+    tr_torrent::queue_move_up(move_torrents);
+
+    for (size_t i = 0; i < ExpectedQueuePosition.size(); ++i)
+    {
+        EXPECT_EQ(ExpectedQueuePosition[i], torrents[i]->queue_position()) << i;
+    }
+}

--- a/tests/libtransmission/torrent-test.cc
+++ b/tests/libtransmission/torrent-test.cc
@@ -74,3 +74,55 @@ TEST_F(TorrentTest, queueMoveDown)
         EXPECT_EQ(ExpectedQueuePosition[i], torrents[i]->queue_position()) << i;
     }
 }
+
+TEST_F(TorrentTest, queueMoveTop)
+{
+    static constexpr auto ExpectedQueuePosition = std::array{ 0, 3, 1, 2 };
+    auto ctor = tr_ctor{ session_ };
+    auto torrents = std::array<tr_torrent*, TorFilenames.size()>{};
+    std::ranges::transform(
+        TorFilenames,
+        torrents.begin(),
+        [this](auto const filename) { return torrentInitFromFile(filename); });
+    auto const move_torrents = std::array{ torrents[0], torrents[2], torrents[3] };
+
+    // Pre-test sanity checks
+    for (size_t i = 0; i < torrents.size(); ++i)
+    {
+        ASSERT_EQ(i, torrents[i]->queue_position());
+        ASSERT_EQ(i + 1U, torrents[i]->id());
+    }
+
+    tr_torrent::queue_move_top(move_torrents);
+
+    for (size_t i = 0; i < ExpectedQueuePosition.size(); ++i)
+    {
+        EXPECT_EQ(ExpectedQueuePosition[i], torrents[i]->queue_position()) << i;
+    }
+}
+
+TEST_F(TorrentTest, queueMoveBottom)
+{
+    static constexpr auto ExpectedQueuePosition = std::array{ 1, 2, 0, 3 };
+    auto ctor = tr_ctor{ session_ };
+    auto torrents = std::array<tr_torrent*, TorFilenames.size()>{};
+    std::ranges::transform(
+        TorFilenames,
+        torrents.begin(),
+        [this](auto const filename) { return torrentInitFromFile(filename); });
+    auto const move_torrents = std::array{ torrents[0], torrents[1], torrents[3] };
+
+    // Pre-test sanity checks
+    for (size_t i = 0; i < torrents.size(); ++i)
+    {
+        ASSERT_EQ(i, torrents[i]->queue_position());
+        ASSERT_EQ(i + 1U, torrents[i]->id());
+    }
+
+    tr_torrent::queue_move_bottom(move_torrents);
+
+    for (size_t i = 0; i < ExpectedQueuePosition.size(); ++i)
+    {
+        EXPECT_EQ(ExpectedQueuePosition[i], torrents[i]->queue_position()) << i;
+    }
+}


### PR DESCRIPTION
`queue_move_up`'s current implementation swaps the torrents on position 0 and 1 even if both torrents are passed into the method. This is clearly wrong because the torrent at position 0 is actually moved down the queue.

Here's some pseudocode to demonstrate the problem:

```c++
tr_torrent::queue_move_up({ at_queue_pos[0], at_queue_pos[1] });
// Expected: Queue positions unchanged
// Actual: Queue positions swapped
```

Similar problem with `queue_move_down` for the last 2 torrents in the queue.

Notes: Fixed edge case that didn't preserve the order of a batch of torrents when moving their queue position up or down.