### PR TITLE
fix: `bugprone-narrowing-conversions` surrounding error codes

### DIFF
--- a/libtransmission/error-types.h
+++ b/libtransmission/error-types.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #ifdef _WIN32
+#include <cstdint>
 
 #include <windows.h>
 
@@ -17,6 +18,14 @@
 #define TR_ERROR_EINVAL ERROR_INVALID_PARAMETER
 #define TR_ERROR_EISDIR ERROR_DIRECTORY_NOT_SUPPORTED
 
+// Smallest integer type that can represent all values returned
+// by `DWORD GetLastError()` and `int WSAGetLastError()`.
+//
+// N.B. DWORD is an unsigned 32-bit integer, so int64_t is the next
+// smallest signed integer type that can represent all its values.
+using tr_error_code_t = int64_t;
+static_assert(sizeof(int) <= sizeof(int64_t));
+
 #else /* _WIN32 */
 
 #include <cerrno>
@@ -24,9 +33,11 @@
 #define TR_ERROR_EINVAL EINVAL
 #define TR_ERROR_EISDIR EISDIR
 
+using tr_error_code_t = int;
+
 #endif /* _WIN32 */
 
-constexpr bool tr_error_is_enoent(int code) noexcept
+constexpr bool tr_error_is_enoent(tr_error_code_t code) noexcept
 {
 #ifdef _WIN32
     return code == ERROR_FILE_NOT_FOUND || code == ERROR_PATH_NOT_FOUND;
@@ -35,7 +46,7 @@ constexpr bool tr_error_is_enoent(int code) noexcept
 #endif
 }
 
-constexpr bool tr_error_is_enospc(int code) noexcept
+constexpr bool tr_error_is_enospc(tr_error_code_t code) noexcept
 {
 #ifdef _WIN32
     return code == ERROR_DISK_FULL;

--- a/libtransmission/error.cc
+++ b/libtransmission/error.cc
@@ -6,9 +6,9 @@
 #include "libtransmission/error.h"
 #include "libtransmission/string-utils.h"
 
-void tr_error::set_from_errno(int errnum)
+void tr_error::set_from_errno(tr_error_code_t errnum)
 {
     code_ = errnum;
 
-    message_ = errnum != 0 ? tr_strerror(errnum) : "";
+    message_ = errnum != 0 ? tr_strerror(static_cast<int>(errnum)) : "";
 }

--- a/libtransmission/error.h
+++ b/libtransmission/error.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <string_view>
 
+#include "libtransmission/error-types.h"
 #include "libtransmission/tr-macros.h"
 
 /** @brief Structure holding error information. */
@@ -16,7 +17,7 @@ struct tr_error
 public:
     TR_CONSTEXPR_STR tr_error() = default;
 
-    TR_CONSTEXPR_STR tr_error(int code, std::string message)
+    TR_CONSTEXPR_STR tr_error(tr_error_code_t code, std::string message)
         : message_{ std::move(message) }
         , code_{ code }
     {
@@ -42,19 +43,19 @@ public:
         return has_value();
     }
 
-    TR_CONSTEXPR_STR void set(int code, std::string&& message)
+    TR_CONSTEXPR_STR void set(tr_error_code_t code, std::string&& message)
     {
         code_ = code;
         message_ = std::move(message);
     }
 
-    TR_CONSTEXPR_STR void set(int code, std::string_view message)
+    TR_CONSTEXPR_STR void set(tr_error_code_t code, std::string_view message)
     {
         code_ = code;
         message_.assign(message);
     }
 
-    TR_CONSTEXPR_STR void set(int code, char const* const message)
+    TR_CONSTEXPR_STR void set(tr_error_code_t code, char const* const message)
     {
         set(code, std::string_view{ message != nullptr ? message : "" });
     }
@@ -65,12 +66,12 @@ public:
     }
 
     // convenience utility for `set(errno, tr_strerror(errno))`
-    void set_from_errno(int errnum);
+    void set_from_errno(tr_error_code_t errnum);
 
 private:
     /** @brief Error message */
     std::string message_;
 
     /** @brief Error code, platform-specific */
-    int code_ = 0;
+    tr_error_code_t code_ = 0;
 };

--- a/libtransmission/inout.cc
+++ b/libtransmission/inout.cc
@@ -233,7 +233,7 @@ std::optional<tr_sha1_digest_t> recalculate_hash(tr_torrent const& tor, tr_piece
 
 } // namespace
 
