### PR TITLE
fix: replace invalid utf8 in peer_id-derived client name

### DIFF
--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -2181,7 +2181,7 @@ tr_peerMsgs::tr_peerMsgs(
     {
         auto buf = std::array<char, 128>{};
         tr_clientForId(std::data(buf), sizeof(buf), peer_id);
-        client = tr_interned_string{ tr_quark_new(std::data(buf)) };
+        client = tr_interned_string{ tr_strv_convert_utf8(std::data(buf)) };
     }
     set_user_agent(client);
     peer_info->set_connected(tr_time());


### PR DESCRIPTION
Part of this was fixed in #7667 but we should have done it here as well.  This is only used for display purposes, the 20-bytes binary is maintained for internal purposes.  Without this, json_rpc pukes, and clients error out when receiving illegal UTF8.

for extra clarity: this is the displayed "client name" after the main handshake but before the LTEP handshake (if there is one).  We mostly don't notice this because it happens only briefly; any torrent bot that skips the LTEP handshake would hit this, however, and provides a DoS attack surface for ill-intended clients.

Notes: Added sanitization for UTF-8 client names provided by peers during handshake.
