### PR TITLE
option to create folder for single files

### DIFF
--- a/gtk/PrefsDialog.cc
+++ b/gtk/PrefsDialog.cc
@@ -453,6 +453,7 @@ DownloadingPage::DownloadingPage(
     init_chooser_button("download_dir_chooser", TR_KEY_download_dir);
     init_spin_button("max_active_downloads_spin", TR_KEY_download_queue_size, 0, std::numeric_limits<int>::max(), 1);
     init_spin_button("max_inactive_time_spin", TR_KEY_queue_stalled_minutes, 1, std::numeric_limits<int>::max(), 15);
+    init_check_button("wrap_single_file_torrents_check", TR_KEY_wrap_single_file_torrents);
     init_check_button("append_suffix_to_incomplete_check", TR_KEY_rename_partial_files);
     init_check_button("incomplete_dir_check", TR_KEY_incomplete_dir_enabled);
     init_chooser_button("incomplete_dir_chooser", TR_KEY_incomplete_dir);

--- a/gtk/ui/gtk3/PrefsDialog.ui
+++ b/gtk/ui/gtk3/PrefsDialog.ui
@@ -719,6 +719,23 @@
                             <property name="top-attach">2</property>
                           </packing>
                         </child>
+                        <child>
+                          <object class="GtkCheckButton" id="wrap_single_file_torrents_check">
+                            <property name="label" translatable="yes">Put single-file torrents into a _subfolder</property>
+                            <property name="visible">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">False</property>
+                            <property name="valign">center</property>
+                            <property name="hexpand">True</property>
+                            <property name="use-underline">True</property>
+                            <property name="draw-indicator">True</property>
+                          </object>
+                          <packing>
+                            <property name="left-attach">0</property>
+                            <property name="top-attach">3</property>
+                            <property name="width">2</property>
+                          </packing>
+                        </child>
                       </object>
                     </child>
                   </object>

--- a/gtk/ui/gtk4/PrefsDialog.ui
+++ b/gtk/ui/gtk4/PrefsDialog.ui
@@ -517,6 +517,20 @@
                                 </layout>
                               </object>
                             </child>
+                            <child>
+                              <object class="GtkCheckButton" id="wrap_single_file_torrents_check">
+                                <property name="label" translatable="yes">Put single-file torrents into a _subfolder</property>
+                                <property name="focusable">1</property>
+                                <property name="valign">center</property>
+                                <property name="hexpand">1</property>
+                                <property name="use-underline">1</property>
+                                <layout>
+                                  <property name="column">0</property>
+                                  <property name="row">3</property>
+                                  <property name="column-span">2</property>
+                                </layout>
+                              </object>
+                            </child>
                           </object>
                         </child>
                       </object>

--- a/libtransmission/quark.cc
+++ b/libtransmission/quark.cc
@@ -738,6 +738,7 @@ auto constexpr MyStatic = std::array<std::u8string_view, TR_N_KEYS>{
     u8"webseedsSendingToUs"sv, // rpc
     u8"webseeds_ex"sv, // rpc
     u8"webseeds_sending_to_us"sv, // rpc
+    u8"wrap_single_file_torrents"sv, // rpc, tr_session::Settings
     u8"yourip"sv, // BEP0010; BT protocol
 };
 

--- a/libtransmission/quark.h
+++ b/libtransmission/quark.h
@@ -749,6 +749,7 @@ enum // NOLINT(performance-enum-size)
     TR_KEY_webseeds_sending_to_us_camel_APICOMPAT,
     TR_KEY_webseeds_ex,
     TR_KEY_webseeds_sending_to_us,
+    TR_KEY_wrap_single_file_torrents,
     TR_KEY_yourip,
     TR_N_KEYS
 };

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -2627,6 +2627,17 @@ using SessionAccessors = std::pair<SessionGetter, SessionSetter>;
         [](tr_session const& /*src*/) -> tr_variant { return tr_variant::unmanaged_string(LONG_VERSION_STRING); },
         nullptr);
 
