### PR TITLE
fix #8110: stop rpc server if rpc-enable changes to false

### DIFF
--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -1034,6 +1034,10 @@ void tr_rpc_server::load(Settings&& settings)
             tr_logAddInfo(_("Password required"));
         }
     }
+    else
+    {
+        session->run_in_session_thread(stop_server, this);
+    }
 
     if (!std::empty(web_client_dir_))
     {


### PR DESCRIPTION
During the rpc server's execution, it would previously turn on if the rpc-enabled variable in settings.json was turned from false to true but it would not turn off if it went from true to false. This patch adds an else branch that stops the server if the newly received rpc-enabled setting is false.
This closes #8110 