### PR TITLE
fix(web): Dismiss inspector when no torrents are selected

### DIFF
--- a/web/src/transmission.js
+++ b/web/src/transmission.js
@@ -649,6 +649,9 @@ export class Transmission extends EventTarget {
     this._selectedTorrentIds.clear();
     this._updateVisibleSelections();
     this._dispatchSelectionChanged();
+    if (this.popup[0] instanceof Inspector) {
+      this.popup[0].close();
+    }
     delete this._last_torrent_clicked;
   }
 


### PR DESCRIPTION
When you click on the empty space under the torrent list with the inspector open (deselecting all torrents), it remains open but shows a whole lot of nothing:
<img width="1134" height="1294" alt="image" src="https://github.com/user-attachments/assets/a6460159-ef20-4c27-a92b-3e15aa783a89" />
The table on the Peers tab also has no rows, and the other two tabs are completely empty.

Notes: Web UI: Close the inspector when there is nothing to actually inspect.