### PR TITLE
Route UDP announces through SOCKS5 proxy via UDP ASSOCIATE

### DIFF
--- a/libtransmission/CMakeLists.txt
+++ b/libtransmission/CMakeLists.txt
@@ -124,6 +124,8 @@ target_sources(${TR_NAME}
         session-thread.h
         session.cc
         session.h
+        socks5-udp.cc
+        socks5-udp.h
         stats.cc
         stats.h
         string-utils.cc

--- a/libtransmission/announcer-udp.cc
+++ b/libtransmission/announcer-udp.cc
@@ -41,6 +41,7 @@
 #include "libtransmission/log.h"
 #include "libtransmission/net.h"
 #include "libtransmission/peer-mgr.h" // for tr_pex::fromCompact4()
+#include "libtransmission/socks5-udp.h"
 #include "libtransmission/tr-assert.h"
 #include "libtransmission/tr-buffer.h"
 #include "libtransmission/tr-strbuf.h"
@@ -393,7 +394,21 @@ struct tau_tracker
         }
 
         auto const& [ss, sslen] = *addr;
-        mediator_.sendto(buf, buflen, reinterpret_cast<sockaddr const*>(&ss), sslen);
+        auto const* sa = reinterpret_cast<sockaddr const*>(&ss);
+
+        // If a SOCKS5 proxy is configured, all UDP tracker traffic must go
+        // through the relay. Sending directly would leak the user's real IP.
+        if (auto* socks = mediator_.socks5_udp(); socks != nullptr)
+        {
+            if (socks->is_ready())
+            {
+                socks->sendto(buf, buflen, sa, sslen);
+            }
+
+            return;
+        }
+
+        mediator_.sendto(buf, buflen, sa, sslen);
     }
 
     void on_connection_response(tr_address_type ip_protocol, tau_action_t action, InBuf& buf)

--- a/libtransmission/announcer.h
+++ b/libtransmission/announcer.h
@@ -29,6 +29,7 @@
 
 struct tr_address;
 class tr_announcer_udp;
+class tr_socks5_udp;
 struct tr_session;
 struct tr_torrent;
 struct tr_torrent_announcer;
@@ -144,6 +145,12 @@ public:
             std::string_view name,
             uint16_t service,
             std::string_view log_name) const;
+
+        // SOCKS5 UDP relay support
+        [[nodiscard]] virtual tr_socks5_udp* socks5_udp() const noexcept
+        {
+            return nullptr;
+        }
     };
 
     virtual ~tr_announcer_udp() noexcept = default;

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -48,6 +48,7 @@
 #include "libtransmission/rpc-server.h"
 #include "libtransmission/session-alt-speeds.h"
 #include "libtransmission/session.h"
+#include "libtransmission/socks5-udp.h"
 #include "libtransmission/string-utils.h"
 #include "libtransmission/timer-ev.h"
 #include "libtransmission/torrent.h"
@@ -61,6 +62,7 @@
 #include "libtransmission/variant.h"
 #include "libtransmission/version.h"
 #include "libtransmission/web.h"
+#include "libtransmission/web-utils.h"
 
 struct tr_ctor;
 
@@ -245,6 +247,11 @@ void tr_session::DhtMediator::add_pex(tr_sha1_digest_t const& info_hash, tr_pex 
     {
         tr_peerMgrAddPex(tor, TR_PEER_FROM_DHT, pex, n_pex);
     }
+}
+
+tr_socks5_udp* tr_session::AnnouncerUdpMediator::socks5_udp() const noexcept
+{
+    return session_.socks5_udp_.get();
 }
 
 // ---
@@ -869,6 +876,35 @@ void tr_session::setSettings(tr_session::Settings&& settings_in, bool force)
         udp_core_ = std::make_unique<tr_session::tr_udp_core>(*this, udpPort());
     }
 
+    // Initialize SOCKS5 UDP relay if proxy_url points to a socks5:// proxy
+    if (auto const& proxy_url = new_settings.proxy_url; force || proxy_url != old_settings.proxy_url)
+    {
+        socks5_udp_.reset();
+
+        if (proxy_url && tr_strv_starts_with(*proxy_url, "socks5://"sv))
+        {
+            // Parse host:port from socks5://host:port
+            if (auto const parsed = tr_urlParse(*proxy_url); parsed)
+            {
+                socks5_udp_ = std::make_unique<tr_socks5_udp>(
+                    event_base(),
+                    parsed->host,
+                    parsed->port != 0 ? parsed->port : uint16_t{ 1080 },
+                    tr_socks5_udp::ReadyCallback{});
+
+                // Route incoming relay packets to the UDP announcer
+                socks5_udp_->set_incoming_callback(
+                    [this](uint8_t const* payload, size_t payload_len, sockaddr const* from, socklen_t fromlen)
+                    {
+                        if (announcer_udp_)
+                        {
+                            announcer_udp_->handle_message(payload, payload_len, from, fromlen);
+                        }
+                    });
+            }
+        }
+    }
+
     // Sends out announce messages with advertisedPeerPort(), so this
     // section needs to happen here after the peer port settings changes
     if (auto const& val = new_settings.lpd_enabled; force || val != old_settings.lpd_enabled)
