### PR TITLE
daemon: avoid periodic idle stats.json rewrites (#8679)

### DIFF
--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -737,7 +737,7 @@ void tr_session::on_save_timer()
         tor->save_resume_file();
     }
 
-    stats().save();
+    stats().save_if_dirty();
     torrent_queue().to_file();
 }
 

--- a/libtransmission/stats.cc
+++ b/libtransmission/stats.cc
@@ -66,10 +66,23 @@ void tr_stats::save() const
     tr_variant_serde::json().to_file(var, tr_pathbuf{ config_dir_, "/stats.json"sv });
 }
 
+void tr_stats::save_if_dirty()
+{
+    if (!is_dirty_)
+    {
+        return;
+    }
+
+    save();
+
+    is_dirty_ = false;
+}
+
 void tr_stats::clear()
 {
     single_ = old_ = Zero;
     start_time_ = tr_time();
+    is_dirty_ = true;
 }
 
 [[nodiscard]] tr_session_stats tr_stats::current() const

--- a/libtransmission/stats.h
+++ b/libtransmission/stats.h
@@ -23,6 +23,7 @@ public:
     tr_stats(std::string_view config_dir, time_t now)
         : config_dir_{ config_dir }
         , start_time_{ now }
+        , is_dirty_{ true }
     {
         single_.sessionCount = 1;
         old_ = load_old_stats(config_dir_);
@@ -50,19 +51,23 @@ public:
     constexpr void add_uploaded(uint32_t n_bytes) noexcept
     {
         single_.uploadedBytes += n_bytes;
+        is_dirty_ = true;
     }
 
     constexpr void add_downloaded(uint32_t n_bytes) noexcept
     {
         single_.downloadedBytes += n_bytes;
+        is_dirty_ = true;
     }
 
     constexpr void add_file_created() noexcept
     {
         ++single_.filesAdded;
+        is_dirty_ = true;
     }
 
     void save() const;
+    void save_if_dirty();
 
 private:
     static tr_session_stats add(tr_session_stats const& a, tr_session_stats const& b);
@@ -75,4 +80,5 @@ private:
     static constexpr auto Zero = tr_session_stats{ TR_RATIO_NA, 0U, 0U, 0U, 0U, 0U };
     tr_session_stats single_ = Zero;
     tr_session_stats old_ = Zero;
+    bool is_dirty_ = false;
 };


### PR DESCRIPTION
Restore dirty-gated periodic stats saves for the daemon.

Cherry-pick of #8679 for 4.1.x.

Notes: Fixed a `4.1.0` regression that periodically wrote upload & download stats to disk even when Transmission had been idle since the last write, preventing the stats file's disk from hibernating while idle.