### PR TITLE
fix: handle peer ReqQ smaller than floor

### DIFF
--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -2156,7 +2156,8 @@ size_t tr_peerMsgsImpl::max_available_reqs() const
     size_t const estimated_blocks_in_period = (rate.base_quantity() * Seconds) / tr_block_info::BlockSize;
     auto const ceil = peer_reqq_.value_or(PeerReqQDefault);
 
-    return std::clamp(estimated_blocks_in_period, Floor, ceil);
+    // Don't use std::clamp as `ceil` can be smaller than `Floor`
+    return std::max(Floor, std::min(estimated_blocks_in_period, ceil));
 }
 
 } // namespace


### PR DESCRIPTION
Cherry-pick #8689.

Notes: Fixed a `4.1.0` crash that could happen when a peer supplied `reqq` value smaller than 32 in LTEP handshake.