### PR TITLE
fix: unify types for `idle_seeding_limit_minutes` to `uint16_t`

### DIFF
--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -2295,7 +2295,7 @@ using SessionAccessors = std::pair<SessionGetter, SessionSetter>;
         [](tr_session const& src) -> tr_variant { return src.idleLimitMinutes(); },
         [](tr_session& tgt, tr_variant const& src, ErrorInfo& /*err*/)
         {
-            if (auto const val = src.value_if<int64_t>())
+            if (auto const val = src.value_if<uint16_t>())
             {
                 tr_sessionSetIdleLimit(&tgt, *val);
             }

--- a/libtransmission/serializer.cc
+++ b/libtransmission/serializer.cc
@@ -544,6 +544,7 @@ void Converters::ensure_default_converters()
             Converters::add(to_int<int64_t>, from_int<int64_t>);
             Converters::add(to_int<size_t>, from_int<size_t>);
             Converters::add(to_int<time_t>, from_int<time_t>);
+            Converters::add(to_int<uint16_t>, from_int<uint16_t>);
             Converters::add(to_int<uint64_t>, from_int<uint64_t>);
             Converters::add(to_log_level, from_log_level);
             Converters::add(to_mode_t, from_mode_t);

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -463,7 +463,6 @@ public:
         double ratio_limit = 2.0;
         size_t unused_cache_size_mbytes = 4U; // TODO(TR5): remove
         size_t download_queue_size = 5U;
-        size_t idle_seeding_limit_minutes = 30U;
         size_t peer_limit_global = TrDefaultPeerLimitGlobal;
         size_t peer_limit_per_torrent = TrDefaultPeerLimitTorrent;
         size_t queue_stalled_minutes = 30U;
@@ -500,6 +499,7 @@ public:
         tr_port peer_port = tr_port::from_host(TrDefaultPeerPort);
         tr_diffserv_t peer_socket_diffserv{ 0x04 };
         tr_verify_added_mode torrent_added_verify_mode = TR_VERIFY_ADDED_FAST;
+        uint16_t idle_seeding_limit_minutes = 30U;
 
     private:
         template<auto MemberPtr>


### PR DESCRIPTION
#4053 changed the data type of the setting from `uint16_t` to `size_t`, but the setter `tr_sessionSetIdleLimit()` and accessor `tr_sessionGetIdleLimit()` is still on `uint16_t`.

This PR unifies the data types again.

Notes: Improved input sanitization.