### PR TITLE
refactor: make some libtransmission types public

### DIFF
--- a/docs/Editing-Configuration-Files.md
+++ b/docs/Editing-Configuration-Files.md
@@ -119,7 +119,7 @@ Here is a sample of the three basic types: respectively Boolean, Number and Stri
  * **peer_congestion_algorithm:** String. This is documented on https://www.pps.jussieu.fr/~jch/software/bittorrent/tcp-congestion-control.html.
  * **peer_limit_global:** Number (default = 200)
  * **peer_limit_per_torrent:** Number (default = 50)
- * **peer_socket_diffserv:** String (default = "le") Set the [DiffServ](https://en.wikipedia.org/wiki/Differentiated_services) parameter for outgoing packets. Allowed values are lowercase DSCP names. See the `tr_diffserv_t` class from `libtransmission/net.h` for the exact list of possible values.
+ * **peer_socket_diffserv:** String (default = "le") Set the [DiffServ](https://en.wikipedia.org/wiki/Differentiated_services) parameter for outgoing packets. Allowed values are lowercase DSCP names. See the `tr_diffserv_t` class from `libtransmission/types.h` for the exact list of possible values.
  * **reqq:** Number (default = 2000) The number of outstanding block requests a peer is allowed to queue in the client. The higher this number, the higher the max possible upload speed towards each peer.
  * **sequential_download** Boolean (default = false) Enable sequential download by default when adding torrents.
 

--- a/libtransmission/inout.cc
+++ b/libtransmission/inout.cc
@@ -86,8 +86,7 @@ bool write_entire_buf(tr_sys_file_t const fd, uint64_t file_offset, std::span<ui
 
     // does the file exist?
     auto const file_size = tor.file_size(file_index);
-    auto const prealloc = writable && tor.file_is_wanted(file_index) ? session.preallocationMode() :
-                                                                       tr_open_files::Preallocation::None;
+    auto const prealloc = writable && tor.file_is_wanted(file_index) ? session.preallocationMode() : tr_preallocation::None;
     if (auto const found = tor.find_file(file_index); found)
     {
         return open_files.get(tor_id, file_index, writable, found->filename(), prealloc, file_size);

--- a/libtransmission/net.cc
+++ b/libtransmission/net.cc
@@ -431,6 +431,16 @@ namespace is_valid_for_peers_helpers
 
 // --- tr_port
 
+tr_port tr_port::from_network(uint16_t const nport) noexcept
+{
+    return tr_port{ ntohs(nport) };
+}
+
+uint16_t tr_port::network() const noexcept
+{
+    return htons(hport_);
+}
+
 std::pair<tr_port, std::byte const*> tr_port::from_compact(std::byte const* compact) noexcept
 {
     static auto constexpr PortLen = size_t{ 2 };

--- a/libtransmission/net.h
+++ b/libtransmission/net.h
@@ -21,7 +21,6 @@
 #ifdef _WIN32
 #include <ws2tcpip.h>
 #else
-#include <arpa/inet.h>
 #include <cerrno>
 #include <sys/socket.h>
 #include <netinet/in.h>
@@ -65,74 +64,6 @@ using tr_socket_t = int;
 #include "libtransmission/tr-assert.h"
 #include "libtransmission/types.h"
 #include "libtransmission/utils.h" // for tr_compare_3way()
-
-/**
- * Literally just a port number.
- *
- * Exists so that you never have to wonder what byte order a port variable is in.
- */
-class tr_port
-{
-public:
-    tr_port() noexcept = default;
-
-    [[nodiscard]] constexpr static tr_port from_host(uint16_t hport) noexcept
-    {
-        return tr_port{ hport };
-    }
-
-    [[nodiscard]] static tr_port from_network(uint16_t nport) noexcept
-    {
-        return tr_port{ ntohs(nport) };
-    }
-
-    [[nodiscard]] constexpr uint16_t host() const noexcept
-    {
-        return hport_;
-    }
-
-    [[nodiscard]] uint16_t network() const noexcept
-    {
-        return htons(hport_);
-    }
-
-    constexpr void set_host(uint16_t hport) noexcept
-    {
-        hport_ = hport;
-    }
-
-    [[nodiscard]] static std::pair<tr_port, std::byte const*> from_compact(std::byte const* compact) noexcept;
-
-    [[nodiscard]] constexpr auto operator<=>(tr_port const& that) const noexcept
-    {
-        return hport_ <=> that.hport_;
-    }
-
-    [[nodiscard]] constexpr auto operator==(tr_port const& that) const noexcept
-    {
-        return (*this <=> that) == 0;
-    }
-
-    [[nodiscard]] constexpr auto empty() const noexcept
-    {
-        return hport_ == 0;
-    }
-
-    constexpr void clear() noexcept
-    {
-        hport_ = 0;
-    }
-
-    static auto constexpr CompactPortBytes = 2U;
-
-private:
-    explicit constexpr tr_port(uint16_t hport) noexcept
-        : hport_{ hport }
-    {
-    }
-
-    uint16_t hport_ = 0;
-};
 
 enum tr_address_type : uint8_t
 {

--- a/libtransmission/net.h
+++ b/libtransmission/net.h
@@ -533,27 +533,6 @@ void tr_net_close_socket(tr_socket_t fd);
 
 // --- TOS / DSCP
 
-// A serializer-friendly wrapper around the DiffServ int value
-class tr_diffserv_t
-{
-public:
-    constexpr tr_diffserv_t() = default;
-
-    constexpr explicit tr_diffserv_t(int value)
-        : value_{ value }
-    {
-    }
-
-    // NOLINTNEXTLINE(google-explicit-constructor)
-    [[nodiscard]] constexpr operator int() const noexcept
-    {
-        return value_;
-    }
-
-private:
-    int value_ = 0x04;
-};
-
 // set the IPTOS_ value for the specified socket
 void tr_netSetDiffServ(tr_socket_t sock, int tos, tr_address_type type);
 

--- a/libtransmission/open-files.cc
+++ b/libtransmission/open-files.cc
@@ -143,7 +143,7 @@ std::optional<tr_sys_file_t> tr_open_files::get(
     tr_file_index_t file_num,
     bool writable,
     std::string_view const filename,
-    Preallocation allocation,
+    tr_preallocation allocation,
     uint64_t file_size)
 {
     // is there already an entry
@@ -196,17 +196,17 @@ std::optional<tr_sys_file_t> tr_open_files::get(
         return {};
     }
 
-    if (writable && !already_existed && allocation != Preallocation::None)
+    if (writable && !already_existed && allocation != tr_preallocation::None)
     {
         bool success = false;
         char const* type = nullptr;
 
-        if (allocation == Preallocation::Full)
+        if (allocation == tr_preallocation::Full)
         {
             success = preallocate_file_full(fd, file_size, &error);
             type = "full";
         }
-        else if (allocation == Preallocation::Sparse)
+        else if (allocation == tr_preallocation::Sparse)
         {
             success = preallocate_file_sparse(fd, file_size, &error);
             type = "sparse";

--- a/libtransmission/open-files.h
+++ b/libtransmission/open-files.h
@@ -23,13 +23,6 @@
 class tr_open_files
 {
 public:
-    enum class Preallocation : uint8_t
-    {
-        None,
-        Sparse,
-        Full
-    };
-
     [[nodiscard]] std::optional<tr_sys_file_t> get(tr_torrent_id_t tor_id, tr_file_index_t file_num, bool writable);
 
     [[nodiscard]] std::optional<tr_sys_file_t> get(
@@ -37,7 +30,7 @@ public:
         tr_file_index_t file_num,
         bool writable,
         std::string_view filename,
-        Preallocation allocation,
+        tr_preallocation allocation,
         uint64_t file_size);
 
     void close_all();

--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -144,7 +144,7 @@ std::shared_ptr<tr_peerIo> tr_peerIo::new_outgoing(
 
     // N.B. This array needs to be kept in the same order as
     // the tr_preferred_transport enum.
-    auto const get_socket = std::array<std::function<tr_peer_socket()>, TR_NUM_PREFERRED_TRANSPORT>{
+    auto const get_socket = std::array<std::function<tr_peer_socket()>, PreferredTransportCount>{
         [&]() -> tr_peer_socket
         {
 #ifdef WITH_UTP
@@ -172,7 +172,8 @@ std::shared_ptr<tr_peerIo> tr_peerIo::new_outgoing(
 
     for (auto const& transport : session->preferred_transports())
     {
-        if (auto sock = get_socket[transport](); sock.is_valid())
+        auto const transport_index = static_cast<std::underlying_type_t<tr_preferred_transport>>(transport);
+        if (auto sock = get_socket[transport_index](); sock.is_valid())
         {
             return tr_peerIo::create(session, std::move(sock), parent, &info_hash, false, client_is_seed);
         }

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -50,13 +50,6 @@ enum class ReadState : uint8_t
     Err
 };
 
-enum tr_preferred_transport : uint8_t
-{
-    TR_PREFER_UTP,
-    TR_PREFER_TCP,
-    TR_NUM_PREFERRED_TRANSPORT
-};
-
 class tr_peerIo final : public std::enable_shared_from_this<tr_peerIo>
 {
     using DH = tr_message_stream_encryption::DH;

--- a/libtransmission/serializer.cc
+++ b/libtransmission/serializer.cc
@@ -25,7 +25,6 @@
 #include "libtransmission/log.h" // for tr_log_level
 #include "libtransmission/net.h" // for tr_port
 #include "libtransmission/open-files.h" // for tr_open_files::Preallocation
-#include "libtransmission/peer-io.h" // tr_preferred_transport
 #include "libtransmission/peer-mgr.h" // tr_pex
 #include "libtransmission/serializer.h"
 #include "libtransmission/string-utils.h"
@@ -343,30 +342,28 @@ tr_variant from_preallocation_mode(tr_open_files::Preallocation const& val)
 
 // ---
 
-auto constexpr PreferredTransportKeys = LookupTable<tr_preferred_transport, TR_NUM_PREFERRED_TRANSPORT>{ {
-    { "utp", TR_PREFER_UTP },
-    { "tcp", TR_PREFER_TCP },
+auto constexpr PreferredTransportKeys = LookupTable<tr_preferred_transport, PreferredTransportCount>{ {
+    { "utp", tr_preferred_transport::UTP },
+    { "tcp", tr_preferred_transport::TCP },
 } };
 
-bool to_preferred_transport(
-    tr_variant const& src,
-    small::max_size_vector<tr_preferred_transport, TR_NUM_PREFERRED_TRANSPORT>* tgt)
+bool to_preferred_transport(tr_variant const& src, small::max_size_vector<tr_preferred_transport, PreferredTransportCount>* tgt)
 {
-    static auto constexpr LoadSingle = [](tr_variant const& var)
+    static auto constexpr LoadSingle = [](tr_variant const& var) -> std::optional<tr_preferred_transport>
     {
         auto tmp = tr_preferred_transport{};
-        return to_enum_or_integral_with_lookup(PreferredTransportKeys, var, &tmp) ? tmp : TR_NUM_PREFERRED_TRANSPORT;
+        return to_enum_or_integral_with_lookup(PreferredTransportKeys, var, &tmp) ? std::make_optional(tmp) : std::nullopt;
     };
 
     if (auto* const l = src.get_if<tr_variant::Vector>(); l != nullptr)
     {
-        auto tmp = small::max_size_unordered_set<tr_preferred_transport, TR_NUM_PREFERRED_TRANSPORT>{};
+        auto tmp = small::max_size_unordered_set<tr_preferred_transport, PreferredTransportCount>{};
         tmp.reserve(tmp.max_size());
 
         for (size_t i = 0, n = std::min(std::size(*l), tmp.max_size()); i < n; ++i)
         {
             auto const value = LoadSingle((*l)[i]);
-            if (value >= TR_NUM_PREFERRED_TRANSPORT || !tmp.insert(value).second)
+            if (!value || !tmp.insert(*value).second)
             {
                 return false;
             }
@@ -379,20 +376,20 @@ bool to_preferred_transport(
     }
 
     auto const preferred = LoadSingle(src);
-    if (preferred >= TR_NUM_PREFERRED_TRANSPORT)
+    if (!preferred)
     {
         return false;
     }
 
-    tgt->assign(1U, preferred);
+    tgt->assign(1U, *preferred);
     return true;
 }
 
-tr_variant from_preferred_transport(small::max_size_vector<tr_preferred_transport, TR_NUM_PREFERRED_TRANSPORT> const& val)
+tr_variant from_preferred_transport(small::max_size_vector<tr_preferred_transport, PreferredTransportCount> const& val)
 {
     static auto constexpr SaveSingle = [](tr_preferred_transport const ele) -> tr_variant
     {
-        return from_enum_or_integral_with_lookup(PreferredTransportKeys, ele);
+        return static_cast<int64_t>(ele);
     };
 
     auto ret = tr_variant::Vector{};

--- a/libtransmission/serializer.cc
+++ b/libtransmission/serializer.cc
@@ -24,7 +24,6 @@
 
 #include "libtransmission/log.h" // for tr_log_level
 #include "libtransmission/net.h" // for tr_port
-#include "libtransmission/open-files.h" // for tr_open_files::Preallocation
 #include "libtransmission/peer-mgr.h" // tr_pex
 #include "libtransmission/serializer.h"
 #include "libtransmission/string-utils.h"
@@ -322,20 +321,20 @@ tr_variant from_port(tr_port const& val)
 
 // ---
 
-auto constexpr PreallocationKeys = LookupTable<tr_open_files::Preallocation, 5U>{ {
-    { "off", tr_open_files::Preallocation::None },
-    { "none", tr_open_files::Preallocation::None },
-    { "fast", tr_open_files::Preallocation::Sparse },
-    { "sparse", tr_open_files::Preallocation::Sparse },
-    { "full", tr_open_files::Preallocation::Full },
+auto constexpr PreallocationKeys = LookupTable<tr_preallocation, 5U>{ {
+    { "off", tr_preallocation::None },
+    { "none", tr_preallocation::None },
+    { "fast", tr_preallocation::Sparse },
+    { "sparse", tr_preallocation::Sparse },
+    { "full", tr_preallocation::Full },
 } };
 
-bool to_preallocation_mode(tr_variant const& src, tr_open_files::Preallocation* tgt)
+bool to_preallocation_mode(tr_variant const& src, tr_preallocation* tgt)
 {
     return to_enum_or_integral_with_lookup(PreallocationKeys, src, tgt);
 }
 
-tr_variant from_preallocation_mode(tr_open_files::Preallocation const& val)
+tr_variant from_preallocation_mode(tr_preallocation const& val)
 {
     return static_cast<int64_t>(val);
 }

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -933,10 +933,10 @@ void tr_session::Settings::fixup_from_preferred_transports()
     {
         switch (transport)
         {
-        case TR_PREFER_UTP:
+        case tr_preferred_transport::UTP:
             utp_enabled = true;
             break;
-        case TR_PREFER_TCP:
+        case tr_preferred_transport::TCP:
             tcp_enabled = true;
             break;
         default:
@@ -949,24 +949,24 @@ void tr_session::Settings::fixup_to_preferred_transports()
 {
     if (!utp_enabled)
     {
-        auto const [first, last] = std::ranges::remove(preferred_transports, TR_PREFER_UTP);
+        auto const [first, last] = std::ranges::remove(preferred_transports, tr_preferred_transport::UTP);
         preferred_transports.erase(first, last);
     }
-    else if (std::ranges::find(preferred_transports, TR_PREFER_UTP) == std::ranges::end(preferred_transports))
+    else if (std::ranges::find(preferred_transports, tr_preferred_transport::UTP) == std::ranges::end(preferred_transports))
     {
         TR_ASSERT(std::size(preferred_transports) < preferred_transports.max_size());
-        preferred_transports.emplace(std::begin(preferred_transports), TR_PREFER_UTP);
+        preferred_transports.emplace(std::begin(preferred_transports), tr_preferred_transport::UTP);
     }
 
     if (!tcp_enabled)
     {
-        auto const [first, last] = std::ranges::remove(preferred_transports, TR_PREFER_TCP);
+        auto const [first, last] = std::ranges::remove(preferred_transports, tr_preferred_transport::TCP);
         preferred_transports.erase(first, last);
     }
-    else if (std::ranges::find(preferred_transports, TR_PREFER_TCP) == std::ranges::end(preferred_transports))
+    else if (std::ranges::find(preferred_transports, tr_preferred_transport::TCP) == std::ranges::end(preferred_transports))
     {
         TR_ASSERT(std::size(preferred_transports) < preferred_transports.max_size());
-        preferred_transports.emplace_back(TR_PREFER_TCP);
+        preferred_transports.emplace_back(tr_preferred_transport::TCP);
     }
 }
 

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -493,7 +493,7 @@ public:
         tr_encryption_mode encryption_mode = TR_ENCRYPTION_PREFERRED;
         tr_log_level log_level = TR_LOG_INFO;
         tr_mode_t umask = 022;
-        tr_open_files::Preallocation preallocation_mode = tr_open_files::Preallocation::Sparse;
+        tr_preallocation preallocation_mode = tr_preallocation::Sparse;
         tr_port peer_port_random_high = tr_port::from_host(65535);
         tr_port peer_port_random_low = tr_port::from_host(49152);
         tr_port peer_port = tr_port::from_host(TrDefaultPeerPort);

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -48,7 +48,7 @@
 #include "libtransmission/log.h" // for tr_log_level
 #include "libtransmission/net.h" // for tr_port, tr_tos_t
 #include "libtransmission/open-files.h"
-#include "libtransmission/peer-io.h" // tr_preferred_transport
+#include "libtransmission/peer-io.h"
 #include "libtransmission/platform.h"
 #include "libtransmission/port-forwarding.h"
 #include "libtransmission/quark.h"
@@ -471,9 +471,9 @@ public:
         size_t speed_limit_down = 100U;
         size_t speed_limit_up = 100U;
         size_t upload_slots_per_torrent = 8U;
-        small::max_size_vector<tr_preferred_transport, TR_NUM_PREFERRED_TRANSPORT> preferred_transports = {
-            TR_PREFER_UTP,
-            TR_PREFER_TCP,
+        small::max_size_vector<tr_preferred_transport, PreferredTransportCount> preferred_transports = {
+            tr_preferred_transport::UTP,
+            tr_preferred_transport::TCP,
         };
         std::vector<std::string> ip_endpoint_ipv4 = { "https://ip4.transmissionbt.com/" };
         std::vector<std::string> ip_endpoint_ipv6 = { "https://ip6.transmissionbt.com/" };

--- a/libtransmission/types.h
+++ b/libtransmission/types.h
@@ -129,6 +129,27 @@ private:
     uint16_t hport_ = 0;
 };
 
+// A serializer-friendly wrapper around the DiffServ int value
+class tr_diffserv_t
+{
+public:
+    constexpr tr_diffserv_t() = default;
+
+    constexpr explicit tr_diffserv_t(int value)
+        : value_{ value }
+    {
+    }
+
+    // NOLINTNEXTLINE(google-explicit-constructor)
+    [[nodiscard]] constexpr operator int() const noexcept
+    {
+        return value_;
+    }
+
+private:
+    int value_ = 0x04;
+};
+
 using tr_tracker_id_t = uint32_t;
 
 using tr_tracker_tier_t = uint32_t;

--- a/libtransmission/types.h
+++ b/libtransmission/types.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <array>
+#include <compare>
 #include <cstddef> // size_t, std::byte
 #include <cstdint> // uint16_t, uint32_t, uint64_t
 #include <ctime> // time_t
@@ -13,6 +14,7 @@
 #include <optional>
 #include <string>
 #include <string_view>
+#include <utility>
 
 #include "libtransmission/values.h"
 
@@ -61,6 +63,63 @@ using tr_sha1_digest_t = std::array<std::byte, 20>;
 using tr_sha256_digest_t = std::array<std::byte, 32>;
 
 using tr_torrent_id_t = int;
+
+class tr_port
+{
+public:
+    tr_port() noexcept = default;
+
+    [[nodiscard]] constexpr static tr_port from_host(uint16_t hport) noexcept
+    {
+        return tr_port{ hport };
+    }
+
+    [[nodiscard]] static tr_port from_network(uint16_t nport) noexcept;
+
+    [[nodiscard]] constexpr uint16_t host() const noexcept
+    {
+        return hport_;
+    }
+
+    [[nodiscard]] uint16_t network() const noexcept;
+
+    constexpr void set_host(uint16_t hport) noexcept
+    {
+        hport_ = hport;
+    }
+
+    [[nodiscard]] static std::pair<tr_port, std::byte const*> from_compact(std::byte const* compact) noexcept;
+
+    [[nodiscard]] constexpr auto operator<=>(tr_port const& that) const noexcept
+    {
+        return hport_ <=> that.hport_;
+    }
+
+    [[nodiscard]] constexpr auto operator==(tr_port const& that) const noexcept
+    {
+        return (*this <=> that) == 0;
+    }
+
+    [[nodiscard]] constexpr auto empty() const noexcept
+    {
+        return hport_ == 0;
+    }
+
+    constexpr void clear() noexcept
+    {
+        hport_ = 0;
+    }
+
+    static auto constexpr CompactPortBytes = 2U;
+
+private:
+    explicit constexpr tr_port(uint16_t hport) noexcept
+        : hport_{ hport }
+    {
+    }
+
+    uint16_t hport_ = 0;
+};
 
 using tr_tracker_id_t = uint32_t;
 

--- a/libtransmission/types.h
+++ b/libtransmission/types.h
@@ -72,6 +72,13 @@ enum class tr_preferred_transport : uint8_t
 
 inline auto constexpr PreferredTransportCount = 2U;
 
+enum class tr_preallocation : uint8_t
+{
+    None,
+    Sparse,
+    Full,
+};
+
 class tr_port
 {
 public:

--- a/libtransmission/types.h
+++ b/libtransmission/types.h
@@ -64,6 +64,14 @@ using tr_sha256_digest_t = std::array<std::byte, 32>;
 
 using tr_torrent_id_t = int;
 
+enum class tr_preferred_transport : uint8_t
+{
+    UTP,
+    TCP,
+};
+
+inline auto constexpr PreferredTransportCount = 2U;
+
 class tr_port
 {
 public:

--- a/tests/libtransmission/open-files-test.cc
+++ b/tests/libtransmission/open-files-test.cc
@@ -27,7 +27,7 @@ using namespace std::literals;
 
 using OpenFilesTest = tr::test::SessionTest;
 
-static auto constexpr PreallocateFull = tr_open_files::Preallocation::Full;
+static auto constexpr PreallocateFull = tr_preallocation::Full;
 
 TEST_F(OpenFilesTest, getCachedFailsIfNotCached)
 {

--- a/tests/libtransmission/settings-test.cc
+++ b/tests/libtransmission/settings-test.cc
@@ -462,9 +462,9 @@ TEST_F(SettingsTest, canSaveVerify)
 TEST_F(SettingsTest, canLoadPreferredTransport)
 {
     static auto constexpr Key = TR_KEY_preferred_transports;
-    auto const expected_value = small::max_size_vector<tr_preferred_transport, TR_NUM_PREFERRED_TRANSPORT>{
-        TR_PREFER_TCP,
-        TR_PREFER_UTP,
+    auto const expected_value = small::max_size_vector<tr_preferred_transport, PreferredTransportCount>{
+        tr_preferred_transport::TCP,
+        tr_preferred_transport::UTP,
     };
     auto expected_value_vec = tr_variant::Vector{};
     expected_value_vec.reserve(std::size(expected_value));
@@ -482,8 +482,8 @@ TEST_F(SettingsTest, canLoadPreferredTransport)
     settings->load(tr_variant{ std::move(map) });
     EXPECT_EQ(expected_value, settings->preferred_transports);
 
-    auto const expected_value_single = small::max_size_vector<tr_preferred_transport, TR_NUM_PREFERRED_TRANSPORT>{
-        TR_PREFER_TCP
+    auto const expected_value_single = small::max_size_vector<tr_preferred_transport, PreferredTransportCount>{
+        tr_preferred_transport::TCP
     };
 
     expected_value_vec = tr_variant::Vector{};
@@ -508,10 +508,13 @@ TEST_F(SettingsTest, canLoadPreferredTransport)
 TEST_F(SettingsTest, canSavePreferredTransport)
 {
     static auto constexpr Key = TR_KEY_preferred_transports;
-    static auto constexpr ExpectedValue = std::array<std::string_view, TR_NUM_PREFERRED_TRANSPORT>{ "tcp"sv, "utp"sv };
-    auto const setting_value = small::max_size_vector<tr_preferred_transport, TR_NUM_PREFERRED_TRANSPORT>{
-        TR_PREFER_TCP,
-        TR_PREFER_UTP,
+    static auto constexpr ExpectedValue = std::array<int64_t, PreferredTransportCount>{
+        static_cast<int64_t>(tr_preferred_transport::TCP),
+        static_cast<int64_t>(tr_preferred_transport::UTP),
+    };
+    auto const setting_value = small::max_size_vector<tr_preferred_transport, PreferredTransportCount>{
+        tr_preferred_transport::TCP,
+        tr_preferred_transport::UTP,
     };
 
     auto settings = tr_session::Settings{};
@@ -527,8 +530,8 @@ TEST_F(SettingsTest, canSavePreferredTransport)
     {
         auto const& expected = ExpectedValue[i];
         auto const& actual = (*l)[i];
-        ASSERT_TRUE(actual.index() == tr_variant::StringIndex || actual.index() == tr_variant::StringViewIndex);
-        EXPECT_EQ(expected, actual.value_if<std::string_view>());
+        ASSERT_TRUE(actual.holds_alternative<int64_t>());
+        EXPECT_EQ(expected, actual.value_if<int64_t>());
     }
 }
 
@@ -537,43 +540,43 @@ TEST_F(SettingsTest, fixupToPreferredTransports)
     auto settings = tr_session::Settings{};
 
     // control case
-    auto expected_value = decltype(settings.preferred_transports){ TR_PREFER_UTP, TR_PREFER_TCP };
+    auto expected_value = decltype(settings.preferred_transports){ tr_preferred_transport::UTP, tr_preferred_transport::TCP };
     settings.utp_enabled = true;
     settings.tcp_enabled = true;
     settings.fixup_to_preferred_transports();
     EXPECT_EQ(expected_value, settings.preferred_transports);
 
     // preserves order if no insert is needed
-    settings.preferred_transports = { TR_PREFER_TCP, TR_PREFER_UTP };
-    expected_value = { TR_PREFER_TCP, TR_PREFER_UTP };
+    settings.preferred_transports = { tr_preferred_transport::TCP, tr_preferred_transport::UTP };
+    expected_value = { tr_preferred_transport::TCP, tr_preferred_transport::UTP };
     settings.utp_enabled = true;
     settings.tcp_enabled = true;
     settings.fixup_to_preferred_transports();
     EXPECT_EQ(expected_value, settings.preferred_transports);
 
     // removes utp if needed
-    expected_value = { TR_PREFER_TCP };
+    expected_value = { tr_preferred_transport::TCP };
     settings.utp_enabled = false;
     settings.tcp_enabled = true;
     settings.fixup_to_preferred_transports();
     EXPECT_EQ(expected_value, settings.preferred_transports);
 
     // inserts UTP in front of TCP
-    expected_value = { TR_PREFER_UTP, TR_PREFER_TCP };
+    expected_value = { tr_preferred_transport::UTP, tr_preferred_transport::TCP };
     settings.utp_enabled = true;
     settings.tcp_enabled = true;
     settings.fixup_to_preferred_transports();
     EXPECT_EQ(expected_value, settings.preferred_transports);
 
     // removes tcp if needed
-    expected_value = { TR_PREFER_UTP };
+    expected_value = { tr_preferred_transport::UTP };
     settings.utp_enabled = true;
     settings.tcp_enabled = false;
     settings.fixup_to_preferred_transports();
     EXPECT_EQ(expected_value, settings.preferred_transports);
 
     // inserts TCP behind UTP
-    expected_value = { TR_PREFER_UTP, TR_PREFER_TCP };
+    expected_value = { tr_preferred_transport::UTP, tr_preferred_transport::TCP };
     settings.utp_enabled = true;
     settings.tcp_enabled = true;
     settings.fixup_to_preferred_transports();
@@ -588,12 +591,12 @@ TEST_F(SettingsTest, fixupFromPreferredTransports)
     EXPECT_TRUE(settings.utp_enabled);
     EXPECT_TRUE(settings.tcp_enabled);
 
-    settings.preferred_transports = { TR_PREFER_UTP };
+    settings.preferred_transports = { tr_preferred_transport::UTP };
     settings.fixup_from_preferred_transports();
     EXPECT_TRUE(settings.utp_enabled);
     EXPECT_FALSE(settings.tcp_enabled);
 
-    settings.preferred_transports = { TR_PREFER_TCP };
+    settings.preferred_transports = { tr_preferred_transport::TCP };
     settings.fixup_from_preferred_transports();
     EXPECT_FALSE(settings.utp_enabled);
     EXPECT_TRUE(settings.tcp_enabled);

--- a/tests/libtransmission/settings-test.cc
+++ b/tests/libtransmission/settings-test.cc
@@ -252,7 +252,7 @@ TEST_F(SettingsTest, canLoadPreallocation)
 
     auto settings = std::make_unique<tr_session::Settings>();
     auto const default_value = settings->preallocation_mode;
-    auto constexpr ExpectedValue = tr_open_files::Preallocation::Full;
+    auto constexpr ExpectedValue = tr_preallocation::Full;
     ASSERT_NE(ExpectedValue, default_value);
 
     auto map = tr_variant::Map{ 1U };
@@ -273,7 +273,7 @@ TEST_F(SettingsTest, canSavePreallocation)
 
     auto settings = tr_session::Settings{};
     auto const default_value = settings.preallocation_mode;
-    auto constexpr ExpectedValue = tr_open_files::Preallocation::Full;
+    auto constexpr ExpectedValue = tr_preallocation::Full;
     ASSERT_NE(ExpectedValue, default_value);
 
     settings.preallocation_mode = ExpectedValue;


### PR DESCRIPTION
Part 1 in a series to refactor qt Preferences. I'm splitting this work into a series so there's not a huge incomprehensible PR.

This PR does some lightweight prework: it moves some libtransmission types into `libtransmission/types.h` to make them public. Previously, these were all unreachable with the `#error only libtransmission should include this header" guard.

- `tr_diffserv_t`
- `tr_port`
- `tr_preallocation`
- `tr_preferred_transport`

Rationale: a followup PR is going to move the alt-speed settings, session settings, and rpc-server settings into a new public header. All the types used in that header need also to be public.