### PR TITLE
fix(web): `unicorn/prefer-math-trunc`

### DIFF
--- a/web/src/prefs-dialog.js
+++ b/web/src/prefs-dialog.js
@@ -15,7 +15,7 @@ import {
 export class PrefsDialog extends EventTarget {
   static _initTimeDropDown(e) {
     for (let index = 0; index < 24 * 4; ++index) {
-      const hour = (index / 4) | 0;
+      const hour = Math.trunc(index / 4);
       const mins = (index % 4) * 15;
       const value = index * 15;
       const content = `${hour}:${mins || '00'}`;


### PR DESCRIPTION
```
/home/runner/work/transmission/transmission/web/src/prefs-dialog.js
Error:   18:20  error  Use `Math.trunc` instead of `| 0`  unicorn/prefer-math-trunc
```