### PR TITLE
fix: prevent crash when toggling alternate speed limits in GTK client

### DIFF
--- a/gtk/Actions.cc
+++ b/gtk/Actions.cc
@@ -70,7 +70,7 @@ void toggle_pref_cb(Gio::SimpleAction& action, gpointer prefs_key)
 
 // action-name, prefs_name
 constexpr auto PrefToggleEntries = std::array<std::pair<std::string_view, tr_quark>, 6>{ {
-    { "alt-speed-enabled"sv, TR_KEY_alt_speed_enabled },
+    { "alt_speed_enabled"sv, TR_KEY_alt_speed_enabled },
     { "compact-view"sv, TR_KEY_compact_view },
     { "show-filterbar"sv, TR_KEY_show_filterbar },
     { "show-statusbar"sv, TR_KEY_show_statusbar },


### PR DESCRIPTION
Notes: prevented a crash when toggling Alternative Speed Limits