### PR TITLE
fix(remote): ui regressions related to JSON-RPC

### DIFF
--- a/utils/remote.cc
+++ b/utils/remote.cc
@@ -2484,7 +2484,7 @@ int flush(char const* rpcurl, tr_variant* const var, RemoteConfig& config)
         case 204:
             if (!config.json)
             {
-                fmt::print("{:s} acknowledged request\n", rpcurl);
+                fmt::print("{:s} acknowledged notification\n", rpcurl);
             }
             break;
 

--- a/utils/remote.cc
+++ b/utils/remote.cc
@@ -2358,7 +2358,7 @@ int process_response(char const* rpcurl, std::string_view const response, Remote
         [[fallthrough]];
 
     default:
-        fmt::print("{:s} responded: {:s}\n", rpcurl, response);
+        fmt::print("{:s} returned a successful response\n", rpcurl);
         break;
     }
 

--- a/utils/remote.cc
+++ b/utils/remote.cc
@@ -2482,7 +2482,10 @@ int flush(char const* rpcurl, tr_variant* const var, RemoteConfig& config)
             break;
 
         case 204:
-            fmt::print("{:s} acknowledged request\n", rpcurl);
+            if (!config.json)
+            {
+                fmt::print("{:s} acknowledged request\n", rpcurl);
+            }
             break;
 
         case 409:

--- a/utils/remote.cc
+++ b/utils/remote.cc
@@ -258,7 +258,7 @@ auto constexpr Options = std::array<tr_option, 106>{ {
     { 941, "info-peers", "List the current torrent(s)' peers", "ip", Arg::None, nullptr },
     { 942, "info-pieces", "List the current torrent(s)' pieces", "ic", Arg::None, nullptr },
     { 943, "info-trackers", "List the current torrent(s)' trackers", "it", Arg::None, nullptr },
-    { 'j', "json", "Return RPC response as a JSON string", "j", Arg::None, nullptr },
+    { 'j', "json", "Return RPC response as a JSON string if the request was not a notification", "j", Arg::None, nullptr },
     { 920, "session-info", "Show the session's details", "si", Arg::None, nullptr },
     { 921, "session-stats", "Show the session's statistics", "st", Arg::None, nullptr },
     { 'l', "list", "List all torrents", "l", Arg::None, nullptr },


### PR DESCRIPTION
Fixes #8142.

Fix various UI regressions in transmission-remote that came with our move to JSON-RPC 2.

- `--json` will now not print anything if the request was a notification, which means there are no json response. The description of `--json` has been updated to reflect this.
- Change the default response handler to print a sentence instead of the json response.

Notes: Improved `transmission-remote` console output for JSON-RPC 2.