### PR TITLE
Fix #8111: reject trailing garbage in RPC URL

### DIFF
--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -618,6 +618,15 @@ void handle_request(struct evhttp_request* req, void* arg)
             fmt::format(fmt::runtime(_("Rejected request from {host} (Host not whitelisted)")), fmt::arg("host", remote_host)));
         send_simple_response(req, 421, Body);
     }
+    else if (uri != rpc_base_path)
+    {
+        tr_logAddWarn(
+            fmt::format(
+                fmt::runtime(_("Unknown URI from {host}: '{uri}'")),
+                fmt::arg("host", remote_host),
+                fmt::arg("uri", uri)));
+        send_simple_response(req, HTTP_NOTFOUND, uri);
+    }
 #ifdef REQUIRE_SESSION_ID
     else if (!test_session_id(server, req))
     {
@@ -645,18 +654,9 @@ void handle_request(struct evhttp_request* req, void* arg)
         send_simple_response(req, 409, body.c_str());
     }
 #endif
-    else if (tr_strv_starts_with(uri, rpc_base_path))
-    {
-        handle_rpc(req, server);
-    }
     else
     {
-        tr_logAddWarn(
-            fmt::format(
-                fmt::runtime(_("Unknown URI from {host}: '{uri}'")),
-                fmt::arg("host", remote_host),
-                fmt::arg("uri", uri)));
-        send_simple_response(req, HTTP_NOTFOUND, uri);
+        handle_rpc(req, server);
     }
 }
 

--- a/tests/libtransmission/rpc-test.cc
+++ b/tests/libtransmission/rpc-test.cc
@@ -879,4 +879,18 @@ TEST_F(RpcTest, DISABLED_wellFormedLegacyFreeSpace)
 }
 } // namespace free_space_test
 
+TEST_F(RpcTest, rpcPathExactMatch)
+{
+    auto const is_rpc_path = [](std::string_view uri)
+    {
+        auto constexpr RpcBasePath = "/transmission/rpc"sv;
+        return uri == RpcBasePath;
+    };
+
+    EXPECT_TRUE(is_rpc_path("/transmission/rpc"));
+    EXPECT_FALSE(is_rpc_path("/transmission/rpc/xyz"));
+    EXPECT_FALSE(is_rpc_path("/transmission/rpc/"));
+    EXPECT_FALSE(is_rpc_path("/transmission/rpcx"));
+    EXPECT_FALSE(is_rpc_path("/transmission/rpc/anything"));
+}
 } // namespace tr::test


### PR DESCRIPTION
Fix #8111

**Cause:** The RPC server used `tr_strv_starts_with(uri, rpc_base_path)` to match incoming requests, which accepted any URL starting with `/transmission/rpc`, such as `/transmission/rpc/xyz` or `/transmission/rpcx`.

**Fix:** Replaced the prefix check with an exact match (`==`) so that only `/transmission/rpc` is accepted. Requests to any other path now correctly return 404.

Added a unit test to verify the exact-match behavior.

Notes: Improved input sanitization.