### PR TITLE
fix: preserve relative order in `queue_move_up` and `queue_move_down`

### DIFF
--- a/libtransmission/torrent-queue.h
+++ b/libtransmission/torrent-queue.h
@@ -11,7 +11,6 @@
 
 #include <cstddef>
 #include <string>
-#include <string_view>
 #include <vector>
 
 #include "libtransmission/transmission.h"
@@ -42,6 +41,11 @@ public:
 
     [[nodiscard]] size_t get_pos(tr_torrent_id_t id);
     [[nodiscard]] std::vector<tr_torrent_id_t> set_pos(tr_torrent_id_t id, size_t new_pos);
+
+    [[nodiscard]] auto size() const noexcept
+    {
+        return queue_.size();
+    }
 
     bool to_file(); // NOLINT(modernize-use-nodiscard)
     [[nodiscard]] std::vector<std::string> from_file();

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -54,7 +54,10 @@ using namespace libtransmission::Values;
 #define tr_return_if_fail(expr) \
     do \
     { \
-        if (!(expr)) \
+        if (expr) [[likely]] \
+        { \
+        } \
+        else \
         { \
             tr_logAddWarn(#expr); \
             return; \
@@ -63,7 +66,10 @@ using namespace libtransmission::Values;
 #define tr_return_val_if_fail(expr, val) \
     do \
     { \
-        if (!(expr)) \
+        if (expr) [[likely]] \
+        { \
+        } \
+        else \
         { \
             tr_logAddWarn(#expr); \
             return val; \
@@ -511,24 +517,36 @@ void tr_torrentsQueueMoveUp(tr_torrent* const* torrents_in, size_t torrent_count
 {
     auto torrents = std::vector<tr_torrent*>(torrents_in, torrents_in + torrent_count);
     std::sort(std::begin(torrents), std::end(torrents), tr_torrent::CompareQueuePosition);
+    auto last_consecutive_pos = tr_torrent_queue::MinQueuePosition;
     for (auto* const tor : torrents)
     {
-        if (auto const pos = tor->queue_position(); pos > tr_torrent_queue::MinQueuePosition)
+        if (auto const pos = tor->queue_position(); pos != last_consecutive_pos)
         {
             tor->set_queue_position(pos - 1U);
+        }
+        else
+        {
+            ++last_consecutive_pos;
         }
     }
 }
 
 void tr_torrentsQueueMoveDown(tr_torrent* const* torrents_in, size_t torrent_count)
 {
+    tr_return_if_fail(torrent_count > 0U);
+
     auto torrents = std::vector<tr_torrent*>(torrents_in, torrents_in + torrent_count);
     std::sort(std::rbegin(torrents), std::rend(torrents), tr_torrent::CompareQueuePosition);
+    auto last_consecutive_pos = torrents.front()->session->torrent_queue().size() - 1U + tr_torrent_queue::MinQueuePosition;
     for (auto* const tor : torrents)
     {
-        if (auto const pos = tor->queue_position(); pos < tr_torrent_queue::MaxQueuePosition)
+        if (auto const pos = tor->queue_position(); pos != last_consecutive_pos)
         {
             tor->set_queue_position(pos + 1U);
+        }
+        else
+        {
+            --last_consecutive_pos;
         }
     }
 }

--- a/tests/libtransmission/CMakeLists.txt
+++ b/tests/libtransmission/CMakeLists.txt
@@ -52,6 +52,7 @@ target_sources(libtransmission-test
         torrent-magnet-test.cc
         torrent-metainfo-test.cc
         torrent-queue-test.cc
+        torrent-test.cc
         torrents-test.cc
         tr-peer-info-test.cc
         utils-test.cc

--- a/tests/libtransmission/test-fixtures.h
+++ b/tests/libtransmission/test-fixtures.h
@@ -468,6 +468,18 @@ protected:
         return tor;
     }
 
+    [[nodiscard]] tr_torrent* torrentInitFromFile(std::string_view filename)
+    {
+        auto* const ctor = tr_ctorNew(session_);
+
+        auto const path = tr_pathbuf{ LIBTRANSMISSION_TEST_ASSETS_DIR, '/', filename };
+        EXPECT_TRUE(ctor->set_metainfo_from_file(path));
+
+        auto* const tor = createTorrentAndWaitForVerifyDone(ctor);
+        tr_ctorFree(ctor);
+        return tor;
+    }
+
     void blockingTorrentVerify(tr_torrent* tor)
     {
         EXPECT_NE(nullptr, tor->session);

--- a/tests/libtransmission/torrent-test.cc
+++ b/tests/libtransmission/torrent-test.cc
@@ -1,0 +1,132 @@
+// This file Copyright © Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
+
+#include <array>
+#include <cstddef>
+#include <ranges>
+
+#include <libtransmission/torrent.h>
+
+#include "test-fixtures.h"
+
+using TorrentTest = libtransmission::test::SessionTest;
+
+namespace
+{
+auto constexpr TorFilenames = std::array{
+    "Android-x86 8.1 r6 iso.torrent"sv,
+    "debian-11.2.0-amd64-DVD-1.iso.torrent"sv,
+    "ubuntu-18.04.6-desktop-amd64.iso.torrent"sv,
+    "ubuntu-20.04.4-desktop-amd64.iso.torrent"sv,
+};
+}
+
+TEST_F(TorrentTest, queueMoveUp)
+{
+    static constexpr auto ExpectedQueuePosition = std::array{ 0, 1, 3, 2 };
+    auto ctor = tr_ctor{ session_ };
+    auto torrents = std::array<tr_torrent*, TorFilenames.size()>{};
+    std::transform(
+        TorFilenames.begin(),
+        TorFilenames.end(),
+        torrents.begin(),
+        [this](auto const filename) { return torrentInitFromFile(filename); });
+    auto const move_torrents = std::array{ torrents[0], torrents[1], torrents[3] };
+
+    // Pre-test sanity checks
+    for (size_t i = 0; i < torrents.size(); ++i)
+    {
+        ASSERT_EQ(i, torrents[i]->queue_position());
+        ASSERT_EQ(i + 1U, torrents[i]->id());
+    }
+
+    tr_torrentsQueueMoveUp(move_torrents.data(), move_torrents.size());
+
+    for (size_t i = 0; i < ExpectedQueuePosition.size(); ++i)
+    {
+        EXPECT_EQ(ExpectedQueuePosition[i], torrents[i]->queue_position()) << i;
+    }
+}
+
+TEST_F(TorrentTest, queueMoveDown)
+{
+    static constexpr auto ExpectedQueuePosition = std::array{ 1, 0, 2, 3 };
+    auto ctor = tr_ctor{ session_ };
+    auto torrents = std::array<tr_torrent*, TorFilenames.size()>{};
+    std::transform(
+        TorFilenames.begin(),
+        TorFilenames.end(),
+        torrents.begin(),
+        [this](auto const filename) { return torrentInitFromFile(filename); });
+    auto const move_torrents = std::array{ torrents[0], torrents[2], torrents[3] };
+
+    // Pre-test sanity checks
+    for (size_t i = 0; i < torrents.size(); ++i)
+    {
+        ASSERT_EQ(i, torrents[i]->queue_position());
+        ASSERT_EQ(i + 1U, torrents[i]->id());
+    }
+
+    tr_torrentsQueueMoveDown(move_torrents.data(), move_torrents.size());
+
+    for (size_t i = 0; i < ExpectedQueuePosition.size(); ++i)
+    {
+        EXPECT_EQ(ExpectedQueuePosition[i], torrents[i]->queue_position()) << i;
+    }
+}
+
+TEST_F(TorrentTest, queueMoveTop)
+{
+    static constexpr auto ExpectedQueuePosition = std::array{ 0, 3, 1, 2 };
+    auto ctor = tr_ctor{ session_ };
+    auto torrents = std::array<tr_torrent*, TorFilenames.size()>{};
+    std::transform(
+        TorFilenames.begin(),
+        TorFilenames.end(),
+        torrents.begin(),
+        [this](auto const filename) { return torrentInitFromFile(filename); });
+    auto const move_torrents = std::array{ torrents[0], torrents[2], torrents[3] };
+
+    // Pre-test sanity checks
+    for (size_t i = 0; i < torrents.size(); ++i)
+    {
+        ASSERT_EQ(i, torrents[i]->queue_position());
+        ASSERT_EQ(i + 1U, torrents[i]->id());
+    }
+
+    tr_torrentsQueueMoveTop(move_torrents.data(), move_torrents.size());
+
+    for (size_t i = 0; i < ExpectedQueuePosition.size(); ++i)
+    {
+        EXPECT_EQ(ExpectedQueuePosition[i], torrents[i]->queue_position()) << i;
+    }
+}
+
+TEST_F(TorrentTest, queueMoveBottom)
+{
+    static constexpr auto ExpectedQueuePosition = std::array{ 1, 2, 0, 3 };
+    auto ctor = tr_ctor{ session_ };
+    auto torrents = std::array<tr_torrent*, TorFilenames.size()>{};
+    std::transform(
+        TorFilenames.begin(),
+        TorFilenames.end(),
+        torrents.begin(),
+        [this](auto const filename) { return torrentInitFromFile(filename); });
+    auto const move_torrents = std::array{ torrents[0], torrents[1], torrents[3] };
+
+    // Pre-test sanity checks
+    for (size_t i = 0; i < torrents.size(); ++i)
+    {
+        ASSERT_EQ(i, torrents[i]->queue_position());
+        ASSERT_EQ(i + 1U, torrents[i]->id());
+    }
+
+    tr_torrentsQueueMoveBottom(move_torrents.data(), move_torrents.size());
+
+    for (size_t i = 0; i < ExpectedQueuePosition.size(); ++i)
+    {
+        EXPECT_EQ(ExpectedQueuePosition[i], torrents[i]->queue_position()) << i;
+    }
+}


### PR DESCRIPTION
Adapted #8685 for `4.1.x`.

Notes: Fixed edge case that didn't preserve the order of a batch of torrents when moving their queue position up or down.