### PR TITLE
fix(web): reconstruct torrent list if `ids` is null

### DIFF
--- a/web/src/transmission.js
+++ b/web/src/transmission.js
@@ -951,6 +951,10 @@ export class Transmission extends EventTarget {
 
   updateTorrents(ids, fields) {
     this.remote.updateTorrents(ids, fields, (table, removed_ids) => {
+      if (!ids) {
+        this._torrents = {};
+      }
+
       const needinfo = [];
 
       const keys = table.shift();


### PR DESCRIPTION
This is a counterpart of #8733. Whereas #8733 handles the case where new torrents were added while the daemon was disconnected from the web client, this PR handles the case where torrents were removed.

Notes: Fix corrupted torrent list in the web client if the connection to the daemon was lost for more than 60 seconds.