### PR TITLE
refactor: add getters, setters to serializer module

### DIFF
--- a/libtransmission/serializer.h
+++ b/libtransmission/serializer.h
@@ -5,7 +5,9 @@
 
 #pragma once
 
+#include <cmath>
 #include <array>
+#include <concepts>
 #include <cstddef>
 #include <iterator>
 #include <optional>
@@ -27,6 +29,19 @@ namespace tr::serializer
 // Example uses: (de)serializing std::vector<T>, QStringList, small::set<T>
 namespace detail
 {
+
+template<std::floating_point T>
+[[nodiscard]] constexpr bool values_differ(T lhs, T rhs) noexcept
+{
+    return std::isunordered(lhs, rhs) || std::isless(lhs, rhs) || std::isgreater(lhs, rhs);
+}
+
+template<typename T>
+    requires(!std::floating_point<T>)
+[[nodiscard]] constexpr bool values_differ(T const& lhs, T const& rhs)
+{
+    return lhs != rhs;
+}
 
 // NOLINTBEGIN(readability-identifier-naming)
 // use std-style naming for these traits
@@ -246,6 +261,11 @@ struct Field;
 template<typename Owner, typename T, T Owner::* MemberPtr, typename Key>
 struct Field<MemberPtr, Key>
 {
+    using owner_type = Owner;
+    using value_type = T;
+    using key_type = Key;
+    static constexpr auto MemberPointer = MemberPtr;
+
     Key const key;
 
     explicit constexpr Field(Key key_in) noexcept
@@ -270,6 +290,194 @@ struct Field<MemberPtr, Key>
         map.try_emplace(key, Converters::serialize(static_cast<Owner const*>(derived)->*MemberPtr));
     }
 };