@@ -1462,6 +1498,7 @@ void tr_session::closeImplPart2(std::promise<void>* closed_promise, std::chrono:
 
     this->announcer_.reset();
     this->announcer_udp_.reset();
+    this->socks5_udp_.reset();
 
     stats().save();
     peer_mgr_.reset();

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -77,6 +77,7 @@ struct tr_pex;
 struct tr_torrent;
 struct struct_utp_context;
 struct tr_variant;
+class tr_socks5_udp;
 
 namespace tr::test
 {
@@ -158,6 +159,8 @@ private:
 
             return tr_address::from_string(session_.announceIP());
         }
+
+        [[nodiscard]] tr_socks5_udp* socks5_udp() const noexcept override;
 
     private:
         tr_session& session_;
@@ -1497,6 +1500,9 @@ private:
 
     // depends-on: udp_core_
     AnnouncerUdpMediator announcer_udp_mediator_{ *this };
+
+    // depends-on: settings_, session_thread_ (event_base)
+    std::unique_ptr<tr_socks5_udp> socks5_udp_;
 
     // depends-on: timer_maker_, torrents_, peer_mgr_
     DhtMediator dht_mediator_{ *this };

--- a/libtransmission/socks5-udp.cc
+++ b/libtransmission/socks5-udp.cc
@@ -1,0 +1,732 @@
+// This file Copyright © Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#ifdef _WIN32
+#include <ws2tcpip.h>
+#else
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+#endif
+
+#include <event2/dns.h>
+#include <event2/event.h>
+#include <event2/util.h>
+
+#include <fmt/format.h>
+
+#include "libtransmission/log.h"
+#include "libtransmission/net.h"
+#include "libtransmission/socks5-udp.h"
+#include "libtransmission/string-utils.h"
+#include "libtransmission/utils.h"
+
+using namespace std::literals;
+
+//  SOCKS5 protocol constants (RFC 1928)
+
+namespace
+{
+
+constexpr uint8_t Socks5Version = 0x05;
+constexpr uint8_t Socks5AuthNone = 0x00;
+constexpr uint8_t Socks5CmdUdpAssociate = 0x03;
+constexpr uint8_t Socks5AtypIpv4 = 0x01;
+constexpr uint8_t Socks5AtypIpv6 = 0x04;
+constexpr uint8_t Socks5Rsv = 0x00;
+constexpr uint8_t Socks5ReplySuccess = 0x00;
+
+} // namespace
+
+// Construction / destruction
+
+tr_socks5_udp::tr_socks5_udp(struct event_base* base, std::string_view proxy_host, uint16_t proxy_port, ReadyCallback on_ready)
+    : base_{ base }
+    , proxy_host_{ proxy_host }
+    , proxy_port_{ proxy_port }
+    , on_ready_{ std::move(on_ready) }
+{
+    start_connect();
+}
+
+tr_socks5_udp::~tr_socks5_udp()
+{
+    if (dns_req_ != nullptr)
+    {
+        evdns_getaddrinfo_cancel(dns_req_);
+        dns_req_ = nullptr;
+    }
+
+    if (dns_base_ != nullptr)
+    {
+        evdns_base_free(dns_base_, 0);
+        dns_base_ = nullptr;
+    }
+
+    tcp_event_.reset();
+    udp_event_.reset();
+
+    if (tcp_socket_ != TR_BAD_SOCKET)
+    {
+        tr_net_close_socket(tcp_socket_);
+    }
+
+    if (udp_socket_ != TR_BAD_SOCKET)
+    {
+        tr_net_close_socket(udp_socket_);
+    }
+}
+
+// TCP connect to SOCKS5 proxy
+
+void tr_socks5_udp::start_connect()
+{
+    if (auto const addr = tr_address::from_string(proxy_host_); addr)
+    {
+        // Numeric IP — skip DNS entirely
+        proxy_addr_ = *addr;
+        proxy_family_ = tr_ip_protocol_to_af(addr->type);
+        auto const socket_address = tr_socket_address{ *addr, tr_port::from_host(proxy_port_) };
+        auto const [ss, sslen] = socket_address.to_sockaddr();
+        state_ = State::Connecting;
+        do_connect(reinterpret_cast<sockaddr const*>(&ss), sslen);
+        return;
+    }
+
+    // Hostname — resolve asynchronously via evdns
+    state_ = State::Resolving;
+
+    dns_base_ = evdns_base_new(base_, EVDNS_BASE_INITIALIZE_NAMESERVERS | EVDNS_BASE_DISABLE_WHEN_INACTIVE);
+    if (dns_base_ == nullptr)
+    {
+        set_error("SOCKS5: couldn't create DNS resolver"sv);
+        return;
+    }
+
+    auto hints = evutil_addrinfo{};
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
+    hints.ai_protocol = IPPROTO_TCP;
+
+    auto port_str = std::array<char, 16>{};
+    *fmt::format_to(std::data(port_str), "{:d}", proxy_port_) = '\0';
+
+    dns_req_ = evdns_getaddrinfo(dns_base_, proxy_host_.c_str(), std::data(port_str), &hints, on_dns_result, this);
+    // dns_req_ is nullptr when the callback was already invoked inline (immediate error or cached result)
+}
+
+void tr_socks5_udp::on_dns_result(int result, evutil_addrinfo* res, void* arg)
+{
+    auto* self = static_cast<tr_socks5_udp*>(arg);
+    self->dns_req_ = nullptr;
+
+    if (result != 0)
+    {
+        self->set_error(
+            fmt::format(
+                "SOCKS5: DNS lookup failed for {}:{} — {}",
+                self->proxy_host_,
+                self->proxy_port_,
+                evutil_gai_strerror(result)));
+        return;
+    }
+
+    auto const res_guard = std::unique_ptr<evutil_addrinfo, decltype(&evutil_freeaddrinfo)>{ res, evutil_freeaddrinfo };
+
+    if (res == nullptr)
+    {
+        self->set_error(fmt::format("SOCKS5: DNS lookup returned no address for {}:{}", self->proxy_host_, self->proxy_port_));
+        return;
+    }
+
+    self->proxy_family_ = res->ai_family;
+    if (auto const socket_address = tr_socket_address::from_sockaddr(res->ai_addr); socket_address)
+    {
+        self->proxy_addr_ = socket_address->address();
+    }
+
+    self->state_ = State::Connecting;
+    self->do_connect(res->ai_addr, static_cast<socklen_t>(res->ai_addrlen));
+}
+
+void tr_socks5_udp::do_connect(sockaddr const* sa, socklen_t salen)
+{
+    tcp_socket_ = socket(proxy_family_, SOCK_STREAM, IPPROTO_TCP);
+    if (tcp_socket_ == TR_BAD_SOCKET)
+    {
+        set_error("SOCKS5: couldn't create TCP socket"sv);
+        return;
+    }
+
+    if (evutil_make_socket_nonblocking(tcp_socket_) != 0)
+    {
+        set_error("SOCKS5: couldn't make TCP socket non-blocking"sv);
+        return;
+    }
+
+    int const ret = connect(tcp_socket_, sa, salen);
+    if (ret != 0 &&
+#ifdef _WIN32
+        sockerrno != WSAEWOULDBLOCK &&
+#endif
+        sockerrno != EINPROGRESS)
+    {
+        set_error(fmt::format("SOCKS5: connect() failed — {}", tr_strerror(sockerrno)));
+        return;
+    }
+
+    // Wait for writable (connect completion) or readable
+    tcp_event_.reset(event_new(base_, tcp_socket_, EV_WRITE | EV_PERSIST, on_tcp_event, this));
+    event_add(tcp_event_.get(), nullptr);
+
+    if (ret == 0)
+    {
+        // Already connected (e.g. loopback)
+        send_greeting();
+    }
+}
+
+//  libevent callback
+
+void tr_socks5_udp::on_tcp_event(evutil_socket_t /*fd*/, short what, void* arg)
+{
+    auto* self = static_cast<tr_socks5_udp*>(arg);
+
+    if ((what & EV_WRITE) != 0)
+    {
+        self->on_tcp_writable();
+    }
+
+    if ((what & EV_READ) != 0)
+    {
+        self->on_tcp_readable();
+    }
+}
+
+void tr_socks5_udp::on_tcp_writable()
+{
+    if (!tcp_write_buf_.empty())
+    {
+        flush_pending_write();
+        return;
+    }
+
+    if (state_ == State::Connecting)
+    {
+        // Check if connect succeeded
+        int err = 0;
+        socklen_t errlen = sizeof(err);
+        if (getsockopt(tcp_socket_, SOL_SOCKET, SO_ERROR, reinterpret_cast<char*>(&err), &errlen) != 0 || err != 0)
+        {
+            set_error(fmt::format("SOCKS5: TCP connect failed — {}", tr_strerror(err != 0 ? err : sockerrno)));
+            return;
+        }
+
+        send_greeting();
+        return;
+    }
+}
+
+void tr_socks5_udp::queue_tcp_write(uint8_t const* data, size_t len)
+{
+    tcp_write_buf_.assign(data, data + len);
+    tcp_write_sent_ = 0;
+    flush_pending_write();
+}
+
+void tr_socks5_udp::flush_pending_write()
+{
+    while (tcp_write_sent_ < std::size(tcp_write_buf_))
+    {
+        auto const n = send(
+            tcp_socket_,
+            reinterpret_cast<char const*>(std::data(tcp_write_buf_) + tcp_write_sent_),
+            std::size(tcp_write_buf_) - tcp_write_sent_,
+            0);
+
+        if (n > 0)
+        {
+            tcp_write_sent_ += static_cast<size_t>(n);
+            continue;
+        }
+
+        if (n < 0 && (sockerrno == EWOULDBLOCK || sockerrno == EAGAIN))
+        {
+            tcp_event_.reset(event_new(base_, tcp_socket_, EV_WRITE | EV_PERSIST, on_tcp_event, this));
+            event_add(tcp_event_.get(), nullptr);
+            return;
+        }
+
+        set_error(fmt::format("SOCKS5: TCP send failed — {}", tr_strerror(sockerrno)));
+        return;
+    }
+
+    tcp_write_buf_.clear();
+    tcp_write_sent_ = 0;
+    state_ = pending_state_;
+    tcp_buf_used_ = 0;
+
+    tcp_event_.reset(event_new(base_, tcp_socket_, EV_READ | EV_PERSIST, on_tcp_event, this));
+    event_add(tcp_event_.get(), nullptr);
+}
+
+void tr_socks5_udp::on_tcp_readable()
+{
+    if (tcp_buf_used_ >= kTcpBufSize)
+    {
+        set_error("SOCKS5: handshake response exceeded buffer size"sv);
+        return;
+    }
+
+    // Read whatever is available into tcp_buf_
+    auto const n = recv(tcp_socket_, reinterpret_cast<char*>(tcp_buf_ + tcp_buf_used_), kTcpBufSize - tcp_buf_used_, 0);
+
+    if (n <= 0)
+    {
+        if (n == 0)
+        {
+            set_error("SOCKS5: proxy closed TCP connection"sv);
+        }
+        else if (sockerrno != EWOULDBLOCK && sockerrno != EAGAIN)
+        {
+            set_error(fmt::format("SOCKS5: TCP recv failed — {}", tr_strerror(sockerrno)));
+        }
+        return;
+    }
+
+    tcp_buf_used_ += static_cast<size_t>(n);
+
+    switch (state_)
+    {
+    case State::SentGreeting:
+        handle_greeting_response();
+        break;
+    case State::SentUdpAssociate:
+        handle_udp_associate_response();
+        break;
+    default:
+        break;
+    }
+}
+
+//  SOCKS5 handshake steps
+
+void tr_socks5_udp::send_greeting()
+{
+    // VER=5, NMETHODS=1, METHOD=NO_AUTH
+    uint8_t const greeting[] = { Socks5Version, 1, Socks5AuthNone };
+
+    pending_state_ = State::SentGreeting;
+    queue_tcp_write(greeting, sizeof(greeting));
+}
+
+void tr_socks5_udp::handle_greeting_response()
+{
+    // Expect 2 bytes: VER(5) METHOD
+    if (tcp_buf_used_ < 2)
+    {
+        return; // need more data
+    }
+
+    if (tcp_buf_[0] != Socks5Version || tcp_buf_[1] != Socks5AuthNone)
+    {
+        set_error(
+            fmt::format("SOCKS5: unsupported auth method {:d} (only no-auth supported)", static_cast<unsigned>(tcp_buf_[1])));
+        return;
+    }
+
+    tcp_buf_used_ = 0;
+    send_udp_associate();
+}
+
+void tr_socks5_udp::send_udp_associate()
+{
+    // Create a local UDP socket that we'll use for relay communication
+    auto const family = proxy_family_ == AF_INET6 ? AF_INET6 : AF_INET;
+    auto const ip_protocol = family == AF_INET6 ? TR_AF_INET6 : TR_AF_INET;
+
+    udp_socket_ = socket(family, SOCK_DGRAM, IPPROTO_UDP);
+    if (udp_socket_ == TR_BAD_SOCKET)
+    {
+        set_error("SOCKS5: couldn't create UDP socket for relay"sv);
+        return;
+    }
+
+    if (evutil_make_socket_nonblocking(udp_socket_) != 0)
+    {
+        set_error("SOCKS5: couldn't make UDP socket non-blocking"sv);
+        return;
+    }
+
+    // Bind to any port
+    auto const bind_address = tr_socket_address{ tr_address::any(ip_protocol), tr_port{} };
+    auto const bind_sockaddr = bind_address.to_sockaddr();
+    if (bind(udp_socket_, reinterpret_cast<sockaddr const*>(&bind_sockaddr.first), bind_sockaddr.second) != 0)
+    {
+        set_error(fmt::format("SOCKS5: bind UDP socket failed — {}", tr_strerror(sockerrno)));
+        return;
+    }
+
+    // Get the bound address/port
+    auto local_addr = sockaddr_storage{};
+    socklen_t local_len = sizeof(local_addr);
+    if (getsockname(udp_socket_, reinterpret_cast<sockaddr*>(&local_addr), &local_len) != 0)
+    {
+        set_error(fmt::format("SOCKS5: couldn't inspect UDP socket address - {}", tr_strerror(sockerrno)));
+        return;
+    }
+
+    // Send: VER=5 CMD=UDP_ASSOCIATE RSV=0 ATYP DST.ADDR DST.PORT
+    // DST.ADDR and DST.PORT tell the proxy where we'll send from. Since the
+    // socket is bound to any address, keep DST.ADDR wildcard but include the
+    // actual UDP source port.
+    auto request = std::vector<uint8_t>{ Socks5Version, Socks5CmdUdpAssociate, Socks5Rsv };
+    request.reserve(4 + 16 + 2);
+
+    if (family == AF_INET6)
+    {
+        auto const& sin6 = reinterpret_cast<sockaddr_in6 const&>(local_addr);
+        request.push_back(Socks5AtypIpv6);
+        auto const* const addr = reinterpret_cast<uint8_t const*>(&sin6.sin6_addr);
+        request.insert(std::end(request), addr, addr + 16);
+        auto const* const port = reinterpret_cast<uint8_t const*>(&sin6.sin6_port);
+        request.insert(std::end(request), port, port + 2);
+    }
+    else
+    {
+        auto const& sin = reinterpret_cast<sockaddr_in const&>(local_addr);
+        request.push_back(Socks5AtypIpv4);
+        auto const* const addr = reinterpret_cast<uint8_t const*>(&sin.sin_addr);
+        request.insert(std::end(request), addr, addr + 4);
+        auto const* const port = reinterpret_cast<uint8_t const*>(&sin.sin_port);
+        request.insert(std::end(request), port, port + 2);
+    }
+
+    pending_state_ = State::SentUdpAssociate;
+    queue_tcp_write(std::data(request), std::size(request));
+}
+
+void tr_socks5_udp::handle_udp_associate_response()
+{
+    // Minimum response: VER(1) REP(1) RSV(1) ATYP(1) + addr + port
+    // IPv4: 4 + 4 + 2 = 10
+    // IPv6: 4 + 16 + 2 = 22
+    if (tcp_buf_used_ < 4)
+    {
+        return; // need more data
+    }
+
+    if (tcp_buf_[0] != Socks5Version)
+    {
+        set_error("SOCKS5: invalid version in UDP ASSOCIATE response"sv);
+        return;
+    }
+
+    if (tcp_buf_[1] != Socks5ReplySuccess)
+    {
+        set_error(fmt::format("SOCKS5: UDP ASSOCIATE failed with reply code {:d}", static_cast<unsigned>(tcp_buf_[1])));
+        return;
+    }
+
+    if (tcp_buf_[2] != Socks5Rsv)
+    {
+        set_error(fmt::format("SOCKS5: invalid RSV byte {:d} in UDP ASSOCIATE response", static_cast<unsigned>(tcp_buf_[2])));
+        return;
+    }
+
+    uint8_t const atyp = tcp_buf_[3];
+    size_t needed = 0;
+    if (atyp == Socks5AtypIpv4)
+    {
+        needed = 4 + 4 + 2; // header + IPv4 + port
+    }
+    else if (atyp == Socks5AtypIpv6)
+    {
+        needed = 4 + 16 + 2; // header + IPv6 + port
+    }
+    else
+    {
+        set_error(fmt::format("SOCKS5: unsupported ATYP {:d} in UDP ASSOCIATE response", static_cast<unsigned>(atyp)));
+        return;
+    }
+
+    if (tcp_buf_used_ < needed)
+    {
+        return; // need more data
+    }
+
+    // Parse the relay address
+    auto relay_address = tr_address{};
+    uint16_t relay_port = 0;
+
+    if (atyp == Socks5AtypIpv4)
+    {
+        relay_address.type = TR_AF_INET;
+        std::memcpy(&relay_address.addr.addr4, tcp_buf_ + 4, 4);
+        std::memcpy(&relay_port, tcp_buf_ + 8, 2);
+        relay_port = ntohs(relay_port);
+    }
+    else // IPv6
+    {
+        relay_address.type = TR_AF_INET6;
+        std::memcpy(&relay_address.addr.addr6, tcp_buf_ + 4, 16);
+        std::memcpy(&relay_port, tcp_buf_ + 20, 2);
+        relay_port = ntohs(relay_port);
+    }
+
+    // If the relay address is 0.0.0.0 or ::, use the proxy host address instead
+    if (relay_address.is_any())
+    {
+        if (proxy_addr_)
+        {
+            relay_address = *proxy_addr_;
+        }
+        else
+        {
+            set_error("SOCKS5: proxy returned wildcard UDP relay address and proxy address is unavailable"sv);
+            return;
+        }
+    }
+
+    relay_addr_ = tr_socket_address{ relay_address, tr_port::from_host(relay_port) };
+
+    state_ = State::Ready;
+
+    tr_logAddInfo(fmt::format("SOCKS5: UDP relay ready at {}", relay_addr_->display_name()));
+
+    // Keep TCP connection alive (closing it terminates the association per RFC 1928).
+    // Switch to read-only to detect proxy-initiated close.
+    tcp_event_.reset(event_new(base_, tcp_socket_, EV_READ | EV_PERSIST, on_tcp_event, this));
+    event_add(tcp_event_.get(), nullptr);
+
+    // Set up UDP read event for relay responses
+    setup_udp_read_event();
+
+    if (on_ready_)
+    {
+        on_ready_();
+    }
+}
+
+//  UDP datagram wrapping (RFC 1928 §7)
+
+void tr_socks5_udp::sendto(void const* buf, size_t buflen, sockaddr const* dest, socklen_t /*destlen*/)
+{
+    if (!is_ready() || udp_socket_ == TR_BAD_SOCKET || !relay_addr_)
+    {
+        return;
+    }
+
+    auto const socket_addr = tr_socket_address::from_sockaddr(dest);
+    if (!socket_addr)
+    {
+        return;
+    }
+
+    // Build SOCKS5 UDP request header:
+    // RSV(2) FRAG(1) ATYP(1) DST.ADDR(4|16) DST.PORT(2) DATA(...)
+    auto header = std::array<uint8_t, 2 + 1 + 1 + 16 + 2>{}; // max size for IPv6
+    size_t hdr_len = 0;
+
+    // RSV = 0x0000
+    header[0] = 0;
+    header[1] = 0;
+    // FRAG = 0 (no fragmentation)
+    header[2] = 0;
+
+    auto const& addr = socket_addr->address();
+    auto const port = socket_addr->port();
+
+    if (addr.is_ipv4())
+    {
+        header[3] = Socks5AtypIpv4;
+        std::memcpy(header.data() + 4, &addr.addr.addr4, 4);
+        auto const nport = port.network();
+        std::memcpy(header.data() + 8, &nport, 2);
+        hdr_len = 10;
+    }
+    else
+    {
+        header[3] = Socks5AtypIpv6;
+        std::memcpy(header.data() + 4, &addr.addr.addr6, 16);
+        auto const nport = port.network();
+        std::memcpy(header.data() + 20, &nport, 2);
+        hdr_len = 22;
+    }
+
+    // Assemble full packet: header + payload
+    auto packet = std::vector<uint8_t>(hdr_len + buflen);
+    std::memcpy(packet.data(), header.data(), hdr_len);
+    std::memcpy(packet.data() + hdr_len, buf, buflen);
+
+    // Send to relay address
+    auto const [ss, sslen] = relay_addr_->to_sockaddr();
+    ::sendto(
+        udp_socket_,
+        reinterpret_cast<char const*>(packet.data()),
+        packet.size(),
+        0,
+        reinterpret_cast<sockaddr const*>(&ss),
+        sslen);
+}
+
+//  Unwrap incoming relay packets
+
+uint8_t const* tr_socks5_udp::unwrap_udp_packet(
+    uint8_t const* data,
+    size_t datalen,
+    size_t& payload_len,
+    sockaddr_storage& from,
+    socklen_t& fromlen)
+{
+    // Minimum: RSV(2) + FRAG(1) + ATYP(1) + IPv4(4) + PORT(2) = 10
+    if (datalen < 10)
+    {
+        return nullptr;
+    }
+
+    // RSV must be 0x0000
+    if (data[0] != 0 || data[1] != 0)
+    {
+        return nullptr;
+    }
+
+    // FRAG — we don't support reassembly, only standalone (0) packets
+    if (data[2] != 0)
+    {
+        return nullptr;
+    }
+
+    uint8_t const atyp = data[3];
+    size_t hdr_len = 0;
+
+    if (atyp == Socks5AtypIpv4)
+    {
+        if (datalen < 10)
+        {
+            return nullptr;
+        }
+        hdr_len = 10;
+
+        auto sin = sockaddr_in{};
+        sin.sin_family = AF_INET;
+        std::memcpy(&sin.sin_addr, data + 4, 4);
+        std::memcpy(&sin.sin_port, data + 8, 2); // already network order
+        std::memcpy(&from, &sin, sizeof(sin));
+        fromlen = sizeof(sin);
+    }
+    else if (atyp == Socks5AtypIpv6)
+    {
+        if (datalen < 22)
+        {
+            return nullptr;
+        }
+        hdr_len = 22;
+
+        auto sin6 = sockaddr_in6{};
+        sin6.sin6_family = AF_INET6;
+        std::memcpy(&sin6.sin6_addr, data + 4, 16);
+        std::memcpy(&sin6.sin6_port, data + 20, 2); // already network order
+        std::memcpy(&from, &sin6, sizeof(sin6));
+        fromlen = sizeof(sin6);
+    }
+    else
+    {
+        return nullptr;
+    }
+
+    payload_len = datalen - hdr_len;
+    return data + hdr_len;
+}
+
+//  UDP relay read event
+
+void tr_socks5_udp::setup_udp_read_event()
+{
+    if (udp_socket_ == TR_BAD_SOCKET)
+    {
+        return;
+    }
+
+    udp_event_.reset(event_new(base_, udp_socket_, EV_READ | EV_PERSIST, on_udp_readable, this));
+    event_add(udp_event_.get(), nullptr);
+}
+
+void tr_socks5_udp::on_udp_readable(evutil_socket_t fd, short /*what*/, void* arg)
+{
+    auto* self = static_cast<tr_socks5_udp*>(arg);
+
+    auto buf = std::array<uint8_t, 8192>{};
+    for (;;)
+    {
+        auto from = sockaddr_storage{};
+        auto fromlen = socklen_t{ sizeof(from) };
+
+        auto const n = recvfrom(
+            fd,
+            reinterpret_cast<char*>(std::data(buf)),
+            std::size(buf),
+            0,
+            reinterpret_cast<sockaddr*>(&from),
+            &fromlen);
+
+        if (n <= 0)
+        {
+            return;
+        }
+
+        // Unwrap the SOCKS5 UDP header to get the real source and payload
+        auto orig_from = sockaddr_storage{};
+        auto orig_fromlen = socklen_t{};
+        size_t payload_len = 0;
+
+        auto const* payload = unwrap_udp_packet(std::data(buf), static_cast<size_t>(n), payload_len, orig_from, orig_fromlen);
+
+        if (payload != nullptr && self->on_incoming_)
+        {
+            self->on_incoming_(payload, payload_len, reinterpret_cast<sockaddr const*>(&orig_from), orig_fromlen);
+        }
+    }
+}
+
+//  Error handling
+
+void tr_socks5_udp::set_error(std::string_view msg)
+{
+    tr_logAddWarn(std::string{ msg });
+    state_ = State::Error;
+
+    tcp_event_.reset();
+    udp_event_.reset();
+
+    if (tcp_socket_ != TR_BAD_SOCKET)
+    {
+        tr_net_close_socket(tcp_socket_);
+        tcp_socket_ = TR_BAD_SOCKET;
+    }
+
+    if (udp_socket_ != TR_BAD_SOCKET)
+    {
+        tr_net_close_socket(udp_socket_);
+        udp_socket_ = TR_BAD_SOCKET;
+    }
+}
+
+//  Helper
+
+std::optional<tr_socket_address> tr_socks5_udp::relay_address() const noexcept
+{
+    return relay_addr_;
+}

--- a/libtransmission/socks5-udp.h
+++ b/libtransmission/socks5-udp.h
@@ -1,0 +1,144 @@
+// This file Copyright © Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
+
+#pragma once
+
+#ifndef __TRANSMISSION__
+#error only libtransmission should #include this header.
+#endif
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#ifdef _WIN32
+#include <ws2tcpip.h>
+#else
+#include <sys/socket.h>
+#endif
+
+#include <event2/dns.h>
+#include <event2/util.h>
+
+#include "libtransmission/net.h"
+#include "libtransmission/utils-ev.h"
+
+struct event_base;
+
+// Manages a SOCKS5 UDP ASSOCIATE relay (RFC 1928) for UDP tracker traffic.
+// The TCP control connection is kept open for the lifetime of the association;
+// outbound datagrams are wrapped with the SOCKS5 UDP header, and relay replies
+// are unwrapped before being passed to the existing UDP announcer path.
+class tr_socks5_udp
+{
+public:
+    enum class State : uint8_t
+    {
+        Idle,
+        Resolving,
+        Connecting,
+        SentGreeting,
+        SentUdpAssociate,
+        Ready,
+        Error,
+    };
+
+    using ReadyCallback = std::function<void()>;
+    using IncomingCallback = std::function<
+        void(uint8_t const* payload, size_t payload_len, sockaddr const* from, socklen_t fromlen)>;
+
+    tr_socks5_udp(struct event_base* base, std::string_view proxy_host, uint16_t proxy_port, ReadyCallback on_ready);
+    ~tr_socks5_udp();
+
+    tr_socks5_udp(tr_socks5_udp const&) = delete;
+    tr_socks5_udp& operator=(tr_socks5_udp const&) = delete;
+    tr_socks5_udp(tr_socks5_udp&&) = delete;
+    tr_socks5_udp& operator=(tr_socks5_udp&&) = delete;
+
+    void set_incoming_callback(IncomingCallback cb)
+    {
+        on_incoming_ = std::move(cb);
+    }
+
+    [[nodiscard]] std::optional<tr_socket_address> relay_address() const noexcept;
+
+    [[nodiscard]] State state() const noexcept
+    {
+        return state_;
+    }
+
+    [[nodiscard]] bool is_ready() const noexcept
+    {
+        return state_ == State::Ready;
+    }
+
+    // `dest` is the final destination (tracker), not the relay.
+    void sendto(void const* buf, size_t buflen, sockaddr const* dest, socklen_t destlen);
+
+    [[nodiscard]] tr_socket_t relay_socket() const noexcept
+    {
+        return udp_socket_;
+    }
+
+    // Returns the inner payload start, or nullptr if malformed.
+    // Domain-name ATYP packets cannot be represented as sockaddr and are rejected.
+    [[nodiscard]] static uint8_t const* unwrap_udp_packet(
+        uint8_t const* data,
+        size_t datalen,
+        size_t& payload_len,
+        sockaddr_storage& from,
+        socklen_t& fromlen);
+
+private:
+    void start_connect();
+    void do_connect(sockaddr const* sa, socklen_t salen);
+    void on_tcp_writable();
+    void on_tcp_readable();
+    void send_greeting();
+    void send_udp_associate();
+    void handle_greeting_response();
+    void handle_udp_associate_response();
+    void set_error(std::string_view msg);
+    void setup_udp_read_event();
+    void queue_tcp_write(uint8_t const* data, size_t len);
+    void flush_pending_write();
+
+    static void on_tcp_event(evutil_socket_t fd, short what, void* arg);
+    static void on_udp_readable(evutil_socket_t fd, short what, void* arg);
+    static void on_dns_result(int result, evutil_addrinfo* res, void* arg);
+
+    struct event_base* base_;
+    std::string proxy_host_;
+    uint16_t proxy_port_;
+    ReadyCallback on_ready_;
+    IncomingCallback on_incoming_;
+
+    State state_ = State::Idle;
+    tr_socket_t tcp_socket_ = TR_BAD_SOCKET;
+    tr_socket_t udp_socket_ = TR_BAD_SOCKET;
+    tr::evhelpers::event_unique_ptr tcp_event_;
+    tr::evhelpers::event_unique_ptr udp_event_;
+
+    std::optional<tr_socket_address> relay_addr_;
+
+    std::optional<tr_address> proxy_addr_;
+    int proxy_family_ = AF_UNSPEC;
+
+    evdns_base* dns_base_ = nullptr;
+    evdns_getaddrinfo_request* dns_req_ = nullptr;
+
+    std::vector<uint8_t> tcp_write_buf_;
+    size_t tcp_write_sent_ = 0;
+    State pending_state_ = State::Idle;
+
+    static constexpr size_t kTcpBufSize = 512;
+    uint8_t tcp_buf_[kTcpBufSize] = {};
+    size_t tcp_buf_used_ = 0;
+};

--- a/tests/libtransmission/CMakeLists.txt
+++ b/tests/libtransmission/CMakeLists.txt
@@ -46,6 +46,7 @@ target_sources(libtransmission-test
         session-alt-speeds-test.cc
         session-test.cc
         settings-test.cc
+        socks5-udp-test.cc
         strbuf-test.cc
         string-utils-test.cc
         subprocess-test-script.cmd

--- a/tests/libtransmission/announcer-udp-test.cc
+++ b/tests/libtransmission/announcer-udp-test.cc
@@ -36,6 +36,7 @@
 #include <libtransmission/net.h>
 #include <libtransmission/peer-mgr.h> // for tr_pex
 #include <libtransmission/session.h> // tr_peerIdInit
+#include <libtransmission/socks5-udp.h>
 #include "libtransmission/timer.h"
 #include <libtransmission/timer-ev.h>
 #include <libtransmission/tr-buffer.h>
@@ -79,6 +80,11 @@ protected:
         [[nodiscard]] auto* eventBase()
         {
             return event_base_.get();
+        }
+
+        [[nodiscard]] tr_socks5_udp* socks5_udp() const noexcept override
+        {
+            return socks5_udp_.get();
         }
 
         [[nodiscard]] std::optional<tr_address> announce_ip() const override
@@ -155,6 +161,7 @@ protected:
         std::deque<Sent> sent_;
 
         std::unique_ptr<event_base, void (*)(event_base*)> const event_base_;
+        std::unique_ptr<tr_socks5_udp> socks5_udp_;
     };
 
     static void expectEqual(tr_scrape_response const& expected, tr_scrape_response const& actual)
@@ -452,6 +459,27 @@ TEST_F(AnnouncerUdpTest, canScrape)
     // Inspect that request for validity.
     std::tie(scrape_transaction_id, info_hashes) = parseScrapeRequest(waitForAnnouncerToSendMessage(mediator), connection_id);
     expectEqual(request, info_hashes);
+}
+
+TEST_F(AnnouncerUdpTest, doesNotLeakDirectUdpWhenSocks5RelayIsNotReady)
+{
+    auto mediator = MockMediator{};
+    mediator.socks5_udp_ = std::make_unique<tr_socks5_udp>(
+        mediator.eventBase(),
+        "127.0.0.1"sv,
+        uint16_t{ 1 },
+        tr_socks5_udp::ReadyCallback{});
+
+    auto announcer = tr_announcer_udp::create(mediator);
+    auto upkeep_timer = createUpkeepTimer(mediator, announcer);
+
+    auto request = buildSimpleScrapeRequestAndResponse().first;
+    auto response = std::optional<tr_scrape_response>{};
+    announcer->scrape(request, [&response](tr_scrape_response const& resp) { response = resp; });
+
+    EXPECT_FALSE(tr::test::waitFor(mediator.eventBase(), [&mediator]() { return !std::empty(mediator.sent_); }, 500ms));
+    EXPECT_TRUE(std::empty(mediator.sent_));
+    EXPECT_FALSE(response.has_value());
 }
 
 TEST_F(AnnouncerUdpTest, canDestructCleanlyEvenWhenBusy)

