### PR TITLE
Fix macOS pasteboard magnet URL handling

### DIFF
--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -1688,50 +1688,17 @@ static void removeKeRangerRansomware()
 
 - (void)openPasteboard
 {
-    // 1. If Pasteboard contains URL objects, we treat those and only those
-    NSArray<NSURL*>* arrayOfURLs = [NSPasteboard.generalPasteboard readObjectsForClasses:@[ [NSURL class] ] options:nil];
-
-    if (arrayOfURLs.count > 0)
-    {
-        for (NSURL* url in arrayOfURLs)
-        {
-            [self openURL:url.absoluteString];
-        }
-        return;
-    }
-
-    // 2. If Pasteboard contains String objects, we'll search for both links and magnets
     NSArray<NSString*>* arrayOfStrings = [NSPasteboard.generalPasteboard readObjectsForClasses:@[ [NSString class] ] options:nil];
-    if (arrayOfStrings.count == 0)
+    NSArray<NSURL*>* arrayOfURLs = [NSPasteboard.generalPasteboard readObjectsForClasses:@[ [NSURL class] ] options:nil];
+    NSArray<NSString*>* urlStrings = torrentURLStringsFromPasteboard(arrayOfStrings, arrayOfURLs);
+
+    if (urlStrings.count == 0)
     {
         return;
     }
-    // The link detector (can't detect magnets)
-    NSDataDetector* linkDetector = [NSDataDetector dataDetectorWithTypes:NSTextCheckingTypeLink error:nil];
-    // The magnet detector
-    // https://www.bittorrent.org/beps/bep_0009.html defines the magnet URI format as `magnet:?query` where query is non-empty.
-    // https://datatracker.ietf.org/doc/html/rfc3986 defines the query format rigorously as `([!$\&-;=?-Z_a-z~]|%[0-9A-F]{2})*`.
-    // But `tr_urlParse` acknowledges that magnet links can be malformed by "not escaping text in the display name".
-    // Those malformed magnets aren't URI anymore, and since a display name can potentially contain any Unicode except '/' (see `isUnixReservedChar`), we may want to be liberal on what we accept.
-    // In practice, copy-pasted magnets might most often be separated by Horizontal tab, Line feed, Carriage Return, Space, XML delimiters '<' '>', JSON delimiter '"' and Markdown delimiter '`'.
-    // But for now, we'll keep the historical separator choice from 8392476b30491ffe7d8d64210f5cf3c3dd1d69ca, whitespaceAndNewlineCharacterSet, which is `[\p{Z}\v]`.
-    NSRegularExpression* magnetDetector = [NSRegularExpression regularExpressionWithPattern:@"magnet:?([^\\p{Z}\\v])+" options:kNilOptions
-                                                                                      error:nil];
-    for (NSString* itemString in arrayOfStrings)
+    for (NSString* urlString in urlStrings)
     {
-        // We open all links
-        for (NSTextCheckingResult* result in [linkDetector matchesInString:itemString options:0
-                                                                     range:NSMakeRange(0, itemString.length)])
-        {
-            [self openURL:result.URL.absoluteString];
-        }
-
-        // We open all magnets
-        for (NSTextCheckingResult* result in [magnetDetector matchesInString:itemString options:0
-                                                                       range:NSMakeRange(0, itemString.length)])
-        {
-            [self openURL:[itemString substringWithRange:result.range]];
-        }
+        [self openURL:urlString];
     }
 }
 

--- a/macosx/Utils.h
+++ b/macosx/Utils.h
@@ -8,3 +8,6 @@
 bool isSpeedEqual(CGFloat old_speed, CGFloat new_speed);
 // 0.01 precision
 bool isRatioEqual(CGFloat old_ratio, CGFloat new_ratio);
+
+NSArray<NSString*>* torrentURLStringsFromPasteboard(NSArray<NSString*>* strings, NSArray<NSURL*>* urls);
+NSArray<NSString*>* torrentURLStringsFromPasteboardStrings(NSArray<NSString*>* strings, BOOL* found_magnet);

--- a/macosx/Utils.mm
+++ b/macosx/Utils.mm
@@ -2,7 +2,9 @@
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 
+#include <algorithm>
 #include <cmath>
+#include <vector>
 
 #import "Utils.h"
 