+    map.try_emplace(
+        TR_KEY_wrap_single_file_torrents,
+        [](tr_session const& src) -> tr_variant { return src.wrap_single_file_torrents(); },
+        [](tr_session& tgt, tr_variant const& src, ErrorInfo& /*err*/)
+        {
+            if (auto const val = src.value_if<bool>())
+            {
+                tr_sessionSetWrapSingleFileTorrents(&tgt, *val);
+            }
+        });
+
     // `row` could have been replaced by structured bindings,
     // but it's not available until clang 16
     // https://github.com/llvm/llvm-project/commit/44f2baa3804a62ca793f0ff3e43aa71cea91a795

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -1009,6 +1009,20 @@ bool tr_sessionIsIncompleteFileNamingEnabled(tr_session const* session)
     return session->isIncompleteFileNamingEnabled();
 }
 
+bool tr_sessionGetWrapSingleFileTorrents(tr_session const* session)
+{
+    TR_ASSERT(session != nullptr);
+
+    return session->wrap_single_file_torrents();
+}
+
+void tr_sessionSetWrapSingleFileTorrents(tr_session* session, bool wrap)
+{
+    TR_ASSERT(session != nullptr);
+
+    session->set_wrap_single_file_torrents(wrap);
+}
+
 // ---
 
 void tr_sessionSetIncompleteDir(tr_session* session, std::string_view const dir)

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -460,6 +460,7 @@ public:
         bool tcp_enabled = true;
         bool torrent_complete_verify_enabled = false;
         bool utp_enabled = true;
+        bool wrap_single_file_torrents = false;
         double ratio_limit = 2.0;
         size_t unused_cache_size_mbytes = 4U; // TODO(TR5): remove
         size_t download_queue_size = 5U;
@@ -571,6 +572,7 @@ public:
             Field<&Settings::umask>{ TR_KEY_umask },
             Field<&Settings::upload_slots_per_torrent>{ TR_KEY_upload_slots_per_torrent },
             Field<&Settings::utp_enabled>{ TR_KEY_utp_enabled },
+            Field<&Settings::wrap_single_file_torrents>{ TR_KEY_wrap_single_file_torrents },
         };
     };
 
@@ -800,6 +802,16 @@ public:
     void set_sequential_download(bool seq) noexcept
     {
         settings_.sequential_download = seq;
+    }
+
+    [[nodiscard]] constexpr auto wrap_single_file_torrents() const noexcept
+    {
+        return settings().wrap_single_file_torrents;
+    }
+
+    void set_wrap_single_file_torrents(bool wrap) noexcept
+    {
+        settings_.wrap_single_file_torrents = wrap;
     }
 
     // bandwidth
@@ -1331,6 +1343,7 @@ private:
     friend void tr_sessionSetRatioLimit(tr_session* session, double desired_ratio);
     friend void tr_sessionSetRatioLimited(tr_session* session, bool is_limited);
     friend void tr_sessionSetUTPEnabled(tr_session* session, bool enabled);
+    friend void tr_sessionSetWrapSingleFileTorrents(tr_session* session, bool wrap);
     friend void tr_sessionUseAltSpeed(tr_session* session, bool enabled);
     friend void tr_sessionUseAltSpeedTime(tr_session* session, bool enabled);
 

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1062,6 +1062,16 @@ tr_torrent* tr_torrentNew(tr_ctor* ctor, tr_torrent** setme_duplicate_of)
         return nullptr;
     }
 