--- a/tests/libtransmission/socks5-udp-test.cc
+++ b/tests/libtransmission/socks5-udp-test.cc
@@ -1,0 +1,694 @@
+// This file Copyright © Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <optional>
+#include <vector>
+
+#ifdef _WIN32
+#include <ws2tcpip.h>
+#else
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#endif
+
+#include <gtest/gtest.h>
+
+#include <event2/event.h>
+#include <event2/util.h>
+
+#include <libtransmission/net.h>
+#include <libtransmission/socks5-udp.h>
+#include <libtransmission/utils-ev.h>
+
+#include "test-fixtures.h"
+
+using namespace std::literals;
+
+namespace
+{
+
+constexpr uint8_t Socks5Version = 0x05;
+constexpr uint8_t Socks5AuthNone = 0x00;
+constexpr uint8_t Socks5CmdUdpAssociate = 0x03;
+constexpr uint8_t Socks5AtypIpv4 = 0x01;
+constexpr uint8_t Socks5AtypIpv6 = 0x04;
+constexpr uint8_t Socks5ReplySuccess = 0x00;
+
+void closeSocket(tr_socket_t& socket)
+{
+    if (socket != TR_BAD_SOCKET)
+    {
+        tr_net_close_socket(socket);
+        socket = TR_BAD_SOCKET;
+    }
+}
+
+[[nodiscard]] std::optional<tr_socket_address> localSocketAddress(tr_socket_t socket)
+{
+    auto ss = sockaddr_storage{};
+    auto sslen = socklen_t{ sizeof(ss) };
+
+    if (getsockname(socket, reinterpret_cast<sockaddr*>(&ss), &sslen) != 0)
+    {
+        return {};
+    }
+
+    return tr_socket_address::from_sockaddr(reinterpret_cast<sockaddr const*>(&ss));
+}
+
+[[nodiscard]] std::vector<uint8_t> makeSocks5UdpPacket(sockaddr const* from, std::vector<uint8_t> const& payload)
+{
+    auto const socket_addr = tr_socket_address::from_sockaddr(from);
+    if (!socket_addr)
+    {
+        return {};
+    }
+
+    auto const& address = socket_addr->address();
+    auto const header_size = address.is_ipv4() ? size_t{ 10 } : size_t{ 22 };
+    auto packet = std::vector<uint8_t>(header_size + std::size(payload));
+
+    packet[0] = 0;
+    packet[1] = 0;
+    packet[2] = 0;
+
+    if (address.is_ipv4())
+    {
+        packet[3] = Socks5AtypIpv4;
+        std::memcpy(std::data(packet) + 4, &address.addr.addr4, 4);
+        auto const port = socket_addr->port().network();
+        std::memcpy(std::data(packet) + 8, &port, 2);
+    }
+    else
+    {
+        packet[3] = Socks5AtypIpv6;
+        std::memcpy(std::data(packet) + 4, &address.addr.addr6, 16);
+        auto const port = socket_addr->port().network();
+        std::memcpy(std::data(packet) + 20, &port, 2);
+    }
+
+    std::memcpy(std::data(packet) + header_size, std::data(payload), std::size(payload));
+    return packet;
+}
+
+class MockSocks5UdpServer
+{
+public:
+    explicit MockSocks5UdpServer(event_base* base)
+        : base_{ base }
+    {
+        openUdpRelay();
+        openTcpListener();
+    }
+
+    ~MockSocks5UdpServer()
+    {
+        tcp_listen_event_.reset();
+        tcp_client_event_.reset();
+        udp_event_.reset();
+
+        closeSocket(tcp_client_socket_);
+        closeSocket(tcp_listen_socket_);
+        closeSocket(udp_socket_);
+    }
+
+    [[nodiscard]] uint16_t tcp_port() const noexcept
+    {
+        return tcp_port_;
+    }
+
+    [[nodiscard]] bool got_greeting() const noexcept
+    {
+        return got_greeting_;
+    }
+
+    [[nodiscard]] bool got_udp_associate() const noexcept
+    {
+        return got_udp_associate_;
+    }
+
+    [[nodiscard]] bool got_udp_datagram() const noexcept
+    {
+        return got_udp_datagram_;
+    }
+
+    [[nodiscard]] std::optional<tr_socket_address> associate_destination() const
+    {
+        return associate_destination_;
+    }
+
+    [[nodiscard]] std::optional<tr_socket_address> udp_destination() const
+    {
+        return udp_destination_;
+    }
+
+    [[nodiscard]] auto const& udp_payload() const noexcept
+    {
+        return udp_payload_;
+    }
+
+    [[nodiscard]] auto const& response_payload() const noexcept
+    {
+        return response_payload_;
+    }
+
+    void close_tcp_control()
+    {
+        tcp_client_event_.reset();
+        closeSocket(tcp_client_socket_);
+    }
+
+private:
+    void openTcpListener()
+    {
+        tcp_listen_socket_ = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+        ASSERT_NE(tcp_listen_socket_, TR_BAD_SOCKET);
+
+        auto const one = int{ 1 };
+        setsockopt(tcp_listen_socket_, SOL_SOCKET, SO_REUSEADDR, reinterpret_cast<char const*>(&one), sizeof(one));
+        ASSERT_EQ(evutil_make_socket_nonblocking(tcp_listen_socket_), 0);
+
+        auto addr = sockaddr_in{};
+        addr.sin_family = AF_INET;
+        addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+        addr.sin_port = 0;
+
+        ASSERT_EQ(bind(tcp_listen_socket_, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)), 0);
+        ASSERT_EQ(listen(tcp_listen_socket_, 1), 0);
+
+        auto const socket_address = localSocketAddress(tcp_listen_socket_);
+        ASSERT_TRUE(socket_address);
+        tcp_port_ = socket_address->port().host();
+
+        tcp_listen_event_.reset(event_new(base_, tcp_listen_socket_, EV_READ | EV_PERSIST, onTcpAccept, this));
+        ASSERT_NE(tcp_listen_event_.get(), nullptr);
+        ASSERT_EQ(event_add(tcp_listen_event_.get(), nullptr), 0);
+    }
+
+    void openUdpRelay()
+    {
+        udp_socket_ = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+        ASSERT_NE(udp_socket_, TR_BAD_SOCKET);
+        ASSERT_EQ(evutil_make_socket_nonblocking(udp_socket_), 0);
+
+        auto addr = sockaddr_in{};
+        addr.sin_family = AF_INET;
+        addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+        addr.sin_port = 0;
+
+        ASSERT_EQ(bind(udp_socket_, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)), 0);
+
+        auto const socket_address = localSocketAddress(udp_socket_);
+        ASSERT_TRUE(socket_address);
+        udp_port_ = socket_address->port().host();
+
+        udp_event_.reset(event_new(base_, udp_socket_, EV_READ | EV_PERSIST, onUdpReadable, this));
+        ASSERT_NE(udp_event_.get(), nullptr);
+        ASSERT_EQ(event_add(udp_event_.get(), nullptr), 0);
+    }
+
+    static void onTcpAccept(evutil_socket_t /*fd*/, short /*what*/, void* arg)
+    {
+        static_cast<MockSocks5UdpServer*>(arg)->acceptTcpClient();
+    }
+
+    void acceptTcpClient()
+    {
+        auto client_addr = sockaddr_storage{};
+        auto client_addr_len = socklen_t{ sizeof(client_addr) };
+        auto const socket = accept(tcp_listen_socket_, reinterpret_cast<sockaddr*>(&client_addr), &client_addr_len);
+        if (socket == TR_BAD_SOCKET)
+        {
+            return;
+        }
+
+        closeSocket(tcp_client_socket_);
+        tcp_client_socket_ = socket;
+        ASSERT_EQ(evutil_make_socket_nonblocking(tcp_client_socket_), 0);
+
+        tcp_client_event_.reset(event_new(base_, tcp_client_socket_, EV_READ | EV_PERSIST, onTcpReadable, this));
+        ASSERT_NE(tcp_client_event_.get(), nullptr);
+        ASSERT_EQ(event_add(tcp_client_event_.get(), nullptr), 0);
+    }
+
+    static void onTcpReadable(evutil_socket_t /*fd*/, short /*what*/, void* arg)
+    {
+        static_cast<MockSocks5UdpServer*>(arg)->readTcpClient();
+    }
+
+    void readTcpClient()
+    {
+        auto buf = std::array<uint8_t, 256>{};
+        auto const n_read = recv(tcp_client_socket_, reinterpret_cast<char*>(std::data(buf)), std::size(buf), 0);
+        if (n_read <= 0)
+        {
+            return;
+        }
+
+        tcp_buffer_.insert(std::end(tcp_buffer_), std::begin(buf), std::begin(buf) + static_cast<size_t>(n_read));
+        processTcpBuffer();
+    }
+
+    void processTcpBuffer()
+    {
+        if (!got_greeting_)
+        {
+            if (std::size(tcp_buffer_) < 2U)
+            {
+                return;
+            }
+
+            auto const n_methods = tcp_buffer_[1];
+            auto const greeting_size = size_t{ 2U + n_methods };
+            if (std::size(tcp_buffer_) < greeting_size)
+            {
+                return;
+            }
+
+            EXPECT_EQ(tcp_buffer_[0], Socks5Version);
+            EXPECT_EQ(n_methods, 1U);
+            EXPECT_EQ(tcp_buffer_[2], Socks5AuthNone);
+
+            uint8_t const response[] = { Socks5Version, Socks5AuthNone };
+            auto const n_sent = send(tcp_client_socket_, reinterpret_cast<char const*>(response), sizeof(response), 0);
+            EXPECT_GE(n_sent, 0);
+            EXPECT_EQ(static_cast<size_t>(n_sent), sizeof(response));
+
+            tcp_buffer_.erase(std::begin(tcp_buffer_), std::begin(tcp_buffer_) + greeting_size);
+            got_greeting_ = true;
+        }
+
+        if (!got_udp_associate_)
+        {
+            if (std::size(tcp_buffer_) < 10U)
+            {
+                return;
+            }
+
+            EXPECT_EQ(tcp_buffer_[0], Socks5Version);
+            EXPECT_EQ(tcp_buffer_[1], Socks5CmdUdpAssociate);
+            EXPECT_EQ(tcp_buffer_[2], 0U);
+            EXPECT_EQ(tcp_buffer_[3], Socks5AtypIpv4);
+
+            auto associate_addr = sockaddr_in{};
+            associate_addr.sin_family = AF_INET;
+            std::memcpy(&associate_addr.sin_addr, std::data(tcp_buffer_) + 4, 4);
+            std::memcpy(&associate_addr.sin_port, std::data(tcp_buffer_) + 8, 2);
+            associate_destination_ = tr_socket_address::from_sockaddr(reinterpret_cast<sockaddr const*>(&associate_addr));
+
+            auto response = std::array<uint8_t, 10>{};
+            response[0] = Socks5Version;
+            response[1] = Socks5ReplySuccess;
+            response[2] = 0;
+            response[3] = Socks5AtypIpv4;
+            response[4] = 127;
+            response[5] = 0;
+            response[6] = 0;
+            response[7] = 1;
+            auto const relay_port = htons(udp_port_);
+            std::memcpy(std::data(response) + 8, &relay_port, 2);
+            auto const n_sent = send(
+                tcp_client_socket_,
+                reinterpret_cast<char const*>(std::data(response)),
+                std::size(response),
+                0);
+            EXPECT_GE(n_sent, 0);
+            EXPECT_EQ(static_cast<size_t>(n_sent), std::size(response));
+
+            tcp_buffer_.erase(std::begin(tcp_buffer_), std::begin(tcp_buffer_) + 10);
+            got_udp_associate_ = true;
+        }
+    }
+
+    static void onUdpReadable(evutil_socket_t /*fd*/, short /*what*/, void* arg)
+    {
+        static_cast<MockSocks5UdpServer*>(arg)->readUdpRelay();
+    }
+
+    void readUdpRelay()
+    {
+        auto buf = std::array<uint8_t, 2048>{};
+        auto client_addr = sockaddr_storage{};
+        auto client_addr_len = socklen_t{ sizeof(client_addr) };
+        auto const n_read = recvfrom(
+            udp_socket_,
+            reinterpret_cast<char*>(std::data(buf)),
+            std::size(buf),
+            0,
+            reinterpret_cast<sockaddr*>(&client_addr),
+            &client_addr_len);
+
+        if (n_read <= 0)
+        {
+            return;
+        }
+
+        auto destination = sockaddr_storage{};
+        auto destination_len = socklen_t{};
+        auto payload_len = size_t{};
+        auto const* payload = tr_socks5_udp::unwrap_udp_packet(
+            std::data(buf),
+            static_cast<size_t>(n_read),
+            payload_len,
+            destination,
+            destination_len);
+
+        if (payload == nullptr)
+        {
+            return;
+        }
+
+        udp_payload_.assign(payload, payload + payload_len);
+        udp_destination_ = tr_socket_address::from_sockaddr(reinterpret_cast<sockaddr const*>(&destination));
+        got_udp_datagram_ = true;
+
+        auto const packet = makeSocks5UdpPacket(reinterpret_cast<sockaddr const*>(&destination), response_payload_);
+        EXPECT_FALSE(std::empty(packet));
+        auto const n_sent = sendto(
+            udp_socket_,
+            reinterpret_cast<char const*>(std::data(packet)),
+            std::size(packet),
+            0,
+            reinterpret_cast<sockaddr const*>(&client_addr),
+            client_addr_len);
+        EXPECT_GE(n_sent, 0);
+        EXPECT_EQ(static_cast<size_t>(n_sent), std::size(packet));
+    }
+
+    event_base* base_ = nullptr;
+
+    tr_socket_t tcp_listen_socket_ = TR_BAD_SOCKET;
+    tr_socket_t tcp_client_socket_ = TR_BAD_SOCKET;
+    tr_socket_t udp_socket_ = TR_BAD_SOCKET;
+
+    tr::evhelpers::event_unique_ptr tcp_listen_event_;
+    tr::evhelpers::event_unique_ptr tcp_client_event_;
+    tr::evhelpers::event_unique_ptr udp_event_;
+
+    uint16_t tcp_port_ = 0;
+    uint16_t udp_port_ = 0;
+
+    bool got_greeting_ = false;
+    bool got_udp_associate_ = false;
+    bool got_udp_datagram_ = false;
+
+    std::vector<uint8_t> tcp_buffer_;
+    std::optional<tr_socket_address> associate_destination_;
+    std::optional<tr_socket_address> udp_destination_;
+    std::vector<uint8_t> udp_payload_;
+    std::vector<uint8_t> response_payload_ = { 0x72, 0x65, 0x6c, 0x61, 0x79, 0x2d, 0x6f, 0x6b };
+};
+
+} // namespace
+
+class Socks5UdpTest : public ::tr::test::TransmissionTest
+{
+};
+
+TEST_F(Socks5UdpTest, proxiesUdpDatagramsThroughMockServer)
+{
+    auto evbase = tr::evhelpers::evbase_unique_ptr{ event_base_new() };
+    ASSERT_NE(evbase.get(), nullptr);
+
+    auto server = MockSocks5UdpServer{ evbase.get() };
+    auto client_ready = false;
+    auto client = tr_socks5_udp{ evbase.get(), "127.0.0.1"sv, server.tcp_port(), [&client_ready]() { client_ready = true; } };
+
+    ASSERT_TRUE(
+        tr::test::waitFor(
+            evbase.get(),
+            [&client, &client_ready, &server]()
+            { return client_ready && client.is_ready() && server.got_greeting() && server.got_udp_associate(); }));
+
+    auto const client_udp_address = localSocketAddress(client.relay_socket());
+    ASSERT_TRUE(client_udp_address);
+
+    auto const associate_destination = server.associate_destination();
+    ASSERT_TRUE(associate_destination);
+    EXPECT_TRUE(associate_destination->address().is_any());
+    EXPECT_EQ(associate_destination->port(), client_udp_address->port());
+
+    auto incoming_called = false;
+    auto incoming_payload = std::vector<uint8_t>{};
+    auto incoming_source = std::optional<tr_socket_address>{};
+    client.set_incoming_callback(
+        [&incoming_called,
+         &incoming_payload,
+         &incoming_source](uint8_t const* payload, size_t payload_len, sockaddr const* from, socklen_t /*fromlen*/)
+        {
+            incoming_called = true;
+            incoming_payload.assign(payload, payload + payload_len);
+            incoming_source = tr_socket_address::from_sockaddr(from);
+        });
+
+    auto const tracker_address = tr_address::from_string("203.0.113.9"sv);
+    ASSERT_TRUE(tracker_address);
+    auto const tracker_socket_address = tr_socket_address{ *tracker_address, tr_port::from_host(6969) };
+    auto const [tracker_sockaddr, tracker_sockaddr_len] = tracker_socket_address.to_sockaddr();
+
+    auto const request_payload = std::vector<uint8_t>{ 0xde, 0xad, 0xbe, 0xef };
+    client.sendto(
+        std::data(request_payload),
+        std::size(request_payload),
+        reinterpret_cast<sockaddr const*>(&tracker_sockaddr),
+        tracker_sockaddr_len);
+
+    ASSERT_TRUE(
+        tr::test::waitFor(
+            evbase.get(),
+            [&incoming_called, &server]() { return incoming_called && server.got_udp_datagram(); }));
+
+    EXPECT_EQ(server.udp_payload(), request_payload);
+
+    auto const udp_destination = server.udp_destination();
+    ASSERT_TRUE(udp_destination);
+    EXPECT_EQ(*udp_destination, tracker_socket_address);
+
+    ASSERT_TRUE(incoming_source);
+    EXPECT_EQ(*incoming_source, tracker_socket_address);
+    EXPECT_EQ(incoming_payload, server.response_payload());
+}
+
+TEST_F(Socks5UdpTest, detectsTcpControlCloseAfterAssociate)
+{
+    auto evbase = tr::evhelpers::evbase_unique_ptr{ event_base_new() };
+    ASSERT_NE(evbase.get(), nullptr);
+
+    auto server = MockSocks5UdpServer{ evbase.get() };
+    auto client = tr_socks5_udp{ evbase.get(), "127.0.0.1"sv, server.tcp_port(), tr_socks5_udp::ReadyCallback{} };
+
+    ASSERT_TRUE(
+        tr::test::waitFor(evbase.get(), [&client, &server]() { return client.is_ready() && server.got_udp_associate(); }));
+
+    server.close_tcp_control();
+
+    EXPECT_TRUE(tr::test::waitFor(evbase.get(), [&client]() { return client.state() == tr_socks5_udp::State::Error; }));
+    EXPECT_FALSE(client.is_ready());
+}
+
+//  Tests for unwrap_udp_packet (static, no network needed)
+
+TEST_F(Socks5UdpTest, unwrapValidIpv4Packet)
+{
+    // RSV(2)=0x0000 FRAG(1)=0x00 ATYP(1)=0x01 ADDR(4) PORT(2) PAYLOAD
+    auto const payload_data = std::array<uint8_t, 4>{ 0xDE, 0xAD, 0xBE, 0xEF };
+    auto packet = std::array<uint8_t, 10 + 4>{};
+    // RSV
+    packet[0] = 0x00;
+    packet[1] = 0x00;
+    // FRAG
+    packet[2] = 0x00;
+    // ATYP = IPv4
+    packet[3] = 0x01;
+    // ADDR = 192.168.1.100
+    packet[4] = 192;
+    packet[5] = 168;
+    packet[6] = 1;
+    packet[7] = 100;
+    // PORT = 6881 (big endian)
+    uint16_t port = htons(6881);
+    std::memcpy(&packet[8], &port, 2);
+    // PAYLOAD
+    std::memcpy(&packet[10], payload_data.data(), 4);
+
+    auto from = sockaddr_storage{};
+    auto fromlen = socklen_t{};
+    size_t payload_len = 0;
+
+    auto const* result = tr_socks5_udp::unwrap_udp_packet(packet.data(), packet.size(), payload_len, from, fromlen);
+
+    ASSERT_NE(result, nullptr);
+    EXPECT_EQ(payload_len, 4U);
+    EXPECT_EQ(std::memcmp(result, payload_data.data(), 4), 0);
+
+    // Verify source address was parsed
+    EXPECT_EQ(fromlen, sizeof(sockaddr_in));
+    auto const* sin = reinterpret_cast<sockaddr_in const*>(&from);
+    EXPECT_EQ(sin->sin_family, AF_INET);
+    EXPECT_EQ(ntohs(sin->sin_port), 6881);
+
+    auto addr_bytes = std::array<uint8_t, 4>{};
+    std::memcpy(addr_bytes.data(), &sin->sin_addr, 4);
+    EXPECT_EQ(addr_bytes[0], 192);
+    EXPECT_EQ(addr_bytes[1], 168);
+    EXPECT_EQ(addr_bytes[2], 1);
+    EXPECT_EQ(addr_bytes[3], 100);
+}
+
+TEST_F(Socks5UdpTest, unwrapValidIpv6Packet)
+{
+    // SOCKS5 UDP relay packet with IPv6
+    auto const payload_data = std::array<uint8_t, 3>{ 0x01, 0x02, 0x03 };
+    auto packet = std::array<uint8_t, 22 + 3>{};
+    // RSV
+    packet[0] = 0x00;
+    packet[1] = 0x00;
+    // FRAG
+    packet[2] = 0x00;
+    // ATYP = IPv6
+    packet[3] = 0x04;
+    // ADDR = ::1 (16 bytes)
+    std::memset(&packet[4], 0, 15);
+    packet[19] = 1;
+    // PORT = 8080 (big endian)
+    uint16_t port = htons(8080);
+    std::memcpy(&packet[20], &port, 2);
+    // PAYLOAD
+    std::memcpy(&packet[22], payload_data.data(), 3);
+
+    auto from = sockaddr_storage{};
+    auto fromlen = socklen_t{};
+    size_t payload_len = 0;
+
+    auto const* result = tr_socks5_udp::unwrap_udp_packet(packet.data(), packet.size(), payload_len, from, fromlen);
+
+    ASSERT_NE(result, nullptr);
+    EXPECT_EQ(payload_len, 3U);
+    EXPECT_EQ(std::memcmp(result, payload_data.data(), 3), 0);
+
+    EXPECT_EQ(fromlen, sizeof(sockaddr_in6));
+    auto const* sin6 = reinterpret_cast<sockaddr_in6 const*>(&from);
+    EXPECT_EQ(sin6->sin6_family, AF_INET6);
+    EXPECT_EQ(ntohs(sin6->sin6_port), 8080);
+}
+
+TEST_F(Socks5UdpTest, unwrapRejectsTooShort)
+{
+    // Less than minimum 10 bytes
+    auto packet = std::array<uint8_t, 5>{ 0x00, 0x00, 0x00, 0x01, 0xFF };
+
+    auto from = sockaddr_storage{};
+    auto fromlen = socklen_t{};
+    size_t payload_len = 0;
+
+    auto const* result = tr_socks5_udp::unwrap_udp_packet(packet.data(), packet.size(), payload_len, from, fromlen);
+
+    EXPECT_EQ(result, nullptr);
+}
+
+TEST_F(Socks5UdpTest, unwrapRejectsNonZeroRsv)
+{
+    // RSV field must be 0x0000
+    auto packet = std::array<uint8_t, 10>{};
+    packet[0] = 0x01; // non-zero RSV
+    packet[1] = 0x00;
+    packet[2] = 0x00;
+    packet[3] = 0x01; // IPv4
+
+    auto from = sockaddr_storage{};
+    auto fromlen = socklen_t{};
+    size_t payload_len = 0;
+
+    auto const* result = tr_socks5_udp::unwrap_udp_packet(packet.data(), packet.size(), payload_len, from, fromlen);
+
+    EXPECT_EQ(result, nullptr);
+}
+
+TEST_F(Socks5UdpTest, unwrapRejectsFragmented)
+{
+    // FRAG != 0 should be rejected (no reassembly support)
+    auto packet = std::array<uint8_t, 10>{};
+    packet[0] = 0x00;
+    packet[1] = 0x00;
+    packet[2] = 0x01; // non-zero FRAG
+    packet[3] = 0x01; // IPv4
+
+    auto from = sockaddr_storage{};
+    auto fromlen = socklen_t{};
+    size_t payload_len = 0;
+
+    auto const* result = tr_socks5_udp::unwrap_udp_packet(packet.data(), packet.size(), payload_len, from, fromlen);
+
+    EXPECT_EQ(result, nullptr);
+}
+
+TEST_F(Socks5UdpTest, unwrapRejectsUnsupportedAtyp)
+{
+    // ATYP = 0x03 (domain name) is unsupported
+    auto packet = std::array<uint8_t, 10>{};
+    packet[0] = 0x00;
+    packet[1] = 0x00;
+    packet[2] = 0x00;
+    packet[3] = 0x03; // domain name ATYP
+
+    auto from = sockaddr_storage{};
+    auto fromlen = socklen_t{};
+    size_t payload_len = 0;
+
+    auto const* result = tr_socks5_udp::unwrap_udp_packet(packet.data(), packet.size(), payload_len, from, fromlen);
+
+    EXPECT_EQ(result, nullptr);
+}
+
+TEST_F(Socks5UdpTest, unwrapHandlesZeroLengthPayload)
+{
+    // Valid header with no payload (IPv4, exactly 10 bytes)
+    auto packet = std::array<uint8_t, 10>{};
+    packet[0] = 0x00;
+    packet[1] = 0x00;
+    packet[2] = 0x00;
+    packet[3] = 0x01; // IPv4
+    // ADDR = 10.0.0.1
+    packet[4] = 10;
+    packet[5] = 0;
+    packet[6] = 0;
+    packet[7] = 1;
+    // PORT = 0
+    packet[8] = 0;
+    packet[9] = 0;
+
+    auto from = sockaddr_storage{};
+    auto fromlen = socklen_t{};
+    size_t payload_len = 0;
+
+    auto const* result = tr_socks5_udp::unwrap_udp_packet(packet.data(), packet.size(), payload_len, from, fromlen);
+
+    ASSERT_NE(result, nullptr);
+    EXPECT_EQ(payload_len, 0U);
+}
+
+TEST_F(Socks5UdpTest, unwrapIpv6TooShort)
+{
+    // ATYP=IPv6 but only 15 bytes total (need 22 minimum)
+    auto packet = std::array<uint8_t, 15>{};
+    packet[0] = 0x00;
+    packet[1] = 0x00;
+    packet[2] = 0x00;
+    packet[3] = 0x04; // IPv6
+
+    auto from = sockaddr_storage{};
+    auto fromlen = socklen_t{};
+    size_t payload_len = 0;
+
+    auto const* result = tr_socks5_udp::unwrap_udp_packet(packet.data(), packet.size(), payload_len, from, fromlen);
+
+    EXPECT_EQ(result, nullptr);
+}


