### PR TITLE
Fix #8180: Initialized torrent list after web reconnect. (#8733)

### DIFF
--- a/web/src/remote.js
+++ b/web/src/remote.js
@@ -71,6 +71,7 @@ export class Remote {
         if (this._connection_alert) {
           this._connection_alert.close();
           this._connection_alert = null;
+          this._controller._initializeTorrents();
         }
       })
       .catch((error) => {


### PR DESCRIPTION
Cherry-pick #8733 to `4.1.x`. See that PR for details

Notes: Fixed a bug that could show incorrect torrent status when reconnecting to the server after a lost connection.