### PR TITLE
refactor(qt): use percent done value from RPC

### DIFF
--- a/qt/Torrent.h
+++ b/qt/Torrent.h
@@ -302,9 +302,7 @@ public:
 
     [[nodiscard]] constexpr double percentDone() const noexcept
     {
-        auto const l = leftUntilDone();
-        auto const s = sizeWhenDone();
-        return s ? static_cast<double>(s - l) / static_cast<double>(s) : 0.0;
+        return percent_done_;
     }
 
     [[nodiscard]] constexpr auto failedEver() const noexcept


### PR DESCRIPTION
The Qt client used to use the value from `torrent-get.percentDone` before #1044. I'm not understanding why the code was changed to duplicate the core logic, while continuing to fetch `torrent-get.percentDone`.

Anyway, this PR makes the client use `torrent_get.percent_done` again.