### PR TITLE
caching the last dir .torrent was taken from

### DIFF
--- a/qt/MainWindow.cc
+++ b/qt/MainWindow.cc
@@ -1307,8 +1307,9 @@ void MainWindow::addTorrents(QStringList const& filenames)
         {
             show_options = b->isChecked();
         }
+        QString dirname = file_dialog->directory().absolutePath();
+        prefs_.set(Prefs::OPEN_DIALOG_FOLDER, dirname);
     }
-
     for (QString const& filename : filenames)
     {
         addTorrent(AddData{ filename }, show_options);


### PR DESCRIPTION
Now when you File->Open, the last directory you took a .torrent file from is cached. Next time you File->Open, you open the right directory.

https://github.com/transmission/transmission/issues/7970