### PR TITLE
fix: do not use std::erase_if() in C++17 code

### DIFF
--- a/qt/Application.cc
+++ b/qt/Application.cc
@@ -130,7 +130,7 @@ QAccessibleInterface* accessibleFactory(QString const& className, QObject* objec
 
 void Application::pruneInternedStrings()
 {
-    std::erase_if(interned_strings_, [](QString const& str) { return str.isDetached(); });
+    interned_strings_.erase_if([](QString const& str) { return str.isDetached(); });
 }
 
 QString Application::intern(QString const& in)

--- a/qt/Application.h
+++ b/qt/Application.h
@@ -7,7 +7,6 @@
 
 #include <ctime>
 #include <memory>
-#include <unordered_set>
 
 #include <QApplication>
 #include <QPixmap>
@@ -17,11 +16,12 @@
 #include <QTranslator>
 #include <QWeakPointer>
 
+#include <small/set.hpp>
+
 #include <libtransmission-app/favicon-cache.h>
 
 #include "AddData.h"
 #include "Typedefs.h"
-#include "Utils.h" // std::hash<QString>
 
 class AddData;
 class MainWindow;
@@ -103,7 +103,7 @@ private:
     QStringList getNames(torrent_ids_t const& ids) const;
     void notifyTorrentAdded(Torrent const*) const;
 
-    std::unordered_set<QString> interned_strings_;
+    small::unordered_set<QString> interned_strings_;
 
     std::unique_ptr<Prefs> prefs_;
     std::unique_ptr<Session> session_;


### PR DESCRIPTION
Fix codeql warning in CI logs, e.g. https://github.com/transmission/transmission/actions/runs/23309608792/job/67793052035?pr=8709

> /home/runner/work/transmission/transmission/qt/Application.cc:133:10: error: ‘erase_if’ is not a member of ‘std’; did you mean ‘enable_if’?
  133 |     std::erase_if(interned_strings_, [](QString const& str) { return str.isDetached(); });
      |          ^~~~~~~~
      |          enable_if

`std::erase_if` is a C++20ism. This fix landed in `main` and then was backported to `4.1.x` -- which is still on std=c++17 -- by #8659.