### PR TITLE
fix: initialized torrent list after web reconnect.

### DIFF
--- a/web/src/remote.js
+++ b/web/src/remote.js
@@ -71,6 +71,7 @@ export class Remote {
         if (this._connection_alert) {
           this._connection_alert.close();
           this._connection_alert = null;
+          this._controller._initializeTorrents();
         }
       })
       .catch((error) => {


### PR DESCRIPTION
Fixes #8180.

When transmission-daemon was restarted with new torrents added to the watch directory while stopped, the web interface would display mismatched progress bars and torrent names. This occurred because on reconnection, only recently active torrents were fetched with partial stats, leaving the UI out of sync with the daemon's actual torrent list. This patch adds a full torrent reinitialization when the connection to the daemon is restored, mirroring the behavior of a full page reload.