### PR TITLE
Notes: Torrent inspector click issues resolved for macOS app

### DIFF
--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -2306,7 +2306,7 @@ static void removeKeRangerRansomware()
     else
     {
         [self.fInfoController updateInfoStats];
-        [self.fInfoController.window orderFront:nil];
+        [self.fInfoController.window makeKeyAndOrderFront:nil];
 
         if (self.fInfoController.canQuickLook && [QLPreviewPanel sharedPreviewPanelExists] &&
             [QLPreviewPanel sharedPreviewPanel].visible)

--- a/macosx/InfoWindowController.mm
+++ b/macosx/InfoWindowController.mm
@@ -89,7 +89,7 @@ typedef NS_ENUM(NSUInteger, TabTag) {
     windowRect.size.height = windowHeight;
     [window setFrame:windowRect display:NO];
 
-    window.becomesKeyOnlyIfNeeded = YES;
+    window.becomesKeyOnlyIfNeeded = NO;
 
     //disable green maximise window button
     //https://github.com/transmission/transmission/issues/3486

--- a/macosx/InfoWindowController.mm
+++ b/macosx/InfoWindowController.mm
@@ -89,6 +89,7 @@ typedef NS_ENUM(NSUInteger, TabTag) {
     windowRect.size.height = windowHeight;
     [window setFrame:windowRect display:NO];
 
+    // Let inspector gain keyboard focus when clicked on non-interactive areas
     window.becomesKeyOnlyIfNeeded = NO;
 
     //disable green maximise window button


### PR DESCRIPTION
Fixes #8040 and #8041.

Manually tested on Xcode build locally. Confirmed from latest 4.2.0-dev build from main that torrent inspector was not auto-focused on double-click or on blank space click before working.

Notes: Fixed navigation focus issues in the Inspector.