### PR TITLE
perf: make the env arg in `tr_spawn_async()` a `std::span<>`

### DIFF
--- a/libtransmission/subprocess-posix.cc
+++ b/libtransmission/subprocess-posix.cc
@@ -115,7 +115,7 @@ void set_system_error(tr_error* error, int code, std::string_view what)
 
 bool tr_spawn_async(
     char const* const* cmd,
-    std::span<std::pair<std::string_view, std::string_view>> env,
+    std::span<std::pair<std::string_view, std::string_view>> const env,
     std::string_view work_dir,
     tr_error* error)
 {

--- a/libtransmission/subprocess-posix.cc
+++ b/libtransmission/subprocess-posix.cc
@@ -7,9 +7,10 @@
 #include <cerrno>
 #include <csignal>
 #include <cstdlib>
-#include <map>
+#include <span>
 #include <string>
 #include <string_view>
+#include <utility>
 
 #include <fcntl.h>
 #include <sys/wait.h>
@@ -53,7 +54,7 @@ void set_system_error(tr_error* error, int code, std::string_view what)
 
 [[nodiscard]] bool tr_spawn_async_in_child(
     char const* const* cmd,
-    std::map<std::string_view, std::string_view> const& env,
+    std::span<std::pair<std::string_view, std::string_view>> env,
     std::string_view work_dir)
 {
     auto key_sz = std::string{};
@@ -114,7 +115,7 @@ void set_system_error(tr_error* error, int code, std::string_view what)
 
 bool tr_spawn_async(
     char const* const* cmd,
-    std::map<std::string_view, std::string_view> const& env,
+    std::span<std::pair<std::string_view, std::string_view>> env,
     std::string_view work_dir,
     tr_error* error)
 {

--- a/libtransmission/subprocess-win32.cc
+++ b/libtransmission/subprocess-win32.cc
@@ -18,6 +18,8 @@
 
 #include <windows.h>
 
+#include <small/map.hpp>
+
 #include "libtransmission/error.h"
 #include "libtransmission/string-utils.h"
 #include "libtransmission/subprocess.h"
@@ -80,7 +82,7 @@ public:
     }
 };
 
-using SortedWideEnv = std::map<std::wstring, std::wstring, WStrICompare>;
+using SortedWideEnv = small::map<std::wstring, std::wstring, 64U, WStrICompare>;
 
 /*
  * Var1=Value1\0

--- a/libtransmission/subprocess-win32.cc
+++ b/libtransmission/subprocess-win32.cc
@@ -7,10 +7,11 @@
 #include <climits>
 #include <cstring>
 #include <cwchar>
-#include <map>
 #include <iterator>
+#include <span>
 #include <string>
 #include <string_view>
+#include <utility>
 
 #include <fmt/format.h>
 #include <fmt/xchar.h> // for wchar_t support
@@ -279,7 +280,7 @@ std::wstring construct_cmd_line(char const* const* cmd)
 
 bool tr_spawn_async(
     char const* const* cmd,
-    std::map<std::string_view, std::string_view> const& env,
+    std::span<std::pair<std::string_view, std::string_view>> env,
     std::string_view work_dir,
     tr_error* error)
 {

--- a/libtransmission/subprocess-win32.cc
+++ b/libtransmission/subprocess-win32.cc
@@ -282,7 +282,7 @@ std::wstring construct_cmd_line(char const* const* cmd)
 
 bool tr_spawn_async(
     char const* const* cmd,
-    std::span<std::pair<std::string_view, std::string_view>> env,
+    std::span<std::pair<std::string_view, std::string_view>> const env,
     std::string_view work_dir,
     tr_error* error)
 {

--- a/libtransmission/subprocess.h
+++ b/libtransmission/subprocess.h
@@ -13,6 +13,6 @@ struct tr_error;
 
 bool tr_spawn_async(
     char const* const* cmd,
-    std::span<std::pair<std::string_view, std::string_view>> env,
+    std::span<std::pair<std::string_view, std::string_view>> const env,
     std::string_view work_dir,
     tr_error* error);

--- a/libtransmission/subprocess.h
+++ b/libtransmission/subprocess.h
@@ -13,6 +13,6 @@ struct tr_error;
 
 bool tr_spawn_async(
     char const* const* cmd,
-    std::span<std::pair<std::string_view, std::string_view>> const env,
+    std::span<std::pair<std::string_view, std::string_view>> env,
     std::string_view work_dir,
     tr_error* error);

--- a/libtransmission/subprocess.h
+++ b/libtransmission/subprocess.h
@@ -5,13 +5,14 @@
 
 #pragma once
 
-#include <map>
+#include <span>
 #include <string_view>
+#include <utility>
 
 struct tr_error;
 
 bool tr_spawn_async(
     char const* const* cmd,
-    std::map<std::string_view, std::string_view> const& env,
+    std::span<std::pair<std::string_view, std::string_view>> env,
     std::string_view work_dir,
     tr_error* error);

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -9,9 +9,9 @@
 #include <chrono>
 #include <cstddef> // size_t
 #include <ctime>
-#include <map>
-#include <sstream>
 #include <ranges>
+#include <span>
+#include <sstream>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -416,7 +416,7 @@ void torrentCallScript(tr_torrent const* tor, std::string const& script)
     auto const localtime_str = fmt::format("{:%a %b %d %T %Y%n}", *std::localtime(&now));
     auto const priority_str = std::to_string(tor->get_priority());
 
-    auto const env = std::map<std::string_view, std::string_view>{
+    auto env = std::array<std::pair<std::string_view, std::string_view>, 10U>{ {
         { "TR_APP_VERSION"sv, SHORT_VERSION_STRING },
         { "TR_TIME_LOCALTIME"sv, localtime_str },
         { "TR_TORRENT_BYTES_DOWNLOADED"sv, bytes_downloaded_str },
@@ -427,12 +427,12 @@ void torrentCallScript(tr_torrent const* tor, std::string const& script)
         { "TR_TORRENT_NAME"sv, tor->name() },
         { "TR_TORRENT_PRIORITY"sv, priority_str },
         { "TR_TORRENT_TRACKERS"sv, trackers_str },
-    };
+    } };
 
     tr_logAddInfoTor(tor, fmt::format(fmt::runtime(_("Calling script '{path}'")), fmt::arg("path", script)));
 
     auto error = tr_error{};
-    if (!tr_spawn_async(std::data(cmd), env, TR_IF_WIN32("\\", "/"), &error))
+    if (!tr_spawn_async(std::data(cmd), std::span{ env }, TR_IF_WIN32("\\", "/"), &error))
     {
         tr_logAddWarnTor(
             tor,

--- a/tests/libtransmission/subprocess-test.cc
+++ b/tests/libtransmission/subprocess-test.cc
@@ -8,9 +8,10 @@
 #include <cstdlib> // setenv
 #include <cstring> // strerror
 #include <fstream>
-#include <map>
+#include <span>
 #include <string>
 #include <string_view>
+#include <utility>
 
 #include <gtest/gtest.h>
 
@@ -176,18 +177,18 @@ TEST_P(SubprocessTest, SpawnAsyncEnv)
         nullptr, //
     };
 
-    auto const env = std::map<std::string_view, std::string_view>{
+    auto env = std::array<std::pair<std::string_view, std::string_view>, 4U>{ {
         { test_env_key1, test_env_value1 },
         { test_env_key2, test_env_value2 },
         { test_env_key3, test_env_value3 },
         { test_env_key5, test_env_value5 },
-    };
+    } };
 
     setenv("FOO", "bar", 1 /*true*/); // inherited
     setenv("ZOO", "tar", 1 /*true*/); // overridden
 
     auto error = tr_error{};
-    bool const ret = tr_spawn_async(std::data(args), env, {}, &error);
+    bool const ret = tr_spawn_async(std::data(args), std::span{ env }, {}, &error);
     EXPECT_TRUE(ret);
     EXPECT_FALSE(error) << error;
 


### PR DESCRIPTION
Notes: Avoid unnecessary heap memory allocations.