### PR TITLE
fix: `performance-move-const-arg`

### DIFF
--- a/libtransmission-app/.clang-tidy
+++ b/libtransmission-app/.clang-tidy
@@ -32,7 +32,6 @@ Checks:
   - modernize-*
   - -modernize-use-trailing-return-type
   - performance-*
-  - -performance-move-const-arg
   - portability-*
   - -portability-template-virtual-member-function # TODO: Enable after https://github.com/llvm/llvm-project/issues/139031 is fixed
   - readability-*
@@ -45,6 +44,7 @@ Checks:
 CheckOptions:
   - { key: cppcoreguidelines-avoid-do-while.IgnoreMacros,                    value: true       }
   - { key: cppcoreguidelines-special-member-functions.AllowSoleDefaultDtor,  value: true       }
+  - { key: performance-move-const-arg.CheckTriviallyCopyableMove,            value: false      }
   - { key: readability-identifier-naming.ConstexprVariableCase,              value: CamelCase  }
   - { key: readability-identifier-naming.ParameterCase,                      value: lower_case }
   - { key: readability-identifier-naming.PrivateMemberSuffix,                value: _          }

--- a/libtransmission/.clang-tidy
+++ b/libtransmission/.clang-tidy
@@ -42,7 +42,6 @@ Checks:
   - modernize-*
   - -modernize-use-trailing-return-type
   - performance-*
-  - -performance-move-const-arg
   - portability-*
   - -portability-template-virtual-member-function
   - readability-*
@@ -56,6 +55,7 @@ CheckOptions:
   - { key: cppcoreguidelines-avoid-do-while.IgnoreMacros,                           value: true       }
   - { key: cppcoreguidelines-rvalue-reference-param-not-moved.IgnoreUnnamedParams,  value: true       }
   - { key: cppcoreguidelines-special-member-functions.AllowSoleDefaultDtor,         value: true       }
+  - { key: performance-move-const-arg.CheckTriviallyCopyableMove,                   value: false      }
   - { key: readability-identifier-naming.ConstexprVariableCase,                     value: CamelCase  }
   - { key: readability-identifier-naming.ParameterCase,                             value: lower_case }
   - { key: readability-identifier-naming.PrivateMemberSuffix,                       value: _          }

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -1100,7 +1100,8 @@ namespace make_torrent_field_helpers
         }
     }
 
-    return { std::move(labels), Error::SUCCESS, {} };
+    auto errmsg = std::string{};
+    return { std::move(labels), Error::SUCCESS, std::move(errmsg) };
 }
 
 [[nodiscard]] std::pair<JsonRpc::Error::Code, std::string> set_labels(tr_torrent* tor, tr_variant::Vector const& list)
@@ -1147,7 +1148,8 @@ namespace make_torrent_field_helpers
         }
     }
 
-    return { std::move(files), Error::SUCCESS, {} };
+    auto errmsg = std::string{};
+    return { std::move(files), Error::SUCCESS, std::move(errmsg) };
 }
 
 [[nodiscard]] std::pair<JsonRpc::Error::Code, std::string> set_file_priorities(
@@ -1155,7 +1157,7 @@ namespace make_torrent_field_helpers
     tr_priority_t priority,
     tr_variant::Vector const& files_vec)
 {
-    auto const [indices, err, errmsg] = get_file_indices(tor, files_vec);
+    auto [indices, err, errmsg] = get_file_indices(tor, files_vec);
     if (err == JsonRpc::Error::SUCCESS)
     {
         tor->set_file_priorities(std::data(indices), std::size(indices), priority);
@@ -1183,7 +1185,7 @@ namespace make_torrent_field_helpers
     bool wanted,
     tr_variant::Vector const& files_vec)
 {
-    auto const [indices, err, errmsg] = get_file_indices(tor, files_vec);
+    auto [indices, err, errmsg] = get_file_indices(tor, files_vec);
     if (err == JsonRpc::Error::SUCCESS)
     {
         tor->set_files_wanted(std::data(indices), std::size(indices), wanted);

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -1100,8 +1100,7 @@ namespace make_torrent_field_helpers
         }
     }
 
-    auto errmsg = std::string{};
-    return { std::move(labels), Error::SUCCESS, std::move(errmsg) };
+    return { std::move(labels), Error::SUCCESS, std::string{} };
 }
 
 [[nodiscard]] std::pair<JsonRpc::Error::Code, std::string> set_labels(tr_torrent* tor, tr_variant::Vector const& list)
