### PR TITLE
docs(rpc-spec): correct bandwidth group name field

### DIFF
--- a/docs/rpc-spec.md
+++ b/docs/rpc-spec.md
@@ -789,10 +789,10 @@ Response parameters: none
 #### 4.8.2 Bandwidth group accessor: `group_get`
 Method name: `group_get`
 
-Request parameters: An optional parameter `group`.
-`group` is either a string naming the bandwidth group,
+Request parameters: An optional parameter `name`.
+`name` is either a string naming the bandwidth group,
 or a list of such strings.
-If `group` is omitted, all bandwidth groups are used.
+If `name` is omitted, all bandwidth groups are used.
 
 Response parameters:
 


### PR DESCRIPTION
Align docs to reflect field expected in the source code: https://github.com/transmission/transmission/blob/884f559c8bad931dcc7e9b71d013ff8730e57480/libtransmission/rpcimpl.cc#L1913

Bug identified and corrections verified via https://github.com/j0rsa/transmission-rpc/pull/106