+
+namespace detail
+{
+
+// NOLINTBEGIN(readability-identifier-naming)
+// use std-style naming for these traits
+
+template<typename T>
+inline constexpr bool is_field_v = false;
+
+template<auto MemberPtr, typename Key>
+inline constexpr bool is_field_v<Field<MemberPtr, Key>> = true;
+
+template<typename Tuple, std::size_t... I>
+consteval bool is_fields_tuple(std::index_sequence<I...> /*indices*/)
+{
+    return (is_field_v<std::tuple_element_t<I, Tuple>> && ...);
+}
+
+template<typename Tuple>
+inline constexpr bool is_fields_tuple_v = is_fields_tuple<Tuple>(std::make_index_sequence<std::tuple_size_v<Tuple>>{});
+
+// NOLINTEND(readability-identifier-naming)
+
+template<typename S, typename T, tr_quark Key, std::size_t... I>
+consteval std::size_t field_index(std::index_sequence<I...> /*indices*/)
+{
+    using Fields = std::remove_cvref_t<decltype(S::Fields)>;
+    constexpr auto Count = std::tuple_size_v<Fields>;
+    auto idx = Count;
+
+    ((std::get<I>(S::Fields).key == Key && std::is_same_v<T, typename std::tuple_element_t<I, Fields>::value_type> ? idx = I :
+                                                                                                                     0),
+     ...);
+
+    return idx;
+}
+
+} // namespace detail
+
+template<typename T>
+concept Serializable = requires {
+    { std::tuple_size_v<std::remove_cvref_t<decltype(T::Fields)>> } -> std::convertible_to<std::size_t>;
+} && detail::is_fields_tuple_v<std::remove_cvref_t<decltype(T::Fields)>>;
+
+template<Serializable S>
+[[nodiscard]] std::optional<tr_variant> to_variant(S const& src, tr_quark key);
+
+template<typename T, Serializable S>
+[[nodiscard]] std::optional<T> get(S const& src, tr_quark key)
+{
+    if (auto value = to_variant(src, key))
+    {
+        return to_value<T>(*value);
+    }
+
+    return {};
+}
+
+template<typename T, tr_quark Key, Serializable S>
+[[nodiscard]] constexpr T get(S const& src)
+{
+    using Fields = std::remove_cvref_t<decltype(S::Fields)>;
+    constexpr auto Count = std::tuple_size_v<Fields>;
+    constexpr auto Index = detail::field_index<S, T, Key>(std::make_index_sequence<Count>{});
+
+    static_assert(Index < Count, "No field with matching tr_quark and value type in Serializable::Fields");
+
+    using FieldType = std::tuple_element_t<Index, Fields>;
+    static_assert(std::is_base_of_v<typename FieldType::owner_type, S>);
+
+    return src.*(FieldType::MemberPointer);
+}
+
+template<typename T, tr_quark Key, Serializable S>
+constexpr bool set(S& tgt, T val)
+{
+    using Fields = std::remove_cvref_t<decltype(S::Fields)>;
+    constexpr auto Count = std::tuple_size_v<Fields>;
+    constexpr auto Index = detail::field_index<S, T, Key>(std::make_index_sequence<Count>{});
+
+    static_assert(Index < Count, "No field with matching tr_quark and value type in Serializable::Fields");
+
+    using FieldType = std::tuple_element_t<Index, Fields>;
+    static_assert(std::is_base_of_v<typename FieldType::owner_type, S>);
+
+    auto& target = tgt.*(FieldType::MemberPointer);
+    if (target == val)
+    {
+        return false;
+    }
+
+    target = std::move(val);
+    return true;
+}
+
+template<Serializable S>
+[[nodiscard]] std::optional<tr_variant> to_variant(S const& src, tr_quark key)
+{
+    auto result = std::optional<tr_variant>{};
+    auto try_field = [&](auto const& field)
+    {
+        if (result || field.key != key)
+        {
+            return;
+        }
+
+        auto map = tr_variant::Map{ 1U };
+        field.save(&src, map);
+
+        if (auto const iter = map.find(key); iter != std::end(map))
+        {
+            result = iter->second.clone();
+        }
+    };
+
+    std::apply([&](auto const&... field) { (try_field(field), ...); }, S::Fields);
+    return result;
+}
+
+template<Serializable S>
+bool set_from_variant(S& tgt, tr_quark key, tr_variant const& value)
+{
+    auto found = false;
+    auto changed = false;
+    auto try_field = [&](auto const& field)
+    {
+        if (found || field.key != key)
+        {
+            return;
+        }
+
+        found = true;
+
+        using FieldType = std::remove_cvref_t<decltype(field)>;
+        if (auto value_cast = to_value<typename FieldType::value_type>(value))
+        {
+            auto& target = tgt.*(FieldType::MemberPointer);
+            if (detail::values_differ(target, *value_cast))
+            {
+                target = std::move(*value_cast);
+                changed = true;
+            }
+        }
+    };
+
+    std::apply([&](auto const&... field) { (try_field(field), ...); }, S::Fields);
+    return changed;
+}
+
+template<typename T, Serializable S>
+bool set(S& tgt, tr_quark key, T val)
+{
+    auto found = false;
+    auto type_ok = true;
+    auto changed = false;
+
+    auto try_field = [&](auto const& field)
+    {
+        if (found || field.key != key)
+        {
+            return;
+        }
+
+        found = true;
+        using FieldType = std::remove_cvref_t<decltype(field)>;
+        if constexpr (std::is_same_v<T, typename FieldType::value_type>)
+        {
+            auto& target = tgt.*(FieldType::MemberPointer);
+            if (target == val)
+            {
+                changed = false;
+            }
+            else
+            {
+                target = std::move(val);
+                changed = true;
+            }
+        }
+        else
+        {
+            type_ok = false;
+        }
+    };
+
+    std::apply([&](auto const&... field) { (try_field(field), ...); }, S::Fields);
+    return found && type_ok && changed;
+}
 
 /**
  * Load fields from a variant map into a target object.

--- a/tests/libtransmission/serializer-tests.cc
+++ b/tests/libtransmission/serializer-tests.cc
@@ -3,15 +3,19 @@
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.
 
+#include <cmath>
 #include <climits>
 #include <cstdint>
 #include <filesystem>
 #include <list>
 #include <mutex>
+#include <limits>
 #include <optional>
 #include <string>
 #include <string_view>
 #include <vector>
+
+#include <fmt/core.h>
 
 #include <libtransmission/net.h>
 #include <libtransmission/log.h>
@@ -403,8 +407,12 @@ TEST_F(SerializerTest, optionalRejectsWrongType)
 // ---
 
 using tr::serializer::Field;
+using tr::serializer::get;
 using tr::serializer::load;
 using tr::serializer::save;
+using tr::serializer::set;
+using tr::serializer::set_from_variant;
+using tr::serializer::to_variant;
 
 struct Endpoint
 {
@@ -428,14 +436,35 @@ struct Endpoint
     }
 };
 
+struct Simple
+{
+    int blocks = 0;
+    bool enabled = false;
+
+    static constexpr auto Fields = std::tuple{
+        Field<&Simple::blocks>{ TR_KEY_blocks },
+        Field<&Simple::enabled>{ TR_KEY_dht_enabled },
+    };
+};
+
+struct Floating
+{
+    double ratio = 0.0;
+
+    static constexpr auto Fields = std::tuple{
+        Field<&Floating::ratio>{ TR_KEY_ratio_limit },
+    };
+};
+
 TEST_F(SerializerTest, fieldSaveLoad)
 {
-    auto const expected = Endpoint{ .address = "localhost", .port = tr_port::from_host(51413) };
+    auto const expected = Endpoint{ .address = "localhost", .port = tr_port::from_host(TrDefaultPeerPort) };
 
     // Save to variant
-    auto constexpr Expected = R"({"address":"localhost","port":51413})"sv;
+    auto const expected_json = fmt::format(R"({{"address":"localhost","port":{}}})", TrDefaultPeerPort);
+    auto const expected_json_sv = std::string_view{ expected_json };
     auto const var = tr_variant{ save(expected, Endpoint::Fields) };
-    EXPECT_EQ(Expected, tr_variant_serde::json().compact().to_string(var));
+    EXPECT_EQ(expected_json_sv, tr_variant_serde::json().compact().to_string(var));
 
     // Load back into a new instance
     auto actual = Endpoint{};
@@ -464,6 +493,108 @@ TEST_F(SerializerTest, fieldLoadIgnoresNonMap)
 
     // Should remain unchanged
     EXPECT_EQ(original, endpoint);
+}
+
+TEST_F(SerializerTest, serializableGetByKey)
+{
+    auto const endpoint = Endpoint{ .address = "localhost", .port = tr_port::from_host(TrDefaultPeerPort) };
+
+    auto const addr = get<std::string>(endpoint, TR_KEY_address);
+    ASSERT_TRUE(addr.has_value());
+    EXPECT_EQ(*addr, "localhost");
+
+    auto const port = get<tr_port>(endpoint, TR_KEY_port);
+    ASSERT_TRUE(port.has_value());
+    EXPECT_EQ(*port, tr_port::from_host(TrDefaultPeerPort));
+
+    auto const missing = get<std::string>(endpoint, TR_KEY_comment);
+    EXPECT_FALSE(missing.has_value());
+
+    auto const wrong_type = get<int>(endpoint, TR_KEY_address);
+    EXPECT_FALSE(wrong_type.has_value());
+}
+
+TEST_F(SerializerTest, serializableSetByKey)
+{
+    auto endpoint = Endpoint{ .address = "localhost", .port = tr_port::from_host(TrDefaultPeerPort) };
+
+    EXPECT_TRUE(set(endpoint, TR_KEY_address, std::string{ "example.com" }));
+    EXPECT_EQ(endpoint.address, "example.com");
+
+    EXPECT_FALSE(set(endpoint, TR_KEY_address, std::string{ "example.com" }));
+
+    EXPECT_FALSE(set(endpoint, TR_KEY_comment, std::string{ "no field" }));
+
+    EXPECT_FALSE(set(endpoint, TR_KEY_address, 42));
+
+    EXPECT_TRUE(set(endpoint, TR_KEY_port, tr_port::from_host(1234)));
+    EXPECT_EQ(endpoint.port, tr_port::from_host(1234));
+}
+
+TEST_F(SerializerTest, serializableToVariantByKey)
+{
+    auto const endpoint = Endpoint{ .address = "localhost", .port = tr_port::from_host(TrDefaultPeerPort) };
+
+    auto const address = to_variant(endpoint, TR_KEY_address);
+    ASSERT_TRUE(address);
+    EXPECT_EQ("localhost"sv, address->value_if<std::string_view>().value_or(""sv));
+
+    auto const port = to_variant(endpoint, TR_KEY_port);
+    ASSERT_TRUE(port);
+    EXPECT_EQ(TrDefaultPeerPort, port->value_if<int64_t>().value_or(-1));
+
+    EXPECT_FALSE(to_variant(endpoint, TR_KEY_comment));
+}
+
+TEST_F(SerializerTest, serializableSetFromVariantByKey)
+{
+    auto endpoint = Endpoint{ .address = "localhost", .port = tr_port::from_host(TrDefaultPeerPort) };
+
+    EXPECT_TRUE(set_from_variant(endpoint, TR_KEY_address, tr_variant{ "example.com"sv }));
+    EXPECT_EQ("example.com", endpoint.address);
+    EXPECT_FALSE(set_from_variant(endpoint, TR_KEY_address, tr_variant{ "example.com"sv }));
+    EXPECT_FALSE(set_from_variant(endpoint, TR_KEY_address, tr_variant{ 123 }));
+    EXPECT_FALSE(set_from_variant(endpoint, TR_KEY_comment, tr_variant{ "unused"sv }));
+
+    EXPECT_TRUE(set_from_variant(endpoint, TR_KEY_port, tr_variant{ int64_t{ 1234 } }));
+    EXPECT_EQ(tr_port::from_host(1234), endpoint.port);
+}
+
+TEST_F(SerializerTest, serializableSetFromVariantUsesFloatingChangePolicy)
+{
+    auto floating = Floating{ .ratio = std::numeric_limits<double>::quiet_NaN() };
+
+    EXPECT_TRUE(set_from_variant(floating, TR_KEY_ratio_limit, tr_variant{ std::numeric_limits<double>::quiet_NaN() }));
+    EXPECT_TRUE(std::isnan(floating.ratio));
+
+    EXPECT_TRUE(set_from_variant(floating, TR_KEY_ratio_limit, tr_variant{ 2.5 }));
+    EXPECT_DOUBLE_EQ(2.5, floating.ratio);
+    EXPECT_FALSE(set_from_variant(floating, TR_KEY_ratio_limit, tr_variant{ 2.5 }));
+}
+
+TEST_F(SerializerTest, serializableConstexprGetSet)
+{
+    constexpr auto KBlocks = TR_KEY_blocks;
+    constexpr auto KEnabled = TR_KEY_dht_enabled;
+
+    constexpr auto CompileTimeGet = []
+    {
+        auto s = Simple{ .blocks = 5, .enabled = true };
+        return get<int, KBlocks>(s) == 5 && get<bool, KEnabled>(s);
+    }();
+
+    static_assert(CompileTimeGet);
+
+    constexpr auto CompileTimeSet = []
+    {
+        auto s = Simple{ .blocks = 1, .enabled = false };
+        auto changed1 = set<int, KBlocks>(s, 2);
+        auto changed2 = set<bool, KEnabled>(s, true);
+        auto changed3 = set<int, KBlocks>(s, 2);
+        return changed1 && changed2 && !changed3 && s.blocks == 2 && s.enabled;
+    }();
+
+    static_assert(CompileTimeSet);
 }
 
 } // namespace


### PR DESCRIPTION
Part 2 in a [series](https://github.com/transmission/transmission/pull/8811) to refactor qt Preferences. I'm splitting this work into a series so there's not a huge incomprehensible PR.

This PR continues the libtransmission prework: it adds getter / setter functionality to the serializer.