### PR TITLE
build: handle error from clang-tidy 22 breaking change

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -889,7 +889,7 @@ if(RUN_CLANG_TIDY)
         endif()
     else()
         message(STATUS "Looking for clang-tidy - found: ${CLANG_TIDY}")
-        set(CMAKE_CXX_CLANG_TIDY "${CLANG_TIDY}")
+        set(CMAKE_CXX_CLANG_TIDY "${CLANG_TIDY}" --allow-no-checks)
     endif()
 endif()
 


### PR DESCRIPTION
Fixes #8717.