### PR TITLE
perf: reuse a cached ProgressBarView instead of instantiating new ones each time (4.1.x)

### DIFF
--- a/macosx/ProgressBarView.h
+++ b/macosx/ProgressBarView.h
@@ -9,6 +9,8 @@
 
 @interface ProgressBarView : NSView
 
+@property(class, nonatomic, readonly) ProgressBarView* sharedInstance;
+
 - (void)drawBarInRect:(NSRect)barRect forTableView:(TorrentTableView*)tableView withTorrent:(Torrent*)torrent;
 
 @end

--- a/macosx/ProgressBarView.mm
+++ b/macosx/ProgressBarView.mm
@@ -25,6 +25,12 @@ static NSInteger const kMaxPieces = 18 * 18;
 
 @implementation ProgressBarView
 
++ (ProgressBarView*)sharedInstance
+{
+    static ProgressBarView* sSharedInstance = [[ProgressBarView alloc] init];
+    return sSharedInstance;
+}
+
 - (instancetype)init
 {
     if ((self = [super init]))

--- a/macosx/TorrentCell.mm
+++ b/macosx/TorrentCell.mm
@@ -18,8 +18,7 @@
 
         // draw progress bar
         NSRect barRect = self.fTorrentProgressBarView.frame;
-        ProgressBarView* progressBar = [[ProgressBarView alloc] init];
-        [progressBar drawBarInRect:barRect forTableView:self.fTorrentTableView withTorrent:torrent];
+        [ProgressBarView.sharedInstance drawBarInRect:barRect forTableView:self.fTorrentTableView withTorrent:torrent];
 
         // set priority icon
         if (torrent.priority != TR_PRI_NORMAL)


### PR DESCRIPTION
Reuse a cached ProgressBarView instead of instantiating a new one every time.

Cherry-pick #8830.

Notes: Improved UI code to use less CPU.