### PR TITLE
BEP 47 basic padding file non persistence

### DIFF
--- a/libtransmission/inout.cc
+++ b/libtransmission/inout.cc
@@ -138,6 +138,13 @@ void read_bytes(
         return;
     }
 
+    // BEP 47: padding files are virtual zeros — no disk access needed
+    if (tor.file_is_padding(file_index))
+    {
+        std::ranges::fill(buf, 0);
+        return;
+    }
+
     auto const fd = get_fd(session, open_files, tor, false, file_index, error);
     if (!fd || error)
     {
@@ -172,6 +179,12 @@ void write_bytes(
     TR_ASSERT(file_size == 0U || file_offset < file_size);
     TR_ASSERT(file_offset + std::size(buf) <= file_size);
     if (file_size == 0U)
+    {
+        return;
+    }
+
+    // BEP 47: padding files are virtual — nothing to write to disk
+    if (tor.file_is_padding(file_index))
     {
         return;
     }

--- a/libtransmission/torrent-files.h
+++ b/libtransmission/torrent-files.h
@@ -44,6 +44,11 @@ public:
         return files_.at(file_index).size_;
     }
 
+    [[nodiscard]] TR_CONSTEXPR_VEC bool file_is_padding(tr_file_index_t file_index) const
+    {
+        return files_.at(file_index).is_padding_;
+    }
+
     [[nodiscard]] constexpr auto total_size() const noexcept
     {
         return total_size_;
@@ -100,10 +105,10 @@ public:
         return ret;
     }
 
-    TR_CONSTEXPR_VEC tr_file_index_t add(std::string_view path, uint64_t file_size)
+    TR_CONSTEXPR_VEC tr_file_index_t add(std::string_view path, uint64_t file_size, bool is_padding = false)
     {
         auto const ret = static_cast<tr_file_index_t>(std::size(files_));
-        files_.emplace_back(path, file_size);
+        files_.emplace_back(path, file_size, is_padding);
         total_size_ += file_size;
         return ret;
     }
@@ -186,14 +191,16 @@ private:
             }
         }
 
-        TR_CONSTEXPR_STR file_t(std::string_view path, uint64_t size)
+        TR_CONSTEXPR_STR file_t(std::string_view path, uint64_t size, bool is_padding = false)
             : path_{ path }
             , size_{ size }
+            , is_padding_{ is_padding }
         {
         }
 
         std::string path_;
         uint64_t size_ = 0;
+        bool is_padding_ = false;
     };
 
     std::vector<file_t> files_;

--- a/libtransmission/torrent-metainfo.cc
+++ b/libtransmission/torrent-metainfo.cc
@@ -69,6 +69,7 @@ struct MetainfoHandler final : public tr::benc::BasicHandler<MaxBencDepth>
     tr_tracker_tier_t tier_ = 0;
     tr_pathbuf file_subpath_;
     int64_t file_length_ = 0;
+    bool file_is_padding_ = false;
 
     enum class State : uint8_t
     {
@@ -311,8 +312,7 @@ struct MetainfoHandler final : public tr::benc::BasicHandler<MaxBencDepth>
             }
             else if (current_key == AttrKey)
             {
-                // currently unused. TODO support for BEP0047
-                // TODO https://github.com/transmission/transmission/issues/3387
+                file_is_padding_ = value.find('p') != std::string_view::npos;
             }
             else if (
                 pathIs(InfoKey, FilesKey, ArrayKey, Crc32Key) || //
@@ -467,10 +467,11 @@ private:
         }
         else
         {
-            tm_.files_.add(file_subpath_, file_length_);
+            tm_.files_.add(file_subpath_, file_length_, file_is_padding_);
         }
 
         file_length_ = 0;
+        file_is_padding_ = false;
         // NB: let caller decide how to clear file_tree_.
         // if we're in "files" mode we clear it; if in "file tree" we pop it
         return ok;

--- a/libtransmission/torrent-metainfo.h
+++ b/libtransmission/torrent-metainfo.h
@@ -49,6 +49,10 @@ public:
     {
         return files().file_size(i);
     }
+    [[nodiscard]] TR_CONSTEXPR_VEC auto file_is_padding(tr_file_index_t i) const
+    {
+        return files().file_is_padding(i);
+    }
     [[nodiscard]] TR_CONSTEXPR_VEC auto const& file_subpath(tr_file_index_t i) const
     {
         return files().path(i);

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -487,6 +487,11 @@ struct tr_torrent
         return metainfo_.file_size(i);
     }
 
+    [[nodiscard]] TR_CONSTEXPR_VEC auto file_is_padding(tr_file_index_t i) const
+    {
+        return metainfo_.file_is_padding(i);
+    }
+
     void set_file_subpath(tr_file_index_t i, std::string_view subpath)
     {
         metainfo_.set_file_subpath(i, subpath);

--- a/tests/libtransmission/torrent-metainfo-test.cc
+++ b/tests/libtransmission/torrent-metainfo-test.cc
@@ -293,4 +293,26 @@ TEST_F(TorrentMetainfoTest, preservesInfoDictOrder)
     }
 }
 
+TEST_F(TorrentMetainfoTest, bep47PaddingFile)
+{
+    // Torrent with three files: file1.txt (2B), a BEP 47 padding file (26B), file2.txt (2B).
+    // Total 30 bytes fits in one piece (length 32768), so pieces field is one SHA1 (20 bytes).
+    // Key ordering in each dict must be lexicographic per the bencoding spec.
+    static auto constexpr Benc =
+        "d4:infod5:filesl"
+        "d6:lengthi2e4:pathl9:file1.txtee"
+        "d4:attr1:p6:lengthi26e4:pathl4:.pad2:26ee"
+        "d6:lengthi2e4:pathl9:file2.txtee"
+        "e4:name7:test-v112:piece lengthi32768e6:pieces20:aaaaaaaaaaaaaaaaaaaaee"sv;
+
+    tr_logSetLevel(TR_LOG_OFF);
+
+    auto metainfo = tr_torrent_metainfo{};
+    ASSERT_TRUE(metainfo.parse_benc(Benc));
+    ASSERT_EQ(3U, metainfo.file_count());
+    EXPECT_FALSE(metainfo.file_is_padding(0)); // file1.txt
+    EXPECT_TRUE(metainfo.file_is_padding(1)); // .pad/26
+    EXPECT_FALSE(metainfo.file_is_padding(2)); // file2.txt
+}
+
 } // namespace tr::test


### PR DESCRIPTION
Notes: Add support for not realizing BEP 47 padding files onto disk


I did some basic testing:
* load torrent and files in seed transmission instance
* load torrent in leech instance
* verify leech downloads files, but doesn't create padding files
* shutdown seed instance, start leech2 with unmodified transmission 4.1.1
* verify leech2 (v4.1.1) downloads all files, including padding successfully

While not a full implementation by any means, I think this is the most wanted feature of BEP 0047.Let me know what I can do to help get this change into main.

Please link this PR to the relevant issue once we are done.