### PR TITLE
refactor: add serializer for `tr_sched_day`

### DIFF
--- a/gtk/Application.cc
+++ b/gtk/Application.cc
@@ -1287,7 +1287,10 @@ void Application::Impl::on_prefs_changed(tr_quark const key)
         break;
 
     case TR_KEY_alt_speed_time_day:
-        tr_sessionSetAltSpeedDay(tr, static_cast<tr_sched_day>(gtr_pref_int_get(key)));
+        if (auto const val = gtr_pref_get<tr_sched_day>(key))
+        {
+            tr_sessionSetAltSpeedDay(tr, *val);
+        }
         break;
 
     case TR_KEY_peer_port_random_on_start:

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -2103,9 +2103,9 @@ using SessionAccessors = std::pair<SessionGetter, SessionSetter>;
         [](tr_session const& src) -> tr_variant { return tr_sessionGetAltSpeedDay(&src); },
         [](tr_session& tgt, tr_variant const& src, ErrorInfo& /*err*/)
         {
-            if (auto const val = src.value_if<int64_t>())
+            if (auto const val = tr::serializer::to_value<tr_sched_day>(src))
             {
-                tr_sessionSetAltSpeedDay(&tgt, static_cast<tr_sched_day>(*val));
+                tr_sessionSetAltSpeedDay(&tgt, *val);
             }
         });
 

--- a/libtransmission/serializer.cc
+++ b/libtransmission/serializer.cc
@@ -225,6 +225,68 @@ tr_variant from_mode_t(tr_mode_t const& val)
 
 // ---
 
+bool to_sched_day(tr_variant const& src, tr_sched_day* tgt)
+{
+    if (auto const val = src.value_if<int64_t>())
+    {
+        switch (*val)
+        {
+        case TR_SCHED_SUN:
+            *tgt = TR_SCHED_SUN;
+            return true;
+
+        case TR_SCHED_MON:
+            *tgt = TR_SCHED_MON;
+            return true;
+
+        case TR_SCHED_TUES:
+            *tgt = TR_SCHED_TUES;
+            return true;
+
+        case TR_SCHED_WED:
+            *tgt = TR_SCHED_WED;
+            return true;
+
+        case TR_SCHED_THURS:
+            *tgt = TR_SCHED_THURS;
+            return true;
+
+        case TR_SCHED_FRI:
+            *tgt = TR_SCHED_FRI;
+            return true;
+
+        case TR_SCHED_SAT:
+            *tgt = TR_SCHED_SAT;
+            return true;
+
+        case TR_SCHED_WEEKDAY:
+            *tgt = TR_SCHED_WEEKDAY;
+            return true;
+
+        case TR_SCHED_WEEKEND:
+            *tgt = TR_SCHED_WEEKEND;
+            return true;
+
+        case TR_SCHED_ALL:
+            *tgt = TR_SCHED_ALL;
+            return true;
+
+        default:
+            tr_logAddWarn(fmt::format(fmt::runtime(_("Invalid tr_sched_days value {val}")), fmt::arg("val", *val)));
+            break;
+        }
+    }
+
+    return false;
+}
+
+tr_variant from_sched_day(tr_sched_day const& val)
+{
+    return val;
+}
+
+// ---
+
 bool to_msec(tr_variant const& src, std::chrono::milliseconds* tgt)
 {
     if (auto val = src.value_if<int64_t>())
@@ -552,6 +614,7 @@ void Converters::ensure_default_converters()
             Converters::add(to_port, from_port);
             Converters::add(to_preallocation_mode, from_preallocation_mode);
             Converters::add(to_preferred_transport, from_preferred_transport);
+            Converters::add(to_sched_day, from_sched_day);
             Converters::add(to_string, from_string);
             Converters::add(to_u8string, from_u8string);
             Converters::add(to_verify_added_mode, from_verify_added_mode);

--- a/libtransmission/session-alt-speeds.h
+++ b/libtransmission/session-alt-speeds.h
@@ -56,7 +56,7 @@ public:
         size_t minute_end = 1020U; // minutes past midnight; 5PM
         size_t speed_down_kbyps = 50U;
         size_t speed_up_kbyps = 50U;
-        size_t use_on_these_weekdays = TR_SCHED_ALL;
+        tr_sched_day use_on_these_weekdays = TR_SCHED_ALL;
 
     private:
         template<auto MemberPtr>
@@ -152,7 +152,7 @@ public:
 
     [[nodiscard]] constexpr tr_sched_day weekdays() const noexcept
     {
-        return static_cast<tr_sched_day>(settings().use_on_these_weekdays);
+        return settings().use_on_these_weekdays;
     }
 
     [[nodiscard]] auto speed_limit(tr_direction const dir) const noexcept


### PR DESCRIPTION
Harden deserialization logic for `tr_sched_day`. RPC and settings.json `alt_speed_time_day` will now only accept values that are in the `tr_sched_day` enum.

Notes: Ignore values that are not valid for `alt_speed_time_day`.