@@ -16,4 +18,129 @@ bool isRatioEqual(CGFloat old_ratio, CGFloat new_ratio)
 {
     static CGFloat constexpr kRatioCompareEps = 0.01 / 2;
     return std::abs(new_ratio - old_ratio) < kRatioCompareEps;
+}
+
+namespace
+{
+
+BOOL isMagnetURLString(NSString* url_string)
+{
+    return [url_string rangeOfString:@"magnet:" options:(NSAnchoredSearch | NSCaseInsensitiveSearch)].location != NSNotFound;
+}
+
+} // namespace
+
+NSArray<NSString*>* torrentURLStringsFromPasteboard(NSArray<NSString*>* strings, NSArray<NSURL*>* urls)
+{
+    BOOL found_magnet = NO;
+    NSArray<NSString*>* string_urls = torrentURLStringsFromPasteboardStrings(strings, &found_magnet);
+
+    if (found_magnet)
+    {
+        NSMutableArray<NSString*>* url_strings = [NSMutableArray array];
+        for (NSURL* url in urls)
+        {
+            NSString* url_string = url.absoluteString;
+            if (isMagnetURLString(url_string))
+            {
+                [url_strings addObject:url_string];
+            }
+        }
+
+        if (url_strings.count == 0)
+        {
+            [url_strings addObjectsFromArray:string_urls];
+        }
+        else
+        {
+            for (NSString* url_string in string_urls)
+            {
+                if (!isMagnetURLString(url_string))
+                {
+                    [url_strings addObject:url_string];
+                }
+            }
+        }
+
+        return url_strings;
+    }
+
+    if (urls.count > 0)
+    {
+        NSMutableArray<NSString*>* url_strings = [NSMutableArray array];
+        for (NSURL* url in urls)
+        {
+            [url_strings addObject:url.absoluteString];
+        }
+
+        return url_strings;
+    }
+
+    return string_urls;
+}
+
+NSArray<NSString*>* torrentURLStringsFromPasteboardStrings(NSArray<NSString*>* strings, BOOL* found_magnet)
+{
+    if (found_magnet != nullptr)
+    {
+        *found_magnet = NO;
+    }
+
+    if (strings.count == 0)
+    {
+        return @[];
+    }
+
+    NSDataDetector* link_detector = [NSDataDetector dataDetectorWithTypes:NSTextCheckingTypeLink error:nil];
+    // https://www.bittorrent.org/beps/bep_0009.html defines the magnet URI format as `magnet:?query` where query is non-empty.
+    // https://datatracker.ietf.org/doc/html/rfc3986 defines the query format rigorously as `([!$\&-;=?-Z_a-z~]|%[0-9A-F]{2})*`.
+    // But `tr_urlParse` acknowledges that magnet links can be malformed by "not escaping text in the display name".
+    // Those malformed magnets aren't URI anymore, and since a display name can potentially contain any Unicode except '/' (see `isUnixReservedChar`), we may want to be liberal on what we accept.
+    // In practice, copy-pasted magnets might most often be separated by Horizontal tab, Line feed, Carriage Return, Space, XML delimiters '<' '>', JSON delimiter '"' and Markdown delimiter '`'.
+    // But for now, we'll keep the historical separator choice from 8392476b30491ffe7d8d64210f5cf3c3dd1d69ca, whitespaceAndNewlineCharacterSet, which is `[\p{Z}\v]`.
+    NSRegularExpression* magnet_detector = [NSRegularExpression regularExpressionWithPattern:@"magnet:?([^\\p{Z}\\v])+"
+                                                                                     options:kNilOptions
+                                                                                       error:nil];
+
+    NSMutableArray<NSString*>* url_strings = [NSMutableArray array];
+    for (NSString* item_string in strings)
+    {
+        NSMutableIndexSet* magnet_indexes = [NSMutableIndexSet indexSet];
+        std::vector<std::pair<NSUInteger, NSString*>> item_url_strings;
+
+        for (NSTextCheckingResult* result in [magnet_detector matchesInString:item_string options:0
+                                                                        range:NSMakeRange(0, item_string.length)])
+        {
+            if (found_magnet != nullptr)
+            {
+                *found_magnet = YES;
+            }
+
+            [magnet_indexes addIndexesInRange:result.range];
+            item_url_strings.emplace_back(result.range.location, [item_string substringWithRange:result.range]);
+        }
+
+        // Open links that are not part of a magnet URI. NSDataDetector can otherwise
+        // report tracker parameters inside a magnet as standalone URLs.
+        for (NSTextCheckingResult* result in [link_detector matchesInString:item_string options:0
+                                                                      range:NSMakeRange(0, item_string.length)])
+        {
+            if (![magnet_indexes intersectsIndexesInRange:result.range])
+            {
+                item_url_strings.emplace_back(result.range.location, result.URL.absoluteString);
+            }
+        }
+
+        std::sort(
+            std::begin(item_url_strings),
+            std::end(item_url_strings),
+            [](auto const& lhs, auto const& rhs) { return lhs.first < rhs.first; });
+
+        for (auto const& url_pair : item_url_strings)
+        {
+            [url_strings addObject:url_pair.second];
+        }
+    }
+
+    return url_strings;
 }

