### PR TITLE
feat: accommodate empty but valid blocklists

### DIFF
--- a/libtransmission/blocklist.cc
+++ b/libtransmission/blocklist.cc
@@ -351,10 +351,11 @@ auto getFilenamesInDir(std::string_view folder)
 
 void Blocklists::Blocklist::ensureLoaded() const
 {
-    if (!std::empty(rules_))
+    if (rules_)
     {
         return;
     }
+    rules_.emplace();
 
     // get the file's size
     auto error = tr_error{};
@@ -416,17 +417,17 @@ void Blocklists::Blocklist::ensureLoaded() const
 
                 tr_logAddInfo(_("Rewriting old blocklist file format to new format"));
                 tr_sys_path_remove(bin_file_);
-                save(bin_file_, std::data(rules_), std::size(rules_));
+                save(bin_file_, std::data(*rules_), std::size(*rules_));
             }
         }
         return;
     }
 
     auto range = address_range_t{};
-    rules_.reserve((file_info->size - std::size(BinContentsPrefix)) / sizeof(address_range_t));
+    rules_->reserve((file_info->size - std::size(BinContentsPrefix)) / sizeof(address_range_t));
     while (in.read(reinterpret_cast<char*>(&range), sizeof(range)))
     {
-        rules_.emplace_back(range);
+        rules_->emplace_back(range);
     }
 
     tr_logAddInfo(
@@ -434,9 +435,9 @@ void Blocklists::Blocklist::ensureLoaded() const
             fmt::runtime(tr_ngettext(
                 "Blocklist '{path}' has {count} entry",
                 "Blocklist '{path}' has {count} entries",
-                std::size(rules_))),
+                std::size(*rules_))),
             fmt::arg("path", tr_sys_path_basename(bin_file_)),
-            fmt::arg("count", std::size(rules_))));
+            fmt::arg("count", std::size(*rules_))));
 }
 
 bool Blocklists::Blocklist::contains(tr_address const& addr) const
@@ -481,8 +482,8 @@ bool Blocklists::Blocklist::contains(tr_address const& addr) const
         }
     } Compare;
 
-    // NOLINTNEXTLINE(modernize-use-ranges)
-    return std::binary_search(std::begin(rules_), std::end(rules_), addr, Compare);
+    // NOLINTNEXTLINE(modernize-use-ranges, bugprone-unchecked-optional-access)
+    return std::binary_search(std::begin(*rules_), std::end(*rules_), addr, Compare);
 }
 
 std::optional<Blocklists::Blocklist> Blocklists::Blocklist::saveNew(

--- a/libtransmission/blocklist.cc
+++ b/libtransmission/blocklist.cc
@@ -260,7 +260,7 @@ std::optional<std::vector<address_range_t>> parseFile(std::string_view filename)
         ++line_number;
 
         // ignore empty lines
-        if (std::empty(line) || std::ranges::all_of(line, [](char c) { return std::isspace(c); }))
+        if (std::empty(line) || std::ranges::all_of(line, [](char c) { return std::isspace(static_cast<unsigned char>(c)); }))
         {
             continue;
         }

--- a/libtransmission/blocklist.cc
+++ b/libtransmission/blocklist.cc
@@ -455,6 +455,7 @@ bool Blocklists::Blocklist::contains(tr_address const& addr) const
     }
 
     ensureLoaded();
+    TR_ASSERT(rules_);
 
     static constexpr struct
     {
@@ -487,7 +488,7 @@ bool Blocklists::Blocklist::contains(tr_address const& addr) const
         }
     } Compare;
 
-    // NOLINTNEXTLINE(modernize-use-ranges, bugprone-unchecked-optional-access)
+    // NOLINTNEXTLINE(modernize-use-ranges)
     return std::binary_search(std::begin(*rules_), std::end(*rules_), addr, Compare);
 }
 

--- a/libtransmission/blocklist.cc
+++ b/libtransmission/blocklist.cc
@@ -234,11 +234,9 @@ std::optional<address_range_t> parseLine(std::string_view line)
 }
 } // namespace ParseHelpers
 
-auto parseFile(std::string_view filename)
+std::optional<std::vector<address_range_t>> parseFile(std::string_view filename)
 {
     using namespace ParseHelpers;
-
-    auto ranges = std::vector<address_range_t>{};
 
     auto in = std::ifstream{ tr_pathbuf{ filename } };
     if (!in.is_open())
@@ -249,14 +247,31 @@ auto parseFile(std::string_view filename)
                 fmt::arg("path", filename),
                 fmt::arg("error", tr_strerror(errno)),
                 fmt::arg("error_code", errno)));
