### PR TITLE
option to close transmission when last transfer auto-removed

### DIFF
--- a/macosx/Base.lproj/PrefsWindow.xib
+++ b/macosx/Base.lproj/PrefsWindow.xib
@@ -1076,6 +1076,17 @@
                                                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                 </textFieldCell>
                                             </textField>
+                                            <button translatesAutoresizingMaskIntoConstraints="NO" id="QWz-Tn-r8K">
+                                                <rect key="frame" x="96" y="159" width="398" height="18"/>
+                                                <buttonCell key="cell" type="check" title="Close Transmission when last active transfer is removed" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="NHx-Vp-d3M">
+                                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                    <font key="font" metaFont="system"/>
+                                                </buttonCell>
+                                                <connections>
+                                                    <binding destination="365" name="enabled" keyPath="values.RemoveWhenFinishSeeding" id="tGw-Hz-J8q"/>
+                                                    <binding destination="365" name="value" keyPath="values.CloseWhenLastTransferRemoved" id="vMn-Xk-L9r"/>
+                                                </connections>
+                                            </button>
                                             <button verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="Evu-rf-BPM">
                                                 <rect key="frame" x="76" y="99" width="257" height="18"/>
                                                 <buttonCell key="cell" type="check" title="Verify data when download completes" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="wM8-cD-WAB">
@@ -1121,7 +1132,7 @@
                                             <constraint firstItem="1298" firstAttribute="leading" secondItem="1301" secondAttribute="trailing" constant="8" symbolic="YES" id="PMy-jP-rEj"/>
                                             <constraint firstItem="2043" firstAttribute="centerY" secondItem="2046" secondAttribute="centerY" id="PSZ-ae-Eqx"/>
                                             <constraint firstItem="2043" firstAttribute="top" secondItem="1299" secondAttribute="bottom" constant="20" id="Qf1-Gf-NrG"/>
-                                            <constraint firstItem="337" firstAttribute="top" secondItem="2122" secondAttribute="bottom" constant="20" id="RNI-7M-7QS"/>
+                                            <constraint firstItem="337" firstAttribute="top" secondItem="QWz-Tn-r8K" secondAttribute="bottom" constant="20" id="RNI-7M-7QS"/>
                                             <constraint firstItem="636" firstAttribute="centerY" secondItem="639" secondAttribute="centerY" id="RzR-et-pCg"/>
                                             <constraint firstItem="2046" firstAttribute="width" secondItem="267" secondAttribute="width" id="Ubm-6P-bEl"/>
                                             <constraint firstItem="1300" firstAttribute="leading" secondItem="1299" secondAttribute="trailing" constant="8" symbolic="YES" id="Vxv-Ha-Cat"/>
@@ -1142,6 +1153,9 @@
                                             <constraint firstItem="257" firstAttribute="centerY" secondItem="337" secondAttribute="centerY" id="f2o-bs-2xS"/>
                                             <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="2118" secondAttribute="trailing" constant="20" symbolic="YES" id="gWX-1m-B0d"/>
                                             <constraint firstItem="2122" firstAttribute="top" secondItem="2118" secondAttribute="bottom" constant="2" id="ifS-4u-lBe"/>
+                                            <constraint firstItem="QWz-Tn-r8K" firstAttribute="leading" secondItem="2118" secondAttribute="leading" constant="20" id="jRw-Kz-B4n"/>
+                                            <constraint firstItem="QWz-Tn-r8K" firstAttribute="top" secondItem="2122" secondAttribute="bottom" constant="4" id="pXk-Yf-T2v"/>
+                                            <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="QWz-Tn-r8K" secondAttribute="trailing" constant="20" symbolic="YES" id="mDs-Ab-C7e"/>
                                             <constraint firstItem="267" firstAttribute="top" secondItem="4cS-54-dlc" secondAttribute="top" constant="3" id="jC8-Fg-aoK"/>
                                             <constraint firstItem="2048" firstAttribute="centerY" secondItem="2046" secondAttribute="centerY" id="kRG-P0-HOO"/>
                                             <constraint firstItem="268" firstAttribute="top" secondItem="264" secondAttribute="bottom" constant="2" id="lDA-6s-bJO"/>

--- a/macosx/Base.lproj/PrefsWindow.xib
+++ b/macosx/Base.lproj/PrefsWindow.xib
@@ -1078,7 +1078,7 @@
                                             </textField>
                                             <button translatesAutoresizingMaskIntoConstraints="NO" id="QWz-Tn-r8K">
                                                 <rect key="frame" x="96" y="159" width="398" height="18"/>
-                                                <buttonCell key="cell" type="check" title="Close Transmission when last active transfer is removed" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="NHx-Vp-d3M">
+                                                <buttonCell key="cell" type="check" title="Close Transmission when last transfer removed" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="NHx-Vp-d3M">
                                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                     <font key="font" metaFont="system"/>
                                                 </buttonCell>

--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -2673,6 +2673,24 @@ static void removeKeRangerRansomware()
     if (torrent.removeWhenFinishSeeding)
     {
         [self confirmRemoveTorrents:@[ torrent ] deleteData:NO];
+
+        if ([self.fDefaults boolForKey:@"CloseWhenLastTransferRemoved"])
+        {
+            BOOL hasActiveTransfer = NO;
+            for (Torrent* t in self.fTorrents)
+            {
+                if (t.active)
+                {
+                    hasActiveTransfer = YES;
+                    break;
+                }
+            }
+            if (!hasActiveTransfer)
+            {
+                self.fQuitRequested = YES;
+                [NSApp terminate:self];
+            }
+        }
     }
     else
     {

--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -2678,6 +2678,7 @@ static void removeKeRangerRansomware()
         {
             if (self.fTorrents.count == 0)
             {
+                [torrent closeRemoveTorrent:NO];
                 self.fQuitRequested = YES;
                 [NSApp terminate:self];
             }

--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -2676,16 +2676,7 @@ static void removeKeRangerRansomware()
 
         if ([self.fDefaults boolForKey:@"CloseWhenLastTransferRemoved"])
         {
-            BOOL hasActiveTransfer = NO;
-            for (Torrent* t in self.fTorrents)
-            {
-                if (t.active)
-                {
-                    hasActiveTransfer = YES;
-                    break;
-                }
-            }
-            if (!hasActiveTransfer)
+            if (self.fTorrents.count == 0)
             {
                 self.fQuitRequested = YES;
                 [NSApp terminate:self];

--- a/macosx/Defaults.plist
+++ b/macosx/Defaults.plist
@@ -32,6 +32,8 @@
 	<false/>
 	<key>CheckUpload</key>
 	<false/>
+	<key>CloseWhenLastTransferRemoved</key>
+	<false/>
 	<key>CreatorLocation</key>
 	<string>~/Desktop</string>
 	<key>DeleteOriginalTorrent</key>


### PR DESCRIPTION
Notes: Added a setting to automatically place single-file torrents into their own subfolder when downloading.

Removing a transfer when a specific seeding goal is achieved is a nice feature. An even nicer feature for me would be to also close Transmission when all is said and done.

I used Cursor to write this, not a one-shot but many iterations to get it do actually work. I have manually QA'd this on my machine and it works.