### PR TITLE
perf: avoid redundant call to Torrent.filePrioritiesForIndexes

### DIFF
--- a/macosx/FilePriorityCellView.mm
+++ b/macosx/FilePriorityCellView.mm
@@ -113,7 +113,7 @@ static CGFloat const kImageOverlap = 1.0;
     }
 
     // Update tooltip
-    [self updateTooltip];
+    [self updateTooltip:priorities];
 }
 
 - (void)updatePriorityIcons:(NSSet*)priorities
@@ -272,16 +272,12 @@ static CGFloat const kImageOverlap = 1.0;
     self.hovered = NO;
 }
 
-- (void)updateTooltip
+- (void)updateTooltip:(NSSet*)priorities
 {
     if (!self.node)
     {
         return;
     }
-
-    FileListNode* node = self.node;
-    Torrent* torrent = node.torrent;
-    NSSet* priorities = [torrent filePrioritiesForIndexes:node.indexes];
 
     NSString* tooltip = nil;
     switch (priorities.count)


### PR DESCRIPTION
Remove a couple of redundant calls to `[Torrent filePrioritiesForIndices]`. This is a moderately expensive call, so we should avoid duplicates here.

Cherry-pick of #8829.

Notes: Improved UI code to use less CPU.