### PR TITLE
fix: shrink decompressed blocklist buffer to actual size before writing

### DIFF
--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -1609,6 +1609,11 @@ void onBlocklistFetched(tr_web::FetchResponse const& web_response)
             // couldn't decompress it; maybe we downloaded an uncompressed file
             content.assign(std::begin(body), std::end(body));
         }
+        else // LIBDEFLATE_SUCCESS
+        {
+            // shrink buffer to actual size
+            content.resize(actual_size);
+        }
         break;
     }
 

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -1598,21 +1598,25 @@ void onBlocklistFetched(tr_web::FetchResponse const& web_response)
             std::data(content),
             std::size(content),
             &actual_size);
-        if (decompress_result == LIBDEFLATE_INSUFFICIENT_SPACE)
+        switch (decompress_result)
         {
+        case LIBDEFLATE_INSUFFICIENT_SPACE:
             // need a bigger buffer
             content.resize(content.size() * 2);
             continue;
-        }
-        if (decompress_result == LIBDEFLATE_BAD_DATA)
-        {
+
+        case LIBDEFLATE_BAD_DATA:
             // couldn't decompress it; maybe we downloaded an uncompressed file
             content.assign(std::begin(body), std::end(body));
-        }
-        else // LIBDEFLATE_SUCCESS
-        {
+            break;
+
+        case LIBDEFLATE_SUCCESS:
             // shrink buffer to actual size
             content.resize(actual_size);
+            break;
+
+        default:
+            break;
         }
         break;
     }


### PR DESCRIPTION
After successfully decompressing the blocklist downloaded from the blocklist URL, shrink the buffer containing the decompressed data to the actual size.

This is so that we don't consume unnecessary disk space when writing the decompressed data to the blocklist "source file".

Notes: Stop appending redundant zeros to blocklist file downloaded from blocklist URL.