### PR TITLE
fix: `bugprone-narrowing-conversions` surrounding `tr_session_stats::uploadedBytes`

### DIFF
--- a/libtransmission/serializer.cc
+++ b/libtransmission/serializer.cc
@@ -543,6 +543,7 @@ void Converters::ensure_default_converters()
             Converters::add(to_fs_path, from_fs_path);
             Converters::add(to_int<int64_t>, from_int<int64_t>);
             Converters::add(to_int<size_t>, from_int<size_t>);
+            Converters::add(to_int<time_t>, from_int<time_t>);
             Converters::add(to_int<uint64_t>, from_int<uint64_t>);
             Converters::add(to_log_level, from_log_level);
             Converters::add(to_mode_t, from_mode_t);

--- a/libtransmission/stats.h
+++ b/libtransmission/stats.h
@@ -83,7 +83,7 @@ private:
         .downloadedBytes = 0U,
         .filesAdded = 0U,
         .sessionCount = 0U,
-        .secondsActive = 0U,
+        .secondsActive = time_t{},
     };
     tr_session_stats single_ = Zero;
     tr_session_stats old_ = Zero;

--- a/libtransmission/types.h
+++ b/libtransmission/types.h
@@ -338,7 +338,7 @@ struct tr_session_stats
     uint64_t downloadedBytes; /* total down */
     uint64_t filesAdded; /* number of files added */
     uint64_t sessionCount; /* program started N times */
-    uint64_t secondsActive; /* how long Transmission's been running */
+    time_t secondsActive; /* how long Transmission's been running */
 };
 
 struct tr_stat

--- a/qt/Session.cc
+++ b/qt/Session.cc
@@ -815,46 +815,30 @@ RpcResponseFuture Session::exec(tr_quark method, tr_variant* args)
     return rpc_.exec(method, args);
 }
 
-void Session::updateStats(tr_variant* args_dict, tr_session_stats* stats)
+void Session::updateStats(tr_variant const& args_dict, tr_session_stats& stats)
 {
-    if (auto const value = dictFind<uint64_t>(args_dict, TR_KEY_uploaded_bytes))
-    {
-        stats->uploadedBytes = *value;
-    }
+    static constexpr auto Fields = std::tuple{
+        tr::serializer::Field<&tr_session_stats::downloadedBytes>{ TR_KEY_downloaded_bytes },
+        tr::serializer::Field<&tr_session_stats::filesAdded>{ TR_KEY_files_added },
+        tr::serializer::Field<&tr_session_stats::secondsActive>{ TR_KEY_seconds_active },
+        tr::serializer::Field<&tr_session_stats::sessionCount>{ TR_KEY_session_count },
+        tr::serializer::Field<&tr_session_stats::uploadedBytes>{ TR_KEY_uploaded_bytes },
+    };
+    tr::serializer::load(stats, Fields, args_dict);
 
-    if (auto const value = dictFind<uint64_t>(args_dict, TR_KEY_downloaded_bytes))
-    {
-        stats->downloadedBytes = *value;
-    }
-
-    if (auto const value = dictFind<uint64_t>(args_dict, TR_KEY_files_added))
-    {
-        stats->filesAdded = *value;
-    }
-
-    if (auto const value = dictFind<uint64_t>(args_dict, TR_KEY_session_count))
-    {
-        stats->sessionCount = *value;
-    }
-
-    if (auto const value = dictFind<uint64_t>(args_dict, TR_KEY_seconds_active))
-    {
-        stats->secondsActive = *value;
-    }
-
-    stats->ratio = static_cast<float>(tr_getRatio(stats->uploadedBytes, stats->downloadedBytes));
+    stats.ratio = static_cast<float>(tr_getRatio(stats.uploadedBytes, stats.downloadedBytes));
 }
 
 void Session::updateStats(tr_variant* dict)
 {
     if (tr_variant* var = nullptr; tr_variantDictFindDict(dict, TR_KEY_current_stats, &var))
     {
-        updateStats(var, &stats_);
+        updateStats(*var, stats_);
     }
 
     if (tr_variant* var = nullptr; tr_variantDictFindDict(dict, TR_KEY_cumulative_stats, &var))
     {
-        updateStats(var, &cumulative_stats_);
+        updateStats(*var, cumulative_stats_);
     }
 
     emit statsUpdated();

--- a/qt/Session.h
+++ b/qt/Session.h
@@ -176,7 +176,7 @@ private:
     void sendTorrentRequest(tr_quark method, torrent_ids_t const& torrent_ids);
     void refreshTorrents(torrent_ids_t const& ids, TorrentProperties props);
 
-    static void updateStats(tr_variant* args_dict, tr_session_stats* stats);
+    static void updateStats(tr_variant const& args_dict, tr_session_stats& stats);
 
     void addOptionalIds(tr_variant::Map& params, torrent_ids_t const& torrent_ids) const;
     void addOptionalIds(tr_variant* args_dict, torrent_ids_t const& torrent_ids) const;
@@ -206,6 +206,6 @@ private:
         .downloadedBytes = 0,
         .filesAdded = 0,
         .sessionCount = 0,
-        .secondsActive = 0,
+        .secondsActive = time_t{},
     };
 };

--- a/qt/StatsDialog.cc
+++ b/qt/StatsDialog.cc
@@ -53,12 +53,12 @@ void StatsDialog::updateStats()
     ui_.currentUploadedValueLabel->setText(Formatter::storage_to_string(current.uploadedBytes));
     ui_.currentDownloadedValueLabel->setText(Formatter::storage_to_string(current.downloadedBytes));
     ui_.currentRatioValueLabel->setText(Formatter::ratio_to_string(current.ratio));
-    ui_.currentDurationValueLabel->setText(Formatter::time_to_string(current.secondsActive));
+    ui_.currentDurationValueLabel->setText(Formatter::time_to_string(static_cast<int>(current.secondsActive)));
 
     ui_.totalUploadedValueLabel->setText(Formatter::storage_to_string(total.uploadedBytes));
     ui_.totalDownloadedValueLabel->setText(Formatter::storage_to_string(total.downloadedBytes));
     ui_.totalRatioValueLabel->setText(Formatter::ratio_to_string(total.ratio));
-    ui_.totalDurationValueLabel->setText(Formatter::time_to_string(total.secondsActive));
+    ui_.totalDurationValueLabel->setText(Formatter::time_to_string(static_cast<int>(total.secondsActive)));
 
     ui_.startCountLabel->setText(tr("Started %Ln time(s)", nullptr, total.sessionCount));
 }

--- a/tests/libtransmission/serializer-tests.cc
+++ b/tests/libtransmission/serializer-tests.cc
@@ -154,6 +154,18 @@ TEST_F(SerializerTest, usesBuiltins)
     }
 }
 
+TEST_F(SerializerTest, usesTimeT)
+{
+    static auto constexpr Expected = time_t{ 1774486600 };
+    auto const var = Converters::serialize(Expected);
+    EXPECT_TRUE(var.holds_alternative<int64_t>());
+    EXPECT_EQ(var.value_if<time_t>(), Expected);
+
+    auto actual = time_t{};
+    EXPECT_TRUE(Converters::deserialize(var, &actual));
+    EXPECT_EQ(actual, Expected);
+}
+
 TEST_F(SerializerTest, usesU8String)
 {
     auto const expected = std::u8string{ u8"hello" };


### PR DESCRIPTION
Change the data type of `tr_session_stats::uploadedBytes` to `time_t`, as most usages of this field expected `time_t`, and semantically it makes more sense too.