### PR DESCRIPTION
This adds SOCKS5 UDP ASSOCIATE support for UDP tracker announces when
`proxy_url` is configured with a `socks5://host:port` URL.

When a SOCKS5 proxy is configured, Transmission opens a persistent TCP
control connection to the proxy, performs the SOCKS5 handshake, sends a
UDP ASSOCIATE request, and routes outgoing UDP tracker announces through
the relay endpoint returned by the proxy.

Incoming relay datagrams are unwrapped and forwarded to the existing UDP
announcer path. If the SOCKS5 UDP relay is not ready, the announcer falls
back to direct UDP, preserving the current behaviour for non-SOCKS5
configurations and for proxy setup failures.

The UDP ASSOCIATE request includes the bound local UDP port, so proxies
that pin the association to a specific client source port can accept the
relayed datagrams correctly.

This also adds:

- a `tr_socks5_udp` helper for the SOCKS5 UDP ASSOCIATE state machine;
- RFC 1928 UDP packet wrapping/unwrapping support;
- tests for valid and malformed SOCKS5 UDP packets;
- a mock SOCKS5 server test covering the TCP handshake, UDP ASSOCIATE,
  outgoing relay wrapping, and incoming relay unwrapping;
- tests for direct-UDP fallback and TCP control connection loss.

Closes #7668