### PR TITLE
perf: avoid redundant calls to `tr_torrentFile()`

### DIFF
--- a/macosx/Torrent.h
+++ b/macosx/Torrent.h
@@ -198,7 +198,6 @@ extern NSString* const kTorrentDidChangeGroupNotification;
 
 //methods require fileStats to have been updated recently to be accurate
 - (CGFloat)fileProgress:(FileListNode*)node;
-- (BOOL)canChangeDownloadCheckForFile:(NSUInteger)index;
 - (BOOL)canChangeDownloadCheckForFiles:(NSIndexSet*)indexSet;
 - (NSControlStateValue)checkForFiles:(NSIndexSet*)indexSet;
 - (void)setFileCheckState:(NSControlStateValue)state forIndexes:(NSIndexSet*)indexSet;

--- a/macosx/Torrent.mm
+++ b/macosx/Torrent.mm
@@ -51,6 +51,8 @@ static dispatch_queue_t timeMachineExcludeQueue;
 @property(nonatomic) BOOL fResumeOnWake;
 @property(nonatomic, copy, readwrite) NSString* hashString;
 
+- (BOOL)canChangeDownloadChecks;
+
 - (void)renameFinished:(BOOL)success
                  nodes:(NSArray<FileListNode*>*)nodes
      completionHandler:(void (^)(BOOL))completionHandler
@@ -62,7 +64,13 @@ static dispatch_queue_t timeMachineExcludeQueue;
 
 @end
 