--- a/tests/libtransmission/CMakeLists.txt
+++ b/tests/libtransmission/CMakeLists.txt
@@ -69,6 +69,8 @@ target_sources(libtransmission-test
 if(APPLE)
     target_sources(libtransmission-test
         PRIVATE
+            ../../macosx/Utils.mm
+            pasteboard-url-test.mm
             utils-apple-test.mm)
 endif()
 

--- a/tests/libtransmission/pasteboard-url-test.mm
+++ b/tests/libtransmission/pasteboard-url-test.mm
@@ -1,0 +1,89 @@
+// This file Copyright © Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
+
+#import <Foundation/Foundation.h>
+
+#include <gtest/gtest.h>
+
+#import "../../macosx/Utils.h"
+
+namespace
+{
+NSString* const MagnetWithEncodedTracker =
+    @"magnet:?xt=urn:btih:792B3577FED6DD95DBB03F5F0972E821230B834F"
+     "&dn=Project.Hail.Mary.2026"
+     "&tr=udp%3A%2F%2Ftracker.bittor.pw%3A1337%2Fannounce";
+}
+
+TEST(PasteboardURLs, MagnetDoesNotOpenEncodedTrackerFragment)
+{
+    @autoreleasepool
+    {
+        BOOL found_magnet = NO;
+        NSArray<NSString*>* urls = torrentURLStringsFromPasteboardStrings(@[ MagnetWithEncodedTracker ], &found_magnet);
+
+        EXPECT_TRUE(found_magnet);
+        ASSERT_EQ(1UL, urls.count);
+        EXPECT_TRUE([urls[0] isEqualToString:MagnetWithEncodedTracker]);
+    }
+}
+
+TEST(PasteboardURLs, ExtractsMagnetWithoutTrackers)
+{
+    @autoreleasepool
+    {
+        NSString* const magnet = @"magnet:?xt=urn:btih:792B3577FED6DD95DBB03F5F0972E821230B834F";
+
+        BOOL found_magnet = NO;
+        NSArray<NSString*>* urls = torrentURLStringsFromPasteboardStrings(@[ magnet ], &found_magnet);
+
+        EXPECT_TRUE(found_magnet);
+        ASSERT_EQ(1UL, urls.count);
+        EXPECT_TRUE([urls[0] isEqualToString:magnet]);
+    }
+}
+
+TEST(PasteboardURLs, PrefersMagnetURLObjectOverTextMagnet)
+{
+    @autoreleasepool
+    {
+        NSString* const text_magnet = @"magnet:?xt=urn:btih:792B3577FED6DD95DBB03F5F0972E821230B834F";
+        NSURL* const url_magnet = [NSURL URLWithString:MagnetWithEncodedTracker];
+
+        NSArray<NSString*>* urls = torrentURLStringsFromPasteboard(@[ text_magnet ], @[ url_magnet ]);
+
+        ASSERT_EQ(1UL, urls.count);
+        EXPECT_TRUE([urls[0] isEqualToString:MagnetWithEncodedTracker]);
+    }
+}
+
+TEST(PasteboardURLs, ExtractsStandaloneTorrentURL)
+{
+    @autoreleasepool
+    {
+        BOOL found_magnet = NO;
+        NSArray<NSString*>* urls = torrentURLStringsFromPasteboardStrings(@[ @"download https://example.com/file.torrent" ], &found_magnet);
+
+        EXPECT_FALSE(found_magnet);
+        ASSERT_EQ(1UL, urls.count);
+        EXPECT_TRUE([urls[0] isEqualToString:@"https://example.com/file.torrent"]);
+    }
+}
+
+TEST(PasteboardURLs, PreservesStandaloneURLAndMagnetOrder)
+{
+    @autoreleasepool
+    {
+        NSString* const text = [NSString stringWithFormat:@"https://example.com/file.torrent\n%@", MagnetWithEncodedTracker];
+
+        BOOL found_magnet = NO;
+        NSArray<NSString*>* urls = torrentURLStringsFromPasteboardStrings(@[ text ], &found_magnet);
+
+        EXPECT_TRUE(found_magnet);
+        ASSERT_EQ(2UL, urls.count);
+        EXPECT_TRUE([urls[0] isEqualToString:@"https://example.com/file.torrent"]);
+        EXPECT_TRUE([urls[1] isEqualToString:MagnetWithEncodedTracker]);
+    }
+}


### PR DESCRIPTION
## Summary
- extract macOS pasteboard URL parsing into a testable helper
- prefer full magnet strings from pasteboard text before rich pasteboard URL objects
- ignore URL detector matches that fall inside magnet URI ranges so encoded tracker parameters are not opened separately

## Root cause
The macOS direct-paste path scans pasteboard strings with NSDataDetector and also reads rich URL objects. Long magnet links can contain percent-encoded tracker URLs, and rich pasteboard contents may expose those fragments as separate URLs. That can make the main-window paste path try to open a tracker fragment instead of the full magnet link, while Open Torrent Address still works because it treats the entered address as one value.

## Validation
- PATH=/opt/homebrew/Cellar/llvm/21.1.6/bin:$PATH ./code_style.sh --check
- cmake -B build/pr-tests -G Ninja -DCMAKE_BUILD_TYPE=Debug -DENABLE_TESTS=ON -DENABLE_CLI=OFF -DENABLE_DAEMON=OFF -DENABLE_GTK=OFF -DENABLE_QT=OFF -DENABLE_MAC=OFF -DENABLE_NLS=OFF -DINSTALL_DOC=OFF -DUSE_SYSTEM_DEFAULT=OFF
- cmake --build build/pr-tests --target libtransmission-test
- ctest --test-dir build/pr-tests -R 'LT\.PasteboardURLs' --output-on-failure
- git diff --check