### PR TITLE
fix: reject values outside of uint16_t range in port settings

### DIFF
--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -2379,7 +2379,7 @@ using SessionAccessors = std::pair<SessionGetter, SessionSetter>;
         [](tr_session const& src) -> tr_variant { return src.advertisedPeerPort().host(); },
         [](tr_session& tgt, tr_variant const& src, ErrorInfo& /*err*/)
         {
-            if (auto const val = src.value_if<int64_t>())
+            if (auto const val = src.value_if<uint16_t>())
             {
                 tr_sessionSetPeerPort(&tgt, *val);
             }

--- a/libtransmission/serializer.cc
+++ b/libtransmission/serializer.cc
@@ -241,7 +241,7 @@ tr_variant from_msec(std::chrono::milliseconds const& src)
 
 bool to_port(tr_variant const& src, tr_port* tgt)
 {
-    if (auto const val = src.value_if<int64_t>())
+    if (auto const val = src.value_if<uint16_t>())
     {
         *tgt = tr_port::from_host(*val);
         return true;
@@ -252,7 +252,7 @@ bool to_port(tr_variant const& src, tr_port* tgt)
 
 tr_variant from_port(tr_port const& val)
 {
-    return int64_t{ val.host() };
+    return val.host();
 }
 
 // ---

--- a/tests/libtransmission/settings-test.cc
+++ b/tests/libtransmission/settings-test.cc
@@ -205,13 +205,29 @@ TEST_F(SettingsTest, canLoadPort)
 
     auto settings = tr_session::Settings{};
     auto const default_value = settings.peer_port;
-    auto constexpr ExpectedValue = tr_port::from_host(8080);
+    static auto constexpr ExpectedValue = tr_port::from_host(8080);
     ASSERT_NE(ExpectedValue, default_value);
 
     auto map = tr_variant::Map{ 1U };
     map.try_emplace(Key, ExpectedValue.host());
-    settings.load(tr_variant{ std::move(map) });
+    settings.load(std::move(map));
     EXPECT_EQ(ExpectedValue, settings.peer_port);
+
+    static auto constexpr TooLargeValue = 0x10000;
+    EXPECT_NE(TooLargeValue, default_value.host());
+    settings = tr_session::Settings{};
+    map = tr_variant::Map{ 1U };
+    map.insert_or_assign(Key, TooLargeValue);
+    settings.load(std::move(map));
+    EXPECT_EQ(default_value, settings.peer_port);
+
+    static auto constexpr TooSmallValue = -1;
+    EXPECT_NE(TooSmallValue, default_value.host());
+    settings = tr_session::Settings{};
+    map = tr_variant::Map{ 1U };
+    map.insert_or_assign(Key, TooSmallValue);
+    settings.load(std::move(map));
+    EXPECT_EQ(default_value, settings.peer_port);
 }
 
 TEST_F(SettingsTest, canSavePort)


### PR DESCRIPTION
Notes: Improved input sanitization.