### PR TITLE
fix: use-after-free in tr_peerMsgsImpl peerIo callbacks

### DIFF
--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -1782,6 +1782,7 @@ int tr_peerMsgsImpl::client_got_block(std::span<uint8_t const> block_data, tr_bl
 void tr_peerMsgsImpl::did_write(tr_peerIo* /*io*/, size_t bytes_written, bool was_piece_data, void* vmsgs)
 {
     auto* const msgs = static_cast<tr_peerMsgsImpl*>(vmsgs);
+    auto const keep_alive = msgs->shared_from_this();
 
     if (was_piece_data)
     {
@@ -1794,6 +1795,7 @@ void tr_peerMsgsImpl::did_write(tr_peerIo* /*io*/, size_t bytes_written, bool wa
 ReadState tr_peerMsgsImpl::can_read(tr_peerIo* io, void* vmsgs, size_t* piece)
 {
     auto* const msgs = static_cast<tr_peerMsgsImpl*>(vmsgs);
+    auto const keep_alive = msgs->shared_from_this();
 
     // https://www.bittorrent.org/beps/bep_0003.html
     // Next comes an alternating stream of length prefixes and messages.
@@ -1875,7 +1877,9 @@ ReadState tr_peerMsgsImpl::can_read(tr_peerIo* io, void* vmsgs, size_t* piece)
 
 void tr_peerMsgsImpl::got_error(tr_peerIo* /*io*/, tr_error const& /*error*/, void* vmsgs)
 {
-    static_cast<tr_peerMsgsImpl*>(vmsgs)->publish(tr_peer_event::GotError(ENOTCONN));
+    auto* const msgs = static_cast<tr_peerMsgsImpl*>(vmsgs);
+    auto const keep_alive = msgs->shared_from_this();
+    msgs->publish(tr_peer_event::GotError(ENOTCONN));
 }
 
 // ---


### PR DESCRIPTION
Add `shared_from_this()` guards in `can_read()`, `did_write()`, and `got_error()` to prevent the `tr_peerMsgsImpl` object from being destroyed mid-callback when `process_peer_message()` or `publish()` synchronously triggers torrent stop and peer removal.

Fixes intermittent crashes under high load and high memory pressure.