### PR TITLE
feat: skip closer pieces preference in sequential mode

### DIFF
--- a/libtransmission/peer-mgr-wishlist.cc
+++ b/libtransmission/peer-mgr-wishlist.cc
@@ -56,6 +56,7 @@ Wishlist::Candidate::Candidate(tr_piece_index_t piece_in, tr_piece_index_t salt_
     , replication{ mediator->count_piece_replication(piece_in) }
     , priority{ mediator->priority(piece_in) }
     , salt{ salt_in }
+    , is_sequential{ mediator->is_sequential_download() }
 {
     unrequested.reserve(block_span.end - block_span.begin);
     for (auto [begin, i] = block_span; i > begin; --i)

--- a/libtransmission/peer-mgr-wishlist.h
+++ b/libtransmission/peer-mgr-wishlist.h
@@ -50,10 +50,14 @@ private:
 
         [[nodiscard]] constexpr auto operator<=>(Candidate const& that) const noexcept
         {
-            // prefer pieces closer to completion
-            if (auto const val = std::size(unrequested) <=> std::size(that.unrequested); val != 0)
+            // prefer pieces closer to completion, skipped in sequential mode
+            // where we want to prioritize pieces in order.
+            if (!is_sequential)
             {
-                return val;
+                if (auto const val = std::size(unrequested) <=> std::size(that.unrequested); val != 0)
+                {
+                    return val;
+                }
             }
 
             // prefer higher priority
@@ -99,6 +103,7 @@ private:
         tr_priority_t priority;
 
         tr_piece_index_t salt;
+        bool is_sequential;
     };
 
     using CandidateVec = std::vector<Candidate>;

--- a/tests/libtransmission/peer-mgr-wishlist-test.cc
+++ b/tests/libtransmission/peer-mgr-wishlist-test.cc
@@ -222,65 +222,67 @@ TEST_F(PeerMgrWishlistTest, doesNotRequestSameBlockTwice)
 
 TEST_F(PeerMgrWishlistTest, sequentialDownload)
 {
-    auto const get_spans = [](size_t n_wanted)
-    {
-        auto mediator = MockMediator{};
+    auto mediator = MockMediator{};
 
-        // setup: three pieces, all missing
-        mediator.block_span_[0] = { .begin = 0, .end = 100 };
-        mediator.block_span_[1] = { .begin = 100, .end = 200 };
-        mediator.block_span_[2] = { .begin = 200, .end = 250 };
+    // setup: three pieces, all missing
+    mediator.block_span_[0] = { .begin = 0, .end = 100 };
+    mediator.block_span_[1] = { .begin = 100, .end = 200 };
+    mediator.block_span_[2] = { .begin = 200, .end = 250 };
 
-        // peer has all pieces
-        mediator.piece_replication_[0] = 1;
-        mediator.piece_replication_[1] = 1;
-        mediator.piece_replication_[2] = 1;
+    // peer has all pieces
+    mediator.piece_replication_[0] = 1;
+    mediator.piece_replication_[1] = 1;
+    mediator.piece_replication_[2] = 1;
 
-        // and we want all three pieces
-        mediator.client_wants_piece_.insert(0);
-        mediator.client_wants_piece_.insert(1);
-        mediator.client_wants_piece_.insert(2);
+    // and we want all three pieces
+    mediator.client_wants_piece_.insert(0);
+    mediator.client_wants_piece_.insert(1);
+    mediator.client_wants_piece_.insert(2);
 
-        // we enabled sequential download
-        mediator.is_sequential_download_ = true;
+    // we enabled sequential download
+    mediator.is_sequential_download_ = true;
 
-        return Wishlist{ mediator }.next(n_wanted, PeerHasAllPieces);
-    };
-
-    // when we ask for blocks, apart from the last piece,
-    // which will be returned first because it is smaller,
-    // we should get pieces in order
+    // first piece is downloaded first, then last piece, since in sequential
+    // mode we do not prefer pieces close to completion.
     // NB: when all other things are equal in the wishlist, pieces are
     // picked at random so this test -could- pass even if there's a bug.
     // So test several times to shake out any randomness
     static auto constexpr NumRuns = 1000;
     for (int run = 0; run < NumRuns; ++run)
     {
-        auto requested = tr_bitfield{ 250 };
-        auto const spans = get_spans(100);
-        for (auto const& [begin, end] : spans)
-        {
-            requested.set_span(begin, end);
-        }
-        EXPECT_EQ(100U, requested.count());
-        EXPECT_EQ(50U, requested.count(0, 100));
-        EXPECT_EQ(0U, requested.count(100, 200));
-        EXPECT_EQ(50U, requested.count(200, 250));
-    }
+        auto wishlist = Wishlist{ mediator };
 
-    // Same premise as previous test, but ask for more blocks.
-    for (int run = 0; run < NumRuns; ++run)
-    {
-        auto requested = tr_bitfield{ 250 };
-        auto const spans = get_spans(200);
-        for (auto const& [begin, end] : spans)
+        // first request: 100 blocks should all come from piece 0
         {
-            requested.set_span(begin, end);
+            auto requested = tr_bitfield{ 250 };
+            auto const spans = wishlist.next(100, PeerHasAllPieces);
+            for (auto const& [begin, end] : spans)
+            {
+                requested.set_span(begin, end);
+                for (auto block = begin; block < end; ++block)
+                {
+                    wishlist.on_got_block(block);
+                }
+            }
+            EXPECT_EQ(100U, requested.count());
+            EXPECT_EQ(100U, requested.count(0, 100));
+            EXPECT_EQ(0U, requested.count(100, 200));
+            EXPECT_EQ(0U, requested.count(200, 250));
         }
-        EXPECT_EQ(200U, requested.count());
-        EXPECT_EQ(100U, requested.count(0, 100));
-        EXPECT_EQ(50U, requested.count(100, 200));
-        EXPECT_EQ(50U, requested.count(200, 250));
+
+        // second request: 50 more blocks should all come from piece 2 (last piece)
+        {
+            auto requested = tr_bitfield{ 250 };
+            auto const spans = wishlist.next(50, PeerHasAllPieces);
+            for (auto const& [begin, end] : spans)
+            {
+                requested.set_span(begin, end);
+            }
+            EXPECT_EQ(50U, requested.count());
+            EXPECT_EQ(0U, requested.count(0, 100));
+            EXPECT_EQ(0U, requested.count(100, 200));
+            EXPECT_EQ(50U, requested.count(200, 250));
+        }
     }
 }
 

--- a/tests/libtransmission/peer-mgr-wishlist-test.cc
+++ b/tests/libtransmission/peer-mgr-wishlist-test.cc
@@ -222,25 +222,30 @@ TEST_F(PeerMgrWishlistTest, doesNotRequestSameBlockTwice)
 
 TEST_F(PeerMgrWishlistTest, sequentialDownload)
 {
-    auto mediator = MockMediator{};
+    auto const get_spans = [](size_t n_wanted)
+    {
+        auto mediator = MockMediator{};
 
-    // setup: three pieces, all missing
-    mediator.block_span_[0] = { .begin = 0, .end = 100 };
-    mediator.block_span_[1] = { .begin = 100, .end = 200 };
-    mediator.block_span_[2] = { .begin = 200, .end = 250 };
+        // setup: three pieces, all missing
+        mediator.block_span_[0] = { .begin = 0, .end = 100 };
+        mediator.block_span_[1] = { .begin = 100, .end = 200 };
+        mediator.block_span_[2] = { .begin = 200, .end = 250 };
 
-    // peer has all pieces
-    mediator.piece_replication_[0] = 1;
-    mediator.piece_replication_[1] = 1;
-    mediator.piece_replication_[2] = 1;
+        // peer has all pieces
+        mediator.piece_replication_[0] = 1;
+        mediator.piece_replication_[1] = 1;
+        mediator.piece_replication_[2] = 1;
 
-    // and we want all three pieces
-    mediator.client_wants_piece_.insert(0);
-    mediator.client_wants_piece_.insert(1);
-    mediator.client_wants_piece_.insert(2);
+        // and we want all three pieces
+        mediator.client_wants_piece_.insert(0);
+        mediator.client_wants_piece_.insert(1);
+        mediator.client_wants_piece_.insert(2);
 
-    // we enabled sequential download
-    mediator.is_sequential_download_ = true;
+        // we enabled sequential download
+        mediator.is_sequential_download_ = true;
+
+        return Wishlist{ mediator }.next(n_wanted, PeerHasAllPieces);
+    };
 
     // first piece is downloaded first, then last piece, since in sequential
     // mode we do not prefer pieces close to completion.
@@ -248,41 +253,36 @@ TEST_F(PeerMgrWishlistTest, sequentialDownload)
     // picked at random so this test -could- pass even if there's a bug.
     // So test several times to shake out any randomness
     static auto constexpr NumRuns = 1000;
+
+    // when nothing is downloaded yet: 100 blocks should all come from piece 0
     for (int run = 0; run < NumRuns; ++run)
     {
-        auto wishlist = Wishlist{ mediator };
-
-        // first request: 100 blocks should all come from piece 0
+        auto requested = tr_bitfield{ 250 };
+        auto const spans = get_spans(100);
+        for (auto const& [begin, end] : spans)
         {
-            auto requested = tr_bitfield{ 250 };
-            auto const spans = wishlist.next(100, PeerHasAllPieces);
-            for (auto const& [begin, end] : spans)
-            {
-                requested.set_span(begin, end);
-                for (auto block = begin; block < end; ++block)
-                {
-                    wishlist.on_got_block(block);
-                }
-            }
-            EXPECT_EQ(100U, requested.count());
-            EXPECT_EQ(100U, requested.count(0, 100));
-            EXPECT_EQ(0U, requested.count(100, 200));
-            EXPECT_EQ(0U, requested.count(200, 250));
+            requested.set_span(begin, end);
         }
+        EXPECT_EQ(100U, requested.count());
+        EXPECT_EQ(100U, requested.count(0, 100));
+        EXPECT_EQ(0U, requested.count(100, 200));
+        EXPECT_EQ(0U, requested.count(200, 250));
+    }
 
-        // second request: 50 more blocks should all come from piece 2 (last piece)
+    // Same premise as previous test, but ask for more blocks:
+    // 100 from piece 0, then piece 2 (last) before piece 1.
+    for (int run = 0; run < NumRuns; ++run)
+    {
+        auto requested = tr_bitfield{ 250 };
+        auto const spans = get_spans(150);
+        for (auto const& [begin, end] : spans)
         {
-            auto requested = tr_bitfield{ 250 };
-            auto const spans = wishlist.next(50, PeerHasAllPieces);
-            for (auto const& [begin, end] : spans)
-            {
-                requested.set_span(begin, end);
-            }
-            EXPECT_EQ(50U, requested.count());
-            EXPECT_EQ(0U, requested.count(0, 100));
-            EXPECT_EQ(0U, requested.count(100, 200));
-            EXPECT_EQ(50U, requested.count(200, 250));
+            requested.set_span(begin, end);
         }
+        EXPECT_EQ(150U, requested.count());
+        EXPECT_EQ(100U, requested.count(0, 100));
+        EXPECT_EQ(0U, requested.count(100, 200));
+        EXPECT_EQ(50U, requested.count(200, 250));
     }
 }
 


### PR DESCRIPTION
Following [this comment](https://github.com/transmission/transmission/pull/7949/changes#r3121908796), I open this standalone PR for this optimization to not prioritize pieces closer to completion in sequential mode.

Notes: Improved sequential downloading.