### PR TITLE
docs(rpc-spec): correct units arrays (5 strings, byte-unit prefix)

### DIFF
--- a/docs/rpc-spec.md
+++ b/docs/rpc-spec.md
@@ -637,11 +637,11 @@ Response parameters: `path`, `name`, and `id`, holding the torrent ID integer
 
 | Key | Value Type | transmission.h source
 |:--|:--|:--
-| `speed_units`  | array  | 4 strings: KB/s, MB/s, GB/s, TB/s
+| `speed_units`  | array  | 5 strings: B/s, kB/s, MB/s, GB/s, TB/s
 | `speed_bytes`  | number | number of bytes in a KB (1000 for kB; 1024 for KiB)
-| `size_units`   | array  | 4 strings: KB/s, MB/s, GB/s, TB/s
+| `size_units`   | array  | 5 strings: B, kB, MB, GB, TB
 | `size_bytes`   | number | number of bytes in a KB (1000 for kB; 1024 for KiB)
-| `memory_units` | array  | 4 strings: KB/s, MB/s, GB/s, TB/s
+| `memory_units` | array  | 5 strings: B, KiB, MiB, GiB, TiB
 | `memory_bytes` | number | number of bytes in a KB (1000 for kB; 1024 for KiB)
 
 #### 4.1.1 Mutators


### PR DESCRIPTION
## Summary

Closes #8771. The `session-get` `units` object documentation in `docs/rpc-spec.md` was out of sync with the API:

- It claimed 4 strings per array, but the API returns 5.
- All three arrays were documented with the same values (`KB/s, MB/s, GB/s, TB/s`), but `memory_units` actually uses IEC binary prefixes and `size_units` does not carry a `/s` suffix.

## Changes

`docs/rpc-spec.md` — align the three unit arrays with the defaults in `libtransmission/utils.cc` (`Config::memory`, `Config::speed`, `Config::storage`):

- `memory_units`: `5 strings: B, KiB, MiB, GiB, TiB`
- `size_units`: `5 strings: B, kB, MB, GB, TB`
- `speed_units`: `5 strings: B/s, kB/s, MB/s, GB/s, TB/s`

No code changes.

Closes #8771