@@ -1148,8 +1147,7 @@ namespace make_torrent_field_helpers
         }
     }
 
-    auto errmsg = std::string{};
-    return { std::move(files), Error::SUCCESS, std::move(errmsg) };
+    return { std::move(files), Error::SUCCESS, std::string{} };
 }
 
 [[nodiscard]] std::pair<JsonRpc::Error::Code, std::string> set_file_priorities(

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -312,7 +312,7 @@ void notifyBatchQueueChange(tr_session* session, std::vector<tr_torrent*> const&
     auto const torrents = getTorrents(session, args_in);
     tr_torrent::queue_move_top(torrents);
     notifyBatchQueueChange(session, torrents);
-    return { JsonRpc::Error::SUCCESS, {} };
+    return { JsonRpc::Error::SUCCESS, std::string{} };
 }
 
 [[nodiscard]] std::pair<JsonRpc::Error::Code, std::string> queueMoveUp(
@@ -323,7 +323,7 @@ void notifyBatchQueueChange(tr_session* session, std::vector<tr_torrent*> const&
     auto const torrents = getTorrents(session, args_in);
     tr_torrent::queue_move_up(torrents);
     notifyBatchQueueChange(session, torrents);
-    return { JsonRpc::Error::SUCCESS, {} };
+    return { JsonRpc::Error::SUCCESS, std::string{} };
 }
 
 [[nodiscard]] std::pair<JsonRpc::Error::Code, std::string> queueMoveDown(
@@ -334,7 +334,7 @@ void notifyBatchQueueChange(tr_session* session, std::vector<tr_torrent*> const&
     auto const torrents = getTorrents(session, args_in);
     tr_torrent::queue_move_down(torrents);
     notifyBatchQueueChange(session, torrents);
-    return { JsonRpc::Error::SUCCESS, {} };
+    return { JsonRpc::Error::SUCCESS, std::string{} };
 }
 
 [[nodiscard]] std::pair<JsonRpc::Error::Code, std::string> queueMoveBottom(
@@ -345,7 +345,7 @@ void notifyBatchQueueChange(tr_session* session, std::vector<tr_torrent*> const&
     auto const torrents = getTorrents(session, args_in);
     tr_torrent::queue_move_bottom(torrents);
     notifyBatchQueueChange(session, torrents);
-    return { JsonRpc::Error::SUCCESS, {} };
+    return { JsonRpc::Error::SUCCESS, std::string{} };
 }
 
 [[nodiscard]] std::pair<JsonRpc::Error::Code, std::string> torrentStart(
@@ -364,7 +364,7 @@ void notifyBatchQueueChange(tr_session* session, std::vector<tr_torrent*> const&
         }
     }
 
-    return { JsonRpc::Error::SUCCESS, {} };
+    return { JsonRpc::Error::SUCCESS, std::string{} };
 }
 
 [[nodiscard]] std::pair<JsonRpc::Error::Code, std::string> torrentStartNow(
@@ -383,7 +383,7 @@ void notifyBatchQueueChange(tr_session* session, std::vector<tr_torrent*> const&
         }
     }
 
-    return { JsonRpc::Error::SUCCESS, {} };
+    return { JsonRpc::Error::SUCCESS, std::string{} };
 }
 
 [[nodiscard]] std::pair<JsonRpc::Error::Code, std::string> torrentStop(
@@ -400,7 +400,7 @@ void notifyBatchQueueChange(tr_session* session, std::vector<tr_torrent*> const&
         }
     }
 
-    return { JsonRpc::Error::SUCCESS, {} };
+    return { JsonRpc::Error::SUCCESS, std::string{} };
 }
 
 [[nodiscard]] std::pair<JsonRpc::Error::Code, std::string> torrentRemove(
@@ -419,7 +419,7 @@ void notifyBatchQueueChange(tr_session* session, std::vector<tr_torrent*> const&
         }
     }
 
-    return { JsonRpc::Error::SUCCESS, {} };
+    return { JsonRpc::Error::SUCCESS, std::string{} };
 }
 
 [[nodiscard]] std::pair<JsonRpc::Error::Code, std::string> torrentReannounce(
@@ -436,7 +436,7 @@ void notifyBatchQueueChange(tr_session* session, std::vector<tr_torrent*> const&
         }
     }
 
