### PR TITLE
Bugfix: Defined serializer and deserializer for int

### DIFF
--- a/libtransmission/serializer.cc
+++ b/libtransmission/serializer.cc
@@ -541,6 +541,7 @@ void Converters::ensure_default_converters()
             Converters::add(to_double, from_double);
             Converters::add(to_encryption_mode, from_encryption_mode);
             Converters::add(to_fs_path, from_fs_path);
+            Converters::add(to_int<int>, from_int<int>);
             Converters::add(to_int<int64_t>, from_int<int64_t>);
             Converters::add(to_int<size_t>, from_int<size_t>);
             Converters::add(to_int<uint64_t>, from_int<uint64_t>);


### PR DESCRIPTION
This is a bugfix for GTK3 integer serialization issue.

How to duplicate?
1. Run transmission-gtk from Linux terminal.
2. Open Preferences -> Network
3. Change Port number
4. Close the dialog
5. Terminal prints:
```
ERROR: No deserializer registered for type 'i'
ERROR: No serializer registered for type 'i'
```
6. Open Preferences -> Network
7. The port is set to "1"

The issue is triggered by line 196 of PrefsDialog.cc and possibly others.
`core_->set_pref(key, spin.get_value_as_int());`

The issue was introduced somewhere between 4.0.5 and 4.2.0-dev