### PR TITLE
fix: don't use int when calculating number of blocklist rules (4.1.x)

### DIFF
--- a/libtransmission/blocklist.cc
+++ b/libtransmission/blocklist.cc
@@ -47,7 +47,7 @@ namespace
 // A string at the beginning of .bin files to test & make sure we don't load incompatible files
 auto constexpr BinContentsPrefix = std::string_view{ "-tr-blocklist-file-format-v3-" };
 
-// In the blocklists directory, the The plaintext source file can be anything, e.g. "level1".
+// In the blocklists directory, the plaintext source file can be anything, e.g. "level1".
 // The pre-parsed, fast-to-load binary file will have a ".bin" suffix e.g. "level1.bin".
 auto constexpr BinFileSuffix = std::string_view{ ".bin" };
 

--- a/libtransmission/blocklist.h
+++ b/libtransmission/blocklist.h
@@ -49,7 +49,7 @@ public:
             std::begin(blocklists_),
             std::end(blocklists_),
             size_t{},
-            [](int sum, auto& cur) { return sum + std::size(cur); });
+            [](auto sum, auto& cur) { return sum + std::size(cur); });
     }
 
     void load(std::string_view folder, bool is_enabled);


### PR DESCRIPTION
Backport #8816 to 4.1.x.

* fix: don't use int when calculating number of blocklist rules