### PR TITLE
docs(rpc-spec): correct bandwidth group name field

### DIFF
--- a/docs/rpc-spec.md
+++ b/docs/rpc-spec.md
@@ -779,10 +779,10 @@ Response parameters: none
 #### 4.8.2 Bandwidth group accessor: `group_get`
 Method name: `group_get`
 
-Request parameters: An optional parameter `group`.
-`group` is either a string naming the bandwidth group,
+Request parameters: An optional parameter `name`.
+`name` is either a string naming the bandwidth group,
 or a list of such strings.
-If `group` is omitted, all bandwidth groups are used.
+If `name` is omitted, all bandwidth groups are used.
 
 Response parameters:
 


### PR DESCRIPTION
Follow-up on #8789 to back-merge into v4.1's branch.

cc @ckerr 