### PR TITLE
fix(gtk): crash when toggling alt speed limit (#8703)

### DIFF
--- a/gtk/Application.cc
+++ b/gtk/Application.cc
@@ -1275,7 +1275,7 @@ void Application::Impl::on_prefs_changed(tr_quark const key)
         {
             bool const b = gtr_pref_flag_get(key);
             tr_sessionUseAltSpeed(tr, b);
-            gtr_action_set_toggled(std::string(tr_quark_get_string_view(key)), b);
+            gtr_action_set_toggled("alt-speed-enabled", b);
             break;
         }
 


### PR DESCRIPTION
cherry-pick #8703 for 4.1.x

Notes: Fixed a `4.1.0` crash when toggling alternative speed limits.