### PR TITLE
Implemented metadata download with test for paused torrents

### DIFF
--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1006,7 +1006,7 @@ void tr_torrent::init(tr_ctor const& ctor)
     {
         on_metainfo_completed();
     }
-    else if (start_when_stable_)
+    else if (start_when_stable_ || !has_metainfo)
     {
         auto const bypass_queue = !has_metainfo; // to fetch metainfo from peers
         start(bypass_queue, has_any_local_data);

--- a/tests/libtransmission/torrent-magnet-test.cc
+++ b/tests/libtransmission/torrent-magnet-test.cc
@@ -3,15 +3,20 @@
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.
 
+#include <condition_variable>
 #include <cstddef> // size_t
 #include <future>
+#include <mutex>
 #include <string>
 
 #include <gtest/gtest.h>
 
+#include <libtransmission/crypto-utils.h> // tr_base64_decode()
 #include <libtransmission/error.h>
+#include <libtransmission/torrent-ctor.h>
 #include <libtransmission/torrent-magnet.h>
 #include <libtransmission/torrent-metainfo.h>
+#include <libtransmission/transmission.h>
 
 #include "test-fixtures.h"
 
@@ -88,6 +93,70 @@ TEST_F(TorrentMagnetTest, setMetadataPiece)
     EXPECT_TRUE(waitFor([tor] { return tor->has_metainfo(); }, 5s));
     EXPECT_EQ(tor->info_dict_size(), metainfo_size);
     EXPECT_EQ(tor->get_metadata_percent(), 1.0);
+}
+
+TEST_F(TorrentMagnetTest, addedPausedFetchesMetadataButRemainsStoppedAfterwards)
+{
+    // Same info dict as `setMetadataPiece` (the zero-torrent's BEP-9 metadata)
+    static auto constexpr InfoDictBase64 =
+        "ZDU6ZmlsZXNsZDY6bGVuZ3RoaTEwNDg1NzZlNDpwYXRobDc6MTA0ODU3NmVlZDY6bGVuZ3RoaTQw"
+        "OTZlNDpwYXRobDQ6NDA5NmVlZDY6bGVuZ3RoaTUxMmU0OnBhdGhsMzo1MTJlZWU0Om5hbWUyNDpm"
+        "aWxlcy1maWxsZWQtd2l0aC16ZXJvZXMxMjpwaWVjZSBsZW5ndGhpMzI3NjhlNjpwaWVjZXM2NjA6"
+        "UYhDGEm0YTFS/XvbpqP/Ck/WQktRiEMYSbRhMVL9e9umo/8KT9ZCS1GIQxhJtGExUv1726aj/wpP"
+        "1kJLUYhDGEm0YTFS/XvbpqP/Ck/WQktRiEMYSbRhMVL9e9umo/8KT9ZCS1GIQxhJtGExUv1726aj"
+        "/wpP1kJLUYhDGEm0YTFS/XvbpqP/Ck/WQktRiEMYSbRhMVL9e9umo/8KT9ZCS1GIQxhJtGExUv17"
+        "26aj/wpP1kJLUYhDGEm0YTFS/XvbpqP/Ck/WQktRiEMYSbRhMVL9e9umo/8KT9ZCS1GIQxhJtGEx"
+        "Uv1726aj/wpP1kJLUYhDGEm0YTFS/XvbpqP/Ck/WQktRiEMYSbRhMVL9e9umo/8KT9ZCS1GIQxhJ"
+        "tGExUv1726aj/wpP1kJLUYhDGEm0YTFS/XvbpqP/Ck/WQktRiEMYSbRhMVL9e9umo/8KT9ZCS1GI"
+        "QxhJtGExUv1726aj/wpP1kJLUYhDGEm0YTFS/XvbpqP/Ck/WQktRiEMYSbRhMVL9e9umo/8KT9ZC"
+        "S1GIQxhJtGExUv1726aj/wpP1kJLUYhDGEm0YTFS/XvbpqP/Ck/WQktRiEMYSbRhMVL9e9umo/8K"
+        "T9ZCS1GIQxhJtGExUv1726aj/wpP1kJLUYhDGEm0YTFS/XvbpqP/Ck/WQktRiEMYSbRhMVL9e9um"
+        "o/8KT9ZCS1GIQxhJtGExUv1726aj/wpP1kJLUYhDGEm0YTFS/XvbpqP/Ck/WQktRiEMYSbRhMVL9"
+        "e9umo/8KT9ZCS1GIQxhJtGExUv1726aj/wpP1kJLUYhDGEm0YTFS/XvbpqP/Ck/WQktRiEMYSbRh"
+        "MVL9e9umo/8KT9ZCSzpX+QPk899JzAVbjTNoaVd8IP9dNzpwcml2YXRlaTBlZQ==";
+
+    // Create a ctor for a paused magnet torrent and register a verify-done hook
+    // so we can wait for the verify that fires automatically after metadata arrives
+    static auto constexpr V1Hash = "fa5794674a18241bec985ddc3390e3cb171345e4";
+    auto* ctor = tr_ctorNew(session_);
+    ctor->set_metainfo_from_magnet_link(V1Hash);
+    tr_ctorSetPaused(ctor, TR_FORCE, true);
+
+    auto verified = std::promise<tr_torrent*>{};
+    auto verified_future = verified.get_future();
+    ctor->set_verify_done_callback([&verified](tr_torrent* const tor) { verified.set_value(tor); });
+
+    auto* const tor = tr_torrentNew(ctor, nullptr);
+    ASSERT_NE(nullptr, tor);
+    tr_ctorFree(ctor);
+
+    // Even though the torrent was added paused it must start immediately so
+    // it can connect to peers and fetch the missing metadata via BEP-9.
+    EXPECT_TRUE(tor->is_running());
+    EXPECT_FALSE(tor->has_metainfo());
+
+    // Simulate receiving the metadata from a peer
+    auto const metainfo_benc = tr_base64_decode(InfoDictBase64);
+    auto const metainfo_size = std::size(metainfo_benc);
+    EXPECT_LE(metainfo_size, MetadataPieceSize);
+    session_->run_in_session_thread(
+        [&]()
+        {
+            tor->maybe_start_metadata_transfer(metainfo_size);
+            tor->set_metadata_piece(0, std::data(metainfo_benc), metainfo_size);
+        });
+
+    // Wait for the metainfo to be stored on the torrent
+    EXPECT_TRUE(waitFor([tor] { return tor->has_metainfo(); }, 5s));
+
+    // Wait for the verify pass triggered by on_metainfo_completed() to finish
+    ASSERT_EQ(std::future_status::ready, verified_future.wait_for(20s));
+    EXPECT_EQ(tor, verified_future.get());
+
+    // After metadata + verify the torrent must still be stopped (paused),
+    // keeping the user's original "add paused" intent
+    EXPECT_FALSE(tor->is_running());
+    EXPECT_EQ(TR_STATUS_STOPPED, tor->activity());
 }
 
 } // namespace tr::test


### PR DESCRIPTION
Hello,

This is a feature PR for downloading metadata for torrents that were added paused from a magnet link.

Some clients implement metadata fetching in the options dialog and I almost finished implementing that originally, but considering the variety of GUI front-ends, including web-based ones, the implementation was getting pretty large.

This is much cleaner approach and works across all front-ends.

Why is it useful?
The torrent can be added paused from a magnet link, and when the metadata is ready, the user can unselect unneeded files, change trackers, do whatever needs to be done, and then start the torrent.

How it works?
When a magnet link is added paused (start_when_stable_ = false), the torrent now calls start(bypass_queue=true, ...) to connect to peers and fetch metadata via BEP-9 (ut_metadata). Once metadata arrives:

1. set_metainfo() -> on_metainfo_completed() is called.
2. tr_torrentVerify() is invoked and since the torrent is running, it calls stop_now() first.

After verify completes, start_when_stable_ = false so the torrent stays stopped with its file list now populated.

The torrent ends up paused as the user intended, but with full metadata available.

I also implemented a test to make sure this feature does not get broken accidentally.