### PR TITLE
refactor(qt): use upload ratio value from RPC

### DIFF
--- a/qt/Session.cc
+++ b/qt/Session.cc
@@ -581,6 +581,7 @@ using TorrentProperties = Session::TorrentProperties;
                 TR_KEY_status,
                 TR_KEY_total_size,
                 TR_KEY_trackers,
+                TR_KEY_upload_ratio,
                 TR_KEY_uploaded_ever,
                 TR_KEY_webseeds_sending_to_us,
             };
@@ -627,6 +628,7 @@ using TorrentProperties = Session::TorrentProperties;
                 TR_KEY_seed_ratio_mode,
                 TR_KEY_size_when_done,
                 TR_KEY_status,
+                TR_KEY_upload_ratio,
                 TR_KEY_uploaded_ever,
                 TR_KEY_webseeds_sending_to_us,
             };

--- a/qt/Torrent.cc
+++ b/qt/Torrent.cc
@@ -235,6 +235,7 @@ Torrent::fields_t Torrent::update(tr_quark const* keys, tr_variant const* const*
             HANDLE_KEY(trackers, tracker_stats, TRACKER_STATS)
             HANDLE_KEY(upload_limit, upload_limit, UPLOAD_LIMIT) // KB/s
             HANDLE_KEY(upload_limited, upload_limited, UPLOAD_LIMITED)
+            HANDLE_KEY(upload_ratio, upload_ratio, UPLOAD_RATIO)
             HANDLE_KEY(uploaded_ever, uploaded_ever, UPLOADED_EVER)
             HANDLE_KEY(webseeds_sending_to_us, webseeds_sending_to_us, WEBSEEDS_SENDING_TO_US)
 #undef HANDLE_KEY

--- a/qt/Torrent.h
+++ b/qt/Torrent.h
@@ -292,9 +292,7 @@ public:
 
     [[nodiscard]] constexpr auto ratio() const noexcept
     {
-        auto const numerator = static_cast<double>(uploadedEver());
-        auto const denominator = sizeWhenDone();
-        return denominator > 0U ? numerator / denominator : double{};
+        return upload_ratio_;
     }
 
     [[nodiscard]] constexpr double percentComplete() const noexcept
@@ -612,6 +610,7 @@ public:
         UPLOADED_EVER,
         UPLOAD_LIMIT,
         UPLOAD_LIMITED,
+        UPLOAD_RATIO,
         UPLOAD_SPEED,
         WEBSEEDS_SENDING_TO_US,
 
@@ -672,6 +671,7 @@ private:
     double percent_done_ = {};
     double recheck_progress_ = {};
     double seed_ratio_limit_ = {};
+    double upload_ratio_ = {};
 
     QString comment_;
     QString creator_;


### PR DESCRIPTION
Dedupe logic to avoid bugs like #4708.

### Extended Discussion

The same logic is also repeated here (kinda):

https://github.com/transmission/transmission/blob/849cd0ecea6f3c3791f0e3da2cad2f64fc1b43cd/qt/DetailsDialog.cc#L659-L667

but I don't think there's a way to calculate this value with just `torrent_get.upload_ratio`.

We could consider printing "Mixed" when more than 1 torrent is selected, so that we avoid the possibility of future bugs if we ever change the formula of upload ratio again.