-    return { JsonRpc::Error::SUCCESS, {} };
+    return { JsonRpc::Error::SUCCESS, std::string{} };
 }
 
 [[nodiscard]] std::pair<JsonRpc::Error::Code, std::string> torrentVerify(
@@ -450,7 +450,7 @@ void notifyBatchQueueChange(tr_session* session, std::vector<tr_torrent*> const&
         session->rpcNotify(TR_RPC_TORRENT_CHANGED, tor->id());
     }
 
-    return { JsonRpc::Error::SUCCESS, {} };
+    return { JsonRpc::Error::SUCCESS, std::string{} };
 }
 
 // ---
@@ -1066,7 +1066,7 @@ namespace make_torrent_field_helpers
     }
 
     args_out.try_emplace(TR_KEY_torrents, std::move(torrents_vec));
-    return { Error::SUCCESS, {} }; // no error message
+    return { Error::SUCCESS, std::string{} }; // no error message
 }
 
 // ---
@@ -1088,12 +1088,12 @@ namespace make_torrent_field_helpers
 
             if (std::empty(label))
             {
-                return { {}, Error::INVALID_PARAMS, "labels cannot be empty"s };
+                return { tr_torrent::labels_t{}, Error::INVALID_PARAMS, "labels cannot be empty"s };
             }
 
             if (tr_strv_contains(label, ','))
             {
-                return { {}, Error::INVALID_PARAMS, "labels cannot contain comma (,) character"s };
+                return { tr_torrent::labels_t{}, Error::INVALID_PARAMS, "labels cannot contain comma (,) character"s };
             }
 
             labels.emplace_back(tr_quark_new(label));
@@ -1141,7 +1141,7 @@ namespace make_torrent_field_helpers
                 }
                 else
                 {
-                    return { {}, Error::FILE_IDX_OOR, std::string{} };
+                    return { std::vector<tr_file_index_t>{}, Error::FILE_IDX_OOR, std::string{} };
                 }
             }
         }
@@ -1175,7 +1175,7 @@ namespace make_torrent_field_helpers
     }
 
     tor.set_sequential_download_from_piece(piece);
-    return { Error::SUCCESS, {} }; // no error
+    return { Error::SUCCESS, std::string{} }; // no error
 }
 
 [[nodiscard]] std::pair<JsonRpc::Error::Code, std::string> set_file_dls(
@@ -1208,11 +1208,11 @@ namespace make_torrent_field_helpers
 
     if (ann == baseline) // unchanged
     {
-        return { Error::SET_ANNOUNCE_LIST, {} };
+        return { Error::SET_ANNOUNCE_LIST, std::string{} };
     }
 
     tor->set_announce_list(std::move(ann));
-    return { Error::SUCCESS, {} };
+    return { Error::SUCCESS, std::string{} };
 }
 
 [[nodiscard]] std::pair<JsonRpc::Error::Code, std::string> replace_trackers(tr_torrent* tor, tr_variant::Vector const& urls_vec)
@@ -1235,11 +1235,11 @@ namespace make_torrent_field_helpers
 
     if (ann == baseline) // unchanged
     {
-        return { Error::SET_ANNOUNCE_LIST, {} };
+        return { Error::SET_ANNOUNCE_LIST, std::string{} };
     }
 
     tor->set_announce_list(std::move(ann));
-    return { Error::SUCCESS, {} };
+    return { Error::SUCCESS, std::string{} };
 }
 
 [[nodiscard]] std::pair<JsonRpc::Error::Code, std::string> remove_trackers(tr_torrent* tor, tr_variant::Vector const& ids_vec)
@@ -1259,11 +1259,11 @@ namespace make_torrent_field_helpers
 
     if (ann == baseline) // unchanged
     {
-        return { Error::SET_ANNOUNCE_LIST, {} };
+        return { Error::SET_ANNOUNCE_LIST, std::string{} };
     }
 
     tor->set_announce_list(std::move(ann));
-    return { Error::SUCCESS, {} };
+    return { Error::SUCCESS, std::string{} };
 }
 
 [[nodiscard]] std::pair<JsonRpc::Error::Code, std::string> torrentSet(
@@ -1444,7 +1444,7 @@ namespace make_torrent_field_helpers
         session->rpcNotify(TR_RPC_TORRENT_MOVED, tor->id());
     }
 
-    return { Error::SUCCESS, {} };
+    return { Error::SUCCESS, std::string{} };
 }
 
 // ---
@@ -1933,7 +1933,7 @@ void add_strings_from_var(std::set<std::string_view>& strings, tr_variant const&
     }
     args_out.try_emplace(TR_KEY_group, std::move(groups_vec));
 