-int tr_ioRead(tr_torrent const& tor, tr_block_info::Location const& loc, std::span<uint8_t> const setme)
+tr_error_code_t tr_ioRead(tr_torrent const& tor, tr_block_info::Location const& loc, std::span<uint8_t> const setme)
 {
     auto error = tr_error{};
     if (loc.piece >= tor.piece_count())
@@ -258,7 +258,7 @@ int tr_ioRead(tr_torrent const& tor, tr_block_info::Location const& loc, std::sp
     return error.code();
 }
 
-int tr_ioWrite(tr_torrent& tor, tr_block_info::Location const& loc, std::span<uint8_t const> const writeme)
+tr_error_code_t tr_ioWrite(tr_torrent& tor, tr_block_info::Location const& loc, std::span<uint8_t const> const writeme)
 {
     auto error = tr_error{};
     if (loc.piece >= tor.piece_count())

--- a/libtransmission/inout.h
+++ b/libtransmission/inout.h
@@ -12,6 +12,7 @@
 #include <cstdint> // uint8_t
 #include <span>
 
+#include "libtransmission/error-types.h"
 #include "libtransmission/block-info.h"
 #include "libtransmission/types.h"
 
@@ -21,13 +22,13 @@ struct tr_torrent;
  * Reads the block specified by the piece index, offset, and length.
  * @return 0 on success, or an errno value on failure.
  */
-[[nodiscard]] int tr_ioRead(tr_torrent const& tor, tr_block_info::Location const& loc, std::span<uint8_t> setme);
+[[nodiscard]] tr_error_code_t tr_ioRead(tr_torrent const& tor, tr_block_info::Location const& loc, std::span<uint8_t> setme);
 
 /**
  * Writes the block specified by the piece index, offset, and length.
  * @return 0 on success, or an errno value on failure.
  */
-[[nodiscard]] int tr_ioWrite(tr_torrent& tor, tr_block_info::Location const& loc, std::span<uint8_t const> writeme);
+[[nodiscard]] tr_error_code_t tr_ioWrite(tr_torrent& tor, tr_block_info::Location const& loc, std::span<uint8_t const> writeme);
 
 /**
  * @brief Test to see if the piece matches its metainfo's SHA1 checksum.

--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -46,7 +46,7 @@ namespace
 {
 // Helps us to ignore errors that say "try again later"
 // since that's what peer-io does by default anyway.
-[[nodiscard]] constexpr auto can_retry_from_error(int error_code) noexcept
+[[nodiscard]] constexpr auto can_retry_from_error(tr_error_code_t error_code) noexcept
 {
 #ifdef _WIN32
     return error_code == 0 || error_code == WSAEWOULDBLOCK || error_code == WSAEINTR || error_code == WSAEINPROGRESS;

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -639,7 +639,7 @@ private:
 
     void send_ut_pex();
 
-    int client_got_block(std::span<uint8_t const> block_data, tr_block_index_t block);
+    tr_error_code_t client_got_block(std::span<uint8_t const> block_data, tr_block_index_t block);
     ReadResult read_piece_data(MessageReader& payload);
     ReadResult process_peer_message(uint8_t id, MessageReader& payload);
 
@@ -1752,7 +1752,7 @@ ReadResult tr_peerMsgsImpl::read_piece_data(MessageReader& payload)
 }
 
 // returns 0 on success, or an errno on failure
-int tr_peerMsgsImpl::client_got_block(std::span<uint8_t const> block_data, tr_block_index_t const block)
+tr_error_code_t tr_peerMsgsImpl::client_got_block(std::span<uint8_t const> block_data, tr_block_index_t const block)
 {
     auto const n_expected = tor_.block_size(block);
     auto const n_actual = std::size(block_data);

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -2345,9 +2345,9 @@ auto renameFindAffectedFiles(tr_torrent const* tor, std::string_view oldpath)
     return indices;
 }
 
-int renamePath(tr_torrent const* tor, std::string_view oldpath, std::string_view newname)
+auto renamePath(tr_torrent const* tor, std::string_view oldpath, std::string_view newname)
 {
-    int err = 0;
+    tr_error_code_t err = 0;
 
     auto const base = tor->is_done() || std::empty(tor->incomplete_dir()) ? tor->download_dir() : tor->incomplete_dir();
 
@@ -2437,7 +2437,7 @@ void tr_torrent::rename_path_in_session_thread(
 {
     using namespace rename_helpers;
 
-    auto error = 0;
+    tr_error_code_t error = 0;
 
     if (!renameArgsAreValid(this, oldpath, newname))
     {


### PR DESCRIPTION
Split off from #8714 because despite the small LOC, the ripples spread far and wide since `tr_error` is used everywhere.

Fix `bugprone-narrowing-conversions` surrounding error codes.

<details>
<summary>Rant</summary>

Win32 API and their inconsistent data types. Different APIs can have different data types to represent the same thing. 💢 

</details>