### PR TITLE
Notes: Torrent inspector click issues resolved for macOS app (#8792)

### DIFF
--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -2313,7 +2313,7 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
     else
     {
         [self.fInfoController updateInfoStats];
-        [self.fInfoController.window orderFront:nil];
+        [self.fInfoController.window makeKeyAndOrderFront:nil];
 
         if (self.fInfoController.canQuickLook && [QLPreviewPanel sharedPreviewPanelExists] &&
             [QLPreviewPanel sharedPreviewPanel].visible)

--- a/macosx/InfoWindowController.mm
+++ b/macosx/InfoWindowController.mm
@@ -89,7 +89,8 @@ typedef NS_ENUM(NSUInteger, TabTag) {
     windowRect.size.height = windowHeight;
     [window setFrame:windowRect display:NO];
 
-    window.becomesKeyOnlyIfNeeded = YES;
+    // Let inspector gain keyboard focus when clicked on non-interactive areas
+    window.becomesKeyOnlyIfNeeded = NO;
 
     //disable green maximise window button
     //https://github.com/transmission/transmission/issues/3486


### PR DESCRIPTION
Manually backport https://github.com/transmission/transmission/pull/8792 to 4.1.x. See that PR for details.

Notes: Fixed navigation focus issues in the Inspector.