-    return { JsonRpc::Error::SUCCESS, {} };
+    return { JsonRpc::Error::SUCCESS, std::string{} };
 }
 
 [[nodiscard]] std::pair<JsonRpc::Error::Code, std::string> groupSet(
@@ -1980,7 +1980,7 @@ void add_strings_from_var(std::set<std::string_view>& strings, tr_variant const&
         group.honor_parent_limits(tr_direction::Down, *val);
     }
 
-    return { Error::SUCCESS, {} };
+    return { Error::SUCCESS, std::string{} };
 }
 
 // ---
@@ -2017,7 +2017,7 @@ void add_strings_from_var(std::set<std::string_view>& strings, tr_variant const&
     args_out.try_emplace(TR_KEY_torrent_count, total);
     args_out.try_emplace(TR_KEY_upload_speed, session->piece_speed(tr_direction::Up).base_quantity());
 
-    return { JsonRpc::Error::SUCCESS, {} };
+    return { JsonRpc::Error::SUCCESS, std::string{} };
 }
 
 [[nodiscard]] auto values_get_units()
@@ -2050,7 +2050,7 @@ void add_strings_from_var(std::set<std::string_view>& strings, tr_variant const&
 }
 
 using ErrorInfo = std::pair<JsonRpc::Error::Code, std::string>;
-auto const error_none = ErrorInfo{ JsonRpc::Error::SUCCESS, {} };
+auto const error_none = ErrorInfo{ JsonRpc::Error::SUCCESS, std::string{} };
 
 using SessionGetter = std::function<tr_variant(tr_session const& src)>;
 using SessionSetter = std::function<void(tr_session& tgt, tr_variant const&, ErrorInfo& err)>;
@@ -2770,7 +2770,7 @@ using SessionAccessors = std::pair<SessionGetter, SessionSetter>;
     {
         return { Error::SYSTEM_ERROR, std::string{ error.message() } };
     }
-    return { Error::SUCCESS, {} };
+    return { Error::SUCCESS, std::string{} };
 }
 
 // ---
@@ -2781,7 +2781,7 @@ using SessionAccessors = std::pair<SessionGetter, SessionSetter>;
     tr_variant::Map& /*args_out*/)
 {
     session->rpcNotify(TR_RPC_SESSION_CLOSE);
-    return { JsonRpc::Error::SUCCESS, {} };
+    return { JsonRpc::Error::SUCCESS, std::string{} };
 }
 
 // ---

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -2507,8 +2507,8 @@ void tr_torrent::rename_path_in_session_thread(
 void tr_torrent::rename_path(std::string_view oldpath, std::string_view newname, tr_torrent_rename_done_func&& callback)
 {
     this->session->run_in_session_thread(
-        [this, oldpath = std::string(oldpath), newname = std::string(newname), cb = std::move(callback)]()
-        { rename_path_in_session_thread(oldpath, newname, std::move(cb)); });
+        [this, oldpath = std::string(oldpath), newname = std::string(newname), cb = std::move(callback)]
+        { rename_path_in_session_thread(oldpath, newname, cb); });
 }
 
 void tr_torrentRenamePath(

--- a/tests/qt/.clang-tidy
+++ b/tests/qt/.clang-tidy
@@ -38,7 +38,6 @@ Checks: >
   modernize-*,
   -modernize-use-trailing-return-type,
   performance-*,
-  -performance-move-const-arg,
   portability-*,
   -portability-template-virtual-member-function,
   readability-*,
@@ -52,6 +51,7 @@ CheckOptions:
   - { key: cppcoreguidelines-avoid-do-while.IgnoreMacros,                           value: true       }
   - { key: cppcoreguidelines-rvalue-reference-param-not-moved.IgnoreUnnamedParams,  value: true       }
   - { key: cppcoreguidelines-special-member-functions.AllowSoleDefaultDtor,         value: true       }
+  - { key: performance-move-const-arg.CheckTriviallyCopyableMove,                   value: false      }
   - { key: readability-identifier-naming.ConstexprVariableCase,                     value: CamelCase  }
   - { key: readability-identifier-naming.ParameterCase,                             value: lower_case }
   - { key: readability-identifier-naming.PrivateMemberSuffix,                       value: _          }


### PR DESCRIPTION
`performance-move-const-arg.CheckTriviallyCopyableMove` is set to `false` because if it is left at the default `true`, this line generates warning, which I don't agree with. The `std::move` does not do anything now, but it acts as a fallback if `dh_pool.back()` ever becomes movable.

https://github.com/transmission/transmission/blob/ab59bccf3c6c1af3bae07f5d4a885ec2dea6b83c/libtransmission/handshake.h#L273