### PR TITLE
fix: shrink decompressed blocklist buffer to actual size before writing

### DIFF
--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -1586,16 +1586,25 @@ void onBlocklistFetched(tr_web::FetchResponse const& web_response)
             std::data(content),
             std::size(content),
             &actual_size);
-        if (decompress_result == LIBDEFLATE_INSUFFICIENT_SPACE)
+        switch (decompress_result)
         {
+        case LIBDEFLATE_INSUFFICIENT_SPACE:
             // need a bigger buffer
             content.resize(content.size() * 2);
             continue;
-        }
-        if (decompress_result == LIBDEFLATE_BAD_DATA)
-        {
+
+        case LIBDEFLATE_BAD_DATA:
             // couldn't decompress it; maybe we downloaded an uncompressed file
             content.assign(std::begin(body), std::end(body));
+            break;
+
+        case LIBDEFLATE_SUCCESS:
+            // shrink buffer to actual size
+            content.resize(actual_size);
+            break;
+
+        default:
+            break;
         }
         break;
     }


### PR DESCRIPTION
Cherry-pick #8815.

Notes: Stopped appending redundant zeros to blocklist files when downloaded from a remote URL.