### PR TITLE
Fix privacy filter in web client

### DIFF
--- a/web/src/torrent.js
+++ b/web/src/torrent.js
@@ -597,6 +597,7 @@ Torrent.Fields = {};
 Torrent.Fields.Metadata = [
   'added_date',
   'file_count',
+  'is_private',
   'name',
   'primary_mime_type',
   'total_size',
@@ -638,7 +639,6 @@ Torrent.Fields.InfoExtra = [
   'date_created',
   'files',
   'hash_string',
-  'is_private',
   'magnet_link',
   'piece_count',
   'piece_size',


### PR DESCRIPTION
Fix for the privacy filter introduced to the web client in https://github.com/transmission/transmission/pull/6977

The `is_private` field needs to be loaded on startup, rather than only when inspecting a torrent.

Notes: Fixed filtering private torrents in the web UI.