+    if (session->wrap_single_file_torrents() && metainfo.file_count() == 1 &&
+        !tr_strv_contains(metainfo.file_subpath(0), '/'))
+    {
+        auto const folder = tr_torrent_files::sanitize_subpath(metainfo.name());
+        if (!std::empty(folder))
+        {
+            metainfo.set_file_subpath(0, tr_pathbuf{ folder, '/', metainfo.file_subpath(0) }.sv());
+        }
+    }
+
     auto* const tor = new tr_torrent{ std::move(metainfo) };
     tor->verify_done_callback_ = ctor->steal_verify_done_callback();
     tor->init(*ctor);

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1026,6 +1026,17 @@ void tr_torrent::init(tr_ctor const& ctor)
 void tr_torrent::set_metainfo(tr_torrent_metainfo tm)
 {
     TR_ASSERT(!has_metainfo());
+
+    if (session->wrap_single_file_torrents() && tm.file_count() == 1 &&
+        !tr_strv_contains(tm.file_subpath(0), '/'))
+    {
+        auto const folder = tr_torrent_files::sanitize_subpath(tm.name());
+        if (!std::empty(folder))
+        {
+            tm.set_file_subpath(0, tr_pathbuf{ folder, '/', tm.file_subpath(0) }.sv());
+        }
+    }
+
     metainfo_ = std::move(tm);
     on_metainfo_updated();
 

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -222,6 +222,9 @@ bool tr_sessionIsIncompleteFileNamingEnabled(tr_session const* session);
  */
 void tr_sessionSetIncompleteFileNamingEnabled(tr_session* session, bool enabled);
 
+bool tr_sessionGetWrapSingleFileTorrents(tr_session const* session);
+void tr_sessionSetWrapSingleFileTorrents(tr_session* session, bool wrap);
+
 /** @brief Get whether or not RPC calls are allowed in this session.
     @see `tr_sessionInit()`
     @see `tr_sessionSetRPCEnabled()` */

--- a/macosx/Base.lproj/PrefsWindow.xib
+++ b/macosx/Base.lproj/PrefsWindow.xib
@@ -447,6 +447,17 @@
                                                     <binding destination="365" name="value" keyPath="values.RenamePartialFiles" id="1942"/>
                                                 </connections>
                                             </button>
+                                            <button translatesAutoresizingMaskIntoConstraints="NO" id="2001">
+                                                <rect key="frame" x="84" y="168" width="280" height="18"/>
+                                                <buttonCell key="cell" type="check" title="Put single-file torrents into a subfolder" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="2002">
+                                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                    <font key="font" metaFont="system"/>
+                                                </buttonCell>
+                                                <connections>
+                                                    <action selector="setWrapSingleFileTorrents:" target="-2" id="2003"/>
+                                                    <binding destination="365" name="value" keyPath="values.WrapSingleFileTorrents" id="2004"/>
+                                                </connections>
+                                            </button>
                                             <button translatesAutoresizingMaskIntoConstraints="NO" id="209">
                                                 <rect key="frame" x="84" y="56" width="177" height="18"/>
                                                 <buttonCell key="cell" type="check" title="Watch for torrent files in:" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="1219">
@@ -664,7 +675,10 @@
                                             <constraint firstItem="1337" firstAttribute="width" secondItem="61" secondAttribute="width" id="pUr-gl-HWr"/>
                                             <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="51" secondAttribute="trailing" constant="20" symbolic="YES" id="pdr-Mz-OEr"/>
                                             <constraint firstItem="115" firstAttribute="leading" secondItem="59" secondAttribute="leading" id="r9n-Jd-yn7"/>
-                                            <constraint firstItem="1293" firstAttribute="top" secondItem="1939" secondAttribute="bottom" constant="20" id="sc7-xe-pwG"/>
+                                            <constraint firstItem="2001" firstAttribute="top" secondItem="1939" secondAttribute="bottom" constant="4" id="sc7-xe-pwG"/>
+                                            <constraint firstItem="2001" firstAttribute="leading" secondItem="59" secondAttribute="leading" id="tr1-WS-F01"/>
+                                            <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="2001" secondAttribute="trailing" constant="20" symbolic="YES" id="tr2-WS-F02"/>
+                                            <constraint firstItem="1293" firstAttribute="top" secondItem="2001" secondAttribute="bottom" constant="4" id="tr3-WS-F03"/>
                                             <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="1334" secondAttribute="trailing" constant="20" symbolic="YES" id="uBl-jP-kgp"/>
                                             <constraint firstItem="59" firstAttribute="leading" secondItem="61" secondAttribute="trailing" constant="8" symbolic="YES" id="udm-xI-Bf1"/>
                                             <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="216" secondAttribute="trailing" constant="20" symbolic="YES" id="ulA-rw-Yfo"/>

--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -486,6 +486,7 @@ static void removeKeRangerRansomware()
         tr_variantDictAddInt(&settings, TR_KEY_seed_queue_size, [_fDefaults integerForKey:@"QueueSeedNumber"]);
         tr_variantDictAddBool(&settings, TR_KEY_start_added_torrents, [_fDefaults boolForKey:@"AutoStartDownload"]);
         tr_variantDictAddBool(&settings, TR_KEY_utp_enabled, [_fDefaults boolForKey:@"UTPGlobal"]);
+        tr_variantDictAddBool(&settings, TR_KEY_wrap_single_file_torrents, [_fDefaults boolForKey:@"WrapSingleFileTorrents"]);
 
         tr_variantDictAddBool(&settings, TR_KEY_script_torrent_done_enabled, [_fDefaults boolForKey:@"DoneScriptEnabled"]);
         NSString* prefs_string = [_fDefaults stringForKey:@"DoneScriptPath"];

--- a/macosx/PrefsController.mm
+++ b/macosx/PrefsController.mm
@@ -1018,6 +1018,11 @@ static NSString* const kWebUIURLFormat = @"http://localhost:%ld/";
     tr_sessionSetIncompleteFileNamingEnabled(self.fHandle, [self.fDefaults boolForKey:@"RenamePartialFiles"]);
 }
 
