### PR TITLE
refactor: TCP segment payloads at least 128 bytes

### DIFF
--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -108,9 +108,15 @@ std::shared_ptr<tr_peerIo> tr_peerIo::create(
     io->flush_outbuf_trigger_->set_callback(
         [weak = io->weak_from_this()]
         {
+            // https://github.com/transmission/transmission/issues/7307
+            static auto constexpr MinPayloadSize = 128U;
+
             if (auto const ptr = weak.lock())
             {
-                ptr->try_write(SIZE_MAX);
+                if (ptr->outbuf_.size() >= MinPayloadSize)
+                {
+                    ptr->try_write(SIZE_MAX);
+                }
             }
         });
     tr_logAddTraceIo(io, fmt::format("bandwidth is {}; its parent is {}", fmt::ptr(&io->bandwidth()), fmt::ptr(parent)));


### PR DESCRIPTION
Cherry-pick #8745.

Notes: Fixed a `4.1.0` bug that prevented TCP peer connections on some systems.