### PR TITLE
fix(web): reconstruct torrent list if `ids` is null

### DIFF
--- a/web/src/transmission.js
+++ b/web/src/transmission.js
@@ -828,6 +828,10 @@ export class Transmission extends EventTarget {
 
   updateTorrents(ids, fields) {
     this.remote.updateTorrents(ids, fields, (table, removed_ids) => {
+      if (!ids) {
+        this._torrents = {};
+      }
+
       const needinfo = [];
 
       const keys = table.shift();


### PR DESCRIPTION
Cherry-pick #8734.

Notes: Fixed a bug that could show incorrect torrent status when reconnecting to the server after a lost connection.