+- (void)setWrapSingleFileTorrents:(id)sender
+{
+    tr_sessionSetWrapSingleFileTorrents(self.fHandle, [self.fDefaults boolForKey:@"WrapSingleFileTorrents"]);
+}
+
 - (void)setShowAddMagnetWindow:(id)sender
 {
     [self.fDefaults setBool:(self.fShowMagnetAddWindowCheck.state == NSControlStateValueOn) forKey:@"MagnetOpenAsk"];

--- a/qt/Prefs.h
+++ b/qt/Prefs.h
@@ -123,7 +123,8 @@ public:
         USPEED_ENABLED,
         USPEED,
         UPLOAD_SLOTS_PER_TORRENT,
-        LAST_CORE_PREF = UPLOAD_SLOTS_PER_TORRENT,
+        WRAP_SINGLE_FILE_TORRENTS,
+        LAST_CORE_PREF = WRAP_SINGLE_FILE_TORRENTS,
         //
         PREFS_COUNT
     };
@@ -286,6 +287,7 @@ private:
         { .id = USPEED_ENABLED, .key = TR_KEY_speed_limit_up_enabled, .type = QMetaType::Bool },
         { .id = USPEED, .key = TR_KEY_speed_limit_up, .type = QMetaType::Int },
         { .id = UPLOAD_SLOTS_PER_TORRENT, .key = TR_KEY_upload_slots_per_torrent, .type = QMetaType::Int },
+        { .id = WRAP_SINGLE_FILE_TORRENTS, .key = TR_KEY_wrap_single_file_torrents, .type = QMetaType::Bool },
     } };
 
     [[nodiscard]] static tr_variant::Map defaults();

--- a/qt/PrefsDialog.cc
+++ b/qt/PrefsDialog.cc
@@ -533,6 +533,7 @@ void PrefsDialog::initDownloadingTab()
     initWidget(ui_.downloadDirFreeSpaceLabel, Prefs::DOWNLOAD_DIR);
     initWidget(ui_.downloadQueueSizeSpin, Prefs::DOWNLOAD_QUEUE_SIZE);
     initWidget(ui_.queueStalledMinutesSpin, Prefs::QUEUE_STALLED_MINUTES);
+    initWidget(ui_.wrapSingleFileTorrentsCheck, Prefs::WRAP_SINGLE_FILE_TORRENTS);
     initWidget(ui_.renamePartialFilesCheck, Prefs::RENAME_PARTIAL_FILES);
     initWidget(ui_.incompleteDirCheck, Prefs::INCOMPLETE_DIR_ENABLED);
     initWidget(ui_.incompleteDirButton, Prefs::INCOMPLETE_DIR);

--- a/qt/PrefsDialog.ui
+++ b/qt/PrefsDialog.ui
@@ -311,6 +311,13 @@
             </property>
            </widget>
           </item>
+          <item row="7" column="0" colspan="2">
+           <widget class="QCheckBox" name="wrapSingleFileTorrentsCheck">
+            <property name="text">
+             <string>Put single-file torrents into a &amp;subfolder</string>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>


### PR DESCRIPTION
Added an option to put single-file torrents into a subfolder.

This has bothered me for a while, I put all my stuff is the same download folder, so any single-file torrents end up flat in that hierarchy. This makes them _stick out like a sore thumb_ but also make them harder to work with -- adding a subtitle file means the need to manually create that folder, if I don't want this subtitle to be misinterpreted as belonging to some other asset.

I used Cursor to write this, but I have QA'd this on my machine and it works now (after a few iterations).