-bool trashDataFile(std::string_view const filename, tr_error* error)
+[[nodiscard]]
+static bool canChangeDownloadCheck(tr_file_view const& file)
+{
+    return file.have < file.length;
+}
+
+static bool trashDataFile(std::string_view const filename, tr_error* error)
 {
     if (std::empty(filename))
     {
@@ -85,7 +93,7 @@ bool trashDataFile(std::string_view const filename, tr_error* error)
     return true;
 }
 
-tr_torrent_rename_done_func makeRenameDoneCallback(NSDictionary* contextInfo)
+static tr_torrent_rename_done_func makeRenameDoneCallback(NSDictionary* contextInfo)
 {
     return [contextInfo](tr_torrent_id_t const /*tor_id*/, std::string_view const oldpath, std::string_view const newname, tr_error const& error)
     {
@@ -1582,39 +1590,39 @@ tr_torrent_rename_done_func makeRenameDoneCallback(NSDictionary* contextInfo)
     return (CGFloat)have / node.size;
 }
 
-- (BOOL)canChangeDownloadCheckForFile:(NSUInteger)index
+- (BOOL)canChangeDownloadChecks
 {
-    NSAssert2(index < self.fileCount, @"Index %lu is greater than file count %lu", index, self.fileCount);
-
-    return [self canChangeDownloadCheckForFiles:[NSIndexSet indexSetWithIndex:index]];
+    return self.fileCount != 1 && !self.complete;
 }
 
 - (BOOL)canChangeDownloadCheckForFiles:(NSIndexSet*)indexSet
 {
-    if (self.fileCount == 1 || self.complete)
+    if ([self canChangeDownloadChecks])
     {
-        return NO;
+        for (NSUInteger index = indexSet.firstIndex; index != NSNotFound; index = [indexSet indexGreaterThanIndex:index])
+        {
+            if (canChangeDownloadCheck(tr_torrentFile(self.fHandle, index)))
+            {
+                return YES;
+            }
+        }
     }
 
-    __block BOOL canChange = NO;
-    [indexSet enumerateIndexesWithOptions:NSEnumerationConcurrent usingBlock:^(NSUInteger index, BOOL* stop) {
-        auto const file = tr_torrentFile(self.fHandle, index);
-        if (file.have < file.length)
-        {
-            canChange = YES;
-            *stop = YES;
-        }
-    }];
-    return canChange;
+    return NO;
 }
 
 - (NSControlStateValue)checkForFiles:(NSIndexSet*)indexSet
 {
+    if (![self canChangeDownloadChecks])
+    {
+        return NSControlStateValueOn;
+    }
+
     BOOL onState = NO, offState = NO;
     for (NSUInteger index = indexSet.firstIndex; index != NSNotFound; index = [indexSet indexGreaterThanIndex:index])
     {
         auto const file = tr_torrentFile(self.fHandle, index);
-        if (file.wanted || ![self canChangeDownloadCheckForFile:index])
+        if (file.wanted || !canChangeDownloadCheck(file))
         {
             onState = YES;
         }
@@ -1659,60 +1667,71 @@ tr_torrent_rename_done_func makeRenameDoneCallback(NSDictionary* contextInfo)
 
 - (BOOL)hasFilePriority:(tr_priority_t)priority forIndexes:(NSIndexSet*)indexSet
 {
-    for (NSUInteger index = indexSet.firstIndex; index != NSNotFound; index = [indexSet indexGreaterThanIndex:index])
+    if ([self canChangeDownloadChecks])
     {
-        if (priority == tr_torrentFile(self.fHandle, index).priority && [self canChangeDownloadCheckForFile:index])
+        for (NSUInteger index = indexSet.firstIndex; index != NSNotFound; index = [indexSet indexGreaterThanIndex:index])
         {
-            return YES;
+            auto const file = tr_torrentFile(self.fHandle, index);
+            if (priority == file.priority && canChangeDownloadCheck(file))
+            {
+                return YES;
+            }
         }
     }
+
     return NO;
 }
 
 - (NSSet*)filePrioritiesForIndexes:(NSIndexSet*)indexSet
 {
-    BOOL low = NO, normal = NO, high = NO;
     NSMutableSet* priorities = [NSMutableSet setWithCapacity:MIN(indexSet.count, 3u)];
 
-    for (NSUInteger index = indexSet.firstIndex; index != NSNotFound; index = [indexSet indexGreaterThanIndex:index])
+    if ([self canChangeDownloadChecks])
     {
-        if (![self canChangeDownloadCheckForFile:index])
-        {
-            continue;
-        }
+        BOOL low = NO, normal = NO, high = NO;
 
-        auto const priority = tr_torrentFile(self.fHandle, index).priority;
-        switch (priority)
+        for (NSUInteger index = indexSet.firstIndex; index != NSNotFound; index = [indexSet indexGreaterThanIndex:index])
         {
-        case TR_PRI_LOW:
-            if (low)
-            {
-                continue;
-            }
-            low = YES;
-            break;
-        case TR_PRI_NORMAL:
-            if (normal)
-            {
-                continue;
-            }
-            normal = YES;
-            break;
-        case TR_PRI_HIGH:
-            if (high)
-            {
-                continue;
-            }
-            high = YES;
-            break;
-        default:
-            NSAssert2(NO, @"Unknown priority %d for file index %ld", priority, index);
-        }
+            auto const file = tr_torrentFile(self.fHandle, index);
 
-        [priorities addObject:@(priority)];
-        if (low && normal && high)
-        {
-            break;
+            if (!canChangeDownloadCheck(file))
+            {
+                continue;
+            }
+
+            auto const priority = file.priority;
+            switch (priority)
+            {
+            case TR_PRI_LOW:
+                if (low)
+                {
+                    continue;
+                }
+                low = YES;
+                break;
+            case TR_PRI_NORMAL:
+                if (normal)
+                {
+                    continue;
+                }
+                normal = YES;
+                break;
+            case TR_PRI_HIGH:
+                if (high)
+                {
+                    continue;
+                }
+                high = YES;
+                break;
+            default:
+                NSAssert2(NO, @"Unknown priority %d for file index %ld", priority, index);
+            }
+
+            [priorities addObject:@(priority)];
+            if (low && normal && high)
+            {
+                break;
+            }
         }
     }
     return priorities;


### PR DESCRIPTION
We have a handful of places that call `tr_torrentFile()` and then call a helper function that also calls `tr_torrentFile()`.

Let's save a little work by having the helper take a `tr_file_view const&` argument.