-        return ranges;
+        return {};
     }
+
+    auto ranges = std::vector<address_range_t>{};
 
     auto line = std::string{};
     auto line_number = size_t{ 0U };
+    auto is_empty = true;
     while (std::getline(in, line))
     {
         ++line_number;
+
+        // ignore empty lines
+        if (std::empty(line) || std::ranges::all_of(line, [](char c) { return std::isspace(c); }))
+        {
+            continue;
+        }
+
+        // ignore comments
+        if (tr_strv_starts_with(line, "//"sv) || tr_strv_starts_with(line, "#"sv))
+        {
+            continue;
+        }
+
+        is_empty = false;
         if (auto range = parseLine(line); range && (range->first.type == range->second.type))
         {
             ranges.push_back(*range);
@@ -275,7 +290,7 @@ auto parseFile(std::string_view filename)
 
     if (std::empty(ranges))
     {
-        return ranges;
+        return is_empty ? std::make_optional(std::move(ranges)) : std::nullopt;
     }
 
     // safeguard against some joker swapping the begin & end ranges
@@ -395,9 +410,10 @@ void Blocklists::Blocklist::ensureLoaded() const
         if (auto const sz_src_file = std::string{ std::data(bin_file_), std::size(bin_file_) - std::size(BinFileSuffix) };
             tr_sys_path_exists(sz_src_file))
         {
-            rules_ = parseFile(sz_src_file);
-            if (!std::empty(rules_))
+            if (auto rules = parseFile(sz_src_file))
             {
+                rules_ = std::move(*rules);
+
                 tr_logAddInfo(_("Rewriting old blocklist file format to new format"));
                 tr_sys_path_remove(bin_file_);
                 save(bin_file_, std::data(rules_), std::size(rules_));
@@ -476,7 +492,7 @@ std::optional<Blocklists::Blocklist> Blocklists::Blocklist::saveNew(
 {
     // if we can't parse the file, do nothing
     auto rules = parseFile(external_file);
-    if (std::empty(rules))
+    if (!rules)
     {
         return {};
     }
@@ -500,11 +516,11 @@ std::optional<Blocklists::Blocklist> Blocklists::Blocklist::saveNew(
         return {};
     }
 
-    save(bin_file, std::data(rules), std::size(rules));
+    save(bin_file, std::data(*rules), std::size(*rules));
 
     // return a new Blocklist with these rules
     auto ret = Blocklist{ bin_file, is_enabled };
-    ret.rules_ = std::move(rules);
+    ret.rules_ = std::move(*rules);
     return ret;
 }
 
@@ -529,7 +545,7 @@ void Blocklists::load(std::string_view folder, bool is_enabled)
 }
 
 // static
-std::vector<Blocklists::Blocklist> Blocklists::Blocklists::load_folder(std::string_view const folder, bool const is_enabled)
+std::vector<Blocklists::Blocklist> Blocklists::load_folder(std::string_view const folder, bool const is_enabled)
 {
     // check for files that need to be updated
     for (auto const& src_file : getFilenamesInDir(folder))
@@ -546,9 +562,9 @@ std::vector<Blocklists::Blocklist> Blocklists::Blocklists::load_folder(std::stri
         auto const bin_needs_update = src_info && (!bin_info || bin_info->last_modified_at <= src_info->last_modified_at);
         if (bin_needs_update)
         {
-            if (auto const ranges = parseFile(src_file); !std::empty(ranges))
+            if (auto const ranges = parseFile(src_file))
             {
-                save(bin_file, std::data(ranges), std::size(ranges));
+                save(bin_file, std::data(*ranges), std::size(*ranges));
             }
         }
     }
@@ -564,7 +580,7 @@ std::vector<Blocklists::Blocklist> Blocklists::Blocklists::load_folder(std::stri
     return ret;
 }
 
-size_t Blocklists::update_primary_blocklist(std::string_view const external_file, bool const is_enabled)
+std::optional<size_t> Blocklists::update_primary_blocklist(std::string_view const external_file, bool const is_enabled)
 {
     // These rules will replace the default blocklist.
     // Build the path of the default blocklist .bin file where we'll save these rules.
@@ -574,7 +590,7 @@ size_t Blocklists::update_primary_blocklist(std::string_view const external_file
     auto added = Blocklist::saveNew(external_file, bin_file, is_enabled);
     if (!added)
     {
-        return 0U;
+        return {};
     }
 
     auto const n_rules = std::size(*added);

--- a/libtransmission/blocklist.cc
+++ b/libtransmission/blocklist.cc
@@ -414,11 +414,16 @@ void Blocklists::Blocklist::ensureLoaded() const
             if (auto rules = parseFile(sz_src_file))
             {
                 rules_ = std::move(*rules);
-
-                tr_logAddInfo(_("Rewriting old blocklist file format to new format"));
-                tr_sys_path_remove(bin_file_);
-                save(bin_file_, std::data(*rules_), std::size(*rules_));
             }
+
+            // N.B. Even if the source file cannot be parsed, save an empty bin file
+            // so that the source file won't be parsed on the next reload(s) until it
+            // was modified.
+            tr_logAddInfo(
+                fmt::format(
+                    fmt::runtime(_("Rewriting old blocklist file {path} to new format")),
+                    fmt::arg("path", tr_sys_path_basename(bin_file_))));
+            save(bin_file_, std::data(*rules_), std::size(*rules_));
         }
         return;
     }

--- a/libtransmission/blocklist.h
+++ b/libtransmission/blocklist.h
@@ -80,8 +80,8 @@ private:
         [[nodiscard]] size_t size() const
         {
             ensureLoaded();
-
-            return std::size(rules_);
+            // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
+            return std::size(*rules_);
         }
 
         [[nodiscard]] constexpr bool enabled() const noexcept
@@ -102,7 +102,7 @@ private:
     private:
         void ensureLoaded() const;
 
-        mutable std::vector<std::pair<tr_address, tr_address>> rules_;
+        mutable std::optional<std::vector<std::pair<tr_address, tr_address>>> rules_;
 
         std::string bin_file_;
         bool is_enabled_ = false;

--- a/libtransmission/blocklist.h
+++ b/libtransmission/blocklist.h
@@ -21,6 +21,7 @@
 #include <sigslot/signal.hpp>
 
 #include "libtransmission/net.h" // for tr_address
+#include "libtransmission/tr-assert.h"
 
 namespace tr
 {
@@ -80,7 +81,7 @@ private:
         [[nodiscard]] size_t size() const
         {
             ensureLoaded();
-            // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
+            TR_ASSERT(rules_);
             return std::size(*rules_);
         }
 

--- a/libtransmission/blocklist.h
+++ b/libtransmission/blocklist.h
@@ -53,7 +53,7 @@ public:
 
     void load(std::string_view folder, bool is_enabled);
     void set_enabled(bool is_enabled);
-    size_t update_primary_blocklist(std::string_view external_file, bool is_enabled);
+    std::optional<size_t> update_primary_blocklist(std::string_view external_file, bool is_enabled);
 
     template<typename Observer>
     [[nodiscard]] sigslot::scoped_connection observe_changes(Observer observer) const

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -1641,13 +1641,13 @@ void onBlocklistFetched(tr_web::FetchResponse const& web_response)
 
     // feed it to the session and give the client a response
     auto const blocklist_size = tr_blocklistSetContent(session, filename);
+    tr_sys_path_remove(filename);
     if (!blocklist_size)
     {
         tr_rpc_idle_done(data, Error::INVALID_BLOCKLIST_DATA, {});
         return;
     }
     data->args_out.try_emplace(TR_KEY_blocklist_size, *blocklist_size);
-    tr_sys_path_remove(filename);
     tr_rpc_idle_done(data, Error::SUCCESS, {});
 }
 

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -95,6 +95,8 @@ namespace Error
         return "HTTP error from backend service"sv;
     case CORRUPT_TORRENT:
         return "invalid or corrupt torrent file"sv;
+    case INVALID_BLOCKLIST_DATA:
+        return "couldn't parse any valid blocklist rules"sv;
     default:
         return {};
     }
@@ -1639,7 +1641,12 @@ void onBlocklistFetched(tr_web::FetchResponse const& web_response)
 
     // feed it to the session and give the client a response
     auto const blocklist_size = tr_blocklistSetContent(session, filename);
-    data->args_out.try_emplace(TR_KEY_blocklist_size, blocklist_size);
+    if (!blocklist_size)
+    {
+        tr_rpc_idle_done(data, Error::INVALID_BLOCKLIST_DATA, {});
+        return;
+    }
+    data->args_out.try_emplace(TR_KEY_blocklist_size, *blocklist_size);
     tr_sys_path_remove(filename);
     tr_rpc_idle_done(data, Error::SUCCESS, {});
 }

--- a/libtransmission/rpcimpl.h
+++ b/libtransmission/rpcimpl.h
@@ -41,7 +41,8 @@ enum Code : int16_t
     FILE_IDX_OOR,
     PIECE_IDX_OOR,
     HTTP_ERROR,
-    CORRUPT_TORRENT
+    CORRUPT_TORRENT,
+    INVALID_BLOCKLIST_DATA,
 };
 
 [[nodiscard]] std::string_view to_string(Code code);

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -1799,7 +1799,7 @@ bool tr_blocklistExists(tr_session const* session)
     return session->blocklists_.num_lists() > 0U;
 }
 
-size_t tr_blocklistSetContent(tr_session* session, std::string_view const content_filename)
+std::optional<size_t> tr_blocklistSetContent(tr_session* session, std::string_view const content_filename)
 {
     auto const lock = session->unique_lock();
     return session->blocklists_.update_primary_blocklist(content_filename, session->blocklist_enabled());

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -1114,10 +1114,10 @@ private:
     friend std::string tr_sessionGetRPCUsername(tr_session const* session);
     friend std::string tr_sessionGetRPCWhitelist(tr_session const* session);
     friend size_t tr_blocklistGetRuleCount(tr_session const* session);
-    friend size_t tr_blocklistSetContent(tr_session* session, std::string_view content_filename);
     friend size_t tr_sessionGetAltSpeedBegin(tr_session const* session);
     friend size_t tr_sessionGetAltSpeedEnd(tr_session const* session);
     friend size_t tr_sessionGetAltSpeed_KBps(tr_session const* session, tr_direction dir);
+    friend std::optional<size_t> tr_blocklistSetContent(tr_session* session, std::string_view content_filename);
     friend tr_port_forwarding_state tr_sessionGetPortForwarding(tr_session const* session);
     friend tr_sched_day tr_sessionGetAltSpeedDay(tr_session const* session);
     friend tr_session* tr_sessionInit(

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -513,7 +513,7 @@ void tr_sessionSetScriptEnabled(tr_session* session, TrScript type, bool enabled
  * The caller only needs to invoke this when the blocklist
  * has changed.
  */
-size_t tr_blocklistSetContent(tr_session* session, std::string_view content_filename);
+std::optional<size_t> tr_blocklistSetContent(tr_session* session, std::string_view content_filename);
 
 size_t tr_blocklistGetRuleCount(tr_session const* session);
 

--- a/macosx/BlocklistDownloader.mm
+++ b/macosx/BlocklistDownloader.mm
@@ -136,7 +136,7 @@ BlocklistDownloader* fBLDownloader = nil;
         //delete downloaded file
         [NSFileManager.defaultManager removeItemAtPath:blocklistFile error:nil];
 
-        if (count > 0)
+        if (count)
         {
             [self.viewController setFinished];
         }

--- a/tests/libtransmission/blocklist-test.cc
+++ b/tests/libtransmission/blocklist-test.cc
@@ -106,13 +106,8 @@ TEST_F(BlocklistTest, parsing)
     EXPECT_FALSE(addressIsBlocked("ffff::ffff"));
 }
 
-/***
-****
-***/
-
-TEST_F(BlocklistTest, updating)
+TEST_F(BlocklistTest, reloading)
 {
-    // init the session
     auto const path = tr_pathbuf{ session_->configDir(), "/blocklists/level1"sv };
 
     // no blocklist to start with...
@@ -150,6 +145,49 @@ TEST_F(BlocklistTest, updating)
 
     createFileWithContents(path, ContentsCommentsOnly);
     tr_sessionReloadBlocklists(session_);
+    EXPECT_EQ(0U, tr_blocklistGetRuleCount(session_));
+}
+
+TEST_F(BlocklistTest, updating)
+{
+    auto const path = tr_pathbuf{ sandboxDir(), "/blocklist.tmp" };
+
+    // no blocklist to start with...
+    EXPECT_EQ(0U, tr_blocklistGetRuleCount(session_));
+
+    // test that updated source files will get loaded
+    createFileWithContents(path, Contents1);
+    tr_blocklistSetContent(session_, path);
+    EXPECT_EQ(6U, tr_blocklistGetRuleCount(session_));
+
+    // test that empty files are loaded as 0 rules
+    createFileWithContents(path, ContentsEmpty);
+    tr_blocklistSetContent(session_, path);
+    EXPECT_EQ(0U, tr_blocklistGetRuleCount(session_));
+
+    // test that updated source files will get loaded
+    createFileWithContents(path, Contents2);
+    tr_blocklistSetContent(session_, path);
+    EXPECT_EQ(7U, tr_blocklistGetRuleCount(session_));
+
+    // test that whitespace-only files are loaded as 0 rules
+    createFileWithContents(path, ContentsWhitespaceOnly);
+    tr_blocklistSetContent(session_, path);
+    EXPECT_EQ(0U, tr_blocklistGetRuleCount(session_));
+
+    // test that comments get ignored and not treated as bad
+    createFileWithContents(path, ContentsWithComments);
+    tr_blocklistSetContent(session_, path);
+    EXPECT_EQ(7U, tr_blocklistGetRuleCount(session_));
+
+    // ensure that new files, if bad, get skipped
+    createFileWithContents(path, "sdfsdjkfasfildbg\n");
+    tr_blocklistSetContent(session_, path);
+    EXPECT_EQ(7U, tr_blocklistGetRuleCount(session_));
+
+    // test that comments get ignored and not treated as bad
+    createFileWithContents(path, ContentsCommentsOnly);
+    tr_blocklistSetContent(session_, path);
     EXPECT_EQ(0U, tr_blocklistGetRuleCount(session_));
 }
 

--- a/tests/libtransmission/blocklist-test.cc
+++ b/tests/libtransmission/blocklist-test.cc
@@ -157,37 +157,37 @@ TEST_F(BlocklistTest, updating)
 
     // test that updated source files will get loaded
     createFileWithContents(path, Contents1);
-    tr_blocklistSetContent(session_, path);
+    EXPECT_EQ(6U, tr_blocklistSetContent(session_, path));
     EXPECT_EQ(6U, tr_blocklistGetRuleCount(session_));
 
     // test that empty files are loaded as 0 rules
     createFileWithContents(path, ContentsEmpty);
-    tr_blocklistSetContent(session_, path);
+    EXPECT_EQ(0U, tr_blocklistSetContent(session_, path));
     EXPECT_EQ(0U, tr_blocklistGetRuleCount(session_));
 
     // test that updated source files will get loaded
     createFileWithContents(path, Contents2);
-    tr_blocklistSetContent(session_, path);
+    EXPECT_EQ(7U, tr_blocklistSetContent(session_, path));
     EXPECT_EQ(7U, tr_blocklistGetRuleCount(session_));
 
     // test that whitespace-only files are loaded as 0 rules
     createFileWithContents(path, ContentsWhitespaceOnly);
-    tr_blocklistSetContent(session_, path);
+    EXPECT_EQ(0U, tr_blocklistSetContent(session_, path));
     EXPECT_EQ(0U, tr_blocklistGetRuleCount(session_));
 
     // test that comments get ignored and not treated as bad
     createFileWithContents(path, ContentsWithComments);
-    tr_blocklistSetContent(session_, path);
+    EXPECT_EQ(7U, tr_blocklistSetContent(session_, path));
     EXPECT_EQ(7U, tr_blocklistGetRuleCount(session_));
 
     // ensure that new files, if bad, get skipped
     createFileWithContents(path, "sdfsdjkfasfildbg\n");
-    tr_blocklistSetContent(session_, path);
+    EXPECT_FALSE(tr_blocklistSetContent(session_, path));
     EXPECT_EQ(7U, tr_blocklistGetRuleCount(session_));
 
     // test that comments get ignored and not treated as bad
     createFileWithContents(path, ContentsCommentsOnly);
-    tr_blocklistSetContent(session_, path);
+    EXPECT_EQ(0U, tr_blocklistSetContent(session_, path));
     EXPECT_EQ(0U, tr_blocklistGetRuleCount(session_));
 }
 

--- a/tests/libtransmission/blocklist-test.cc
+++ b/tests/libtransmission/blocklist-test.cc
@@ -22,22 +22,41 @@ namespace tr::test
 class BlocklistTest : public SessionTest
 {
 protected:
-    static char constexpr const* const Contents1 =
+    static auto constexpr Contents1 =
         "10.5.6.7/8\n"
         "Austin Law Firm:216.16.1.144-216.16.1.151\n"
         "Sargent Controls and Aerospace:216.19.18.0-216.19.18.255\n"
         "Corel Corporation:216.21.157.192-216.21.157.223\n"
         "Fox Speed Channel:216.79.131.192-216.79.131.223\n"
-        "IPv6 example:2001:db8::-2001:db8:ffff:ffff:ffff:ffff:ffff:ffff\n";
+        "IPv6 example:2001:db8::-2001:db8:ffff:ffff:ffff:ffff:ffff:ffff\n"sv;
 
-    static char constexpr const* const Contents2 =
+    static auto constexpr Contents2 =
         "10.5.6.7/8\n"
         "Austin Law Firm:216.16.1.144-216.16.1.151\n"
         "Sargent Controls and Aerospace:216.19.18.0-216.19.18.255\n"
         "Corel Corporation:216.21.157.192-216.21.157.223\n"
         "Fox Speed Channel:216.79.131.192-216.79.131.223\n"
         "IPv6 example:2001:db8::-2001:db8:ffff:ffff:ffff:ffff:ffff:ffff\n"
-        "Evilcorp:216.88.88.0-216.88.88.255\n";
+        "Evilcorp:216.88.88.0-216.88.88.255\n"sv;
+
+    static auto constexpr ContentsEmpty = ""sv;
+
+    static auto constexpr ContentsWhitespaceOnly = " \t\r\n\f\n"sv;
+
+    static auto constexpr ContentsWithComments =
+        "# this is a comment\n"
+        "// this is a comment\n"
+        "10.5.6.7/8\n"
+        "Austin Law Firm:216.16.1.144-216.16.1.151\n"
+        "Sargent Controls and Aerospace:216.19.18.0-216.19.18.255\n"
+        "Corel Corporation:216.21.157.192-216.21.157.223\n"
+        "Fox Speed Channel:216.79.131.192-216.79.131.223\n"
+        "IPv6 example:2001:db8::-2001:db8:ffff:ffff:ffff:ffff:ffff:ffff\n"
+        "Evilcorp:216.88.88.0-216.88.88.255\n"sv;
+
+    static auto constexpr ContentsCommentsOnly =
+        "# this is a comment\n"
+        "// this is a comment\n"sv;
 
     bool addressIsBlocked(char const* address_str)
     {
@@ -104,22 +123,34 @@ TEST_F(BlocklistTest, updating)
     tr_sessionReloadBlocklists(session_);
     EXPECT_EQ(6U, tr_blocklistGetRuleCount(session_));
 
+    // test that empty files are loaded as 0 rules
+    createFileWithContents(path, ContentsEmpty);
+    tr_sessionReloadBlocklists(session_);
+    EXPECT_EQ(0U, tr_blocklistGetRuleCount(session_));
+
     // test that updated source files will get loaded
     createFileWithContents(path, Contents2);
     tr_sessionReloadBlocklists(session_);
     EXPECT_EQ(7U, tr_blocklistGetRuleCount(session_));
 
-    // test that updated source files will get loaded
-    createFileWithContents(path, Contents1);
+    // test that whitespace-only files are loaded as 0 rules
+    createFileWithContents(path, ContentsWhitespaceOnly);
     tr_sessionReloadBlocklists(session_);
-    EXPECT_EQ(6U, tr_blocklistGetRuleCount(session_));
+    EXPECT_EQ(0U, tr_blocklistGetRuleCount(session_));
+
+    // test that comments get ignored and not treated as bad
+    createFileWithContents(path, ContentsWithComments);
+    tr_sessionReloadBlocklists(session_);
+    EXPECT_EQ(7U, tr_blocklistGetRuleCount(session_));
 
     // ensure that new files, if bad, get skipped
-    createFileWithContents(path, "# nothing useful\n");
+    createFileWithContents(path, "sdfsdjkfasfildbg\n");
     tr_sessionReloadBlocklists(session_);
-    EXPECT_EQ(6U, tr_blocklistGetRuleCount(session_));
+    EXPECT_EQ(7U, tr_blocklistGetRuleCount(session_));
 
-    // cleanup
+    createFileWithContents(path, ContentsCommentsOnly);
+    tr_sessionReloadBlocklists(session_);
+    EXPECT_EQ(0U, tr_blocklistGetRuleCount(session_));
 }
 
 } // namespace tr::test


### PR DESCRIPTION
Closes #7942.

Notes: Fixed handling of empty blocklists when downloading a new blocklist.