### PR TITLE
fix: retain socket address after `tr_peerIo::close()`

### DIFF
--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -184,7 +184,7 @@ tr_peerIo::~tr_peerIo()
 // i.e. NEVER call this method in the constructor
 void tr_peerIo::set_socket(std::shared_ptr<tr_peer_socket> socket_in)
 {
-    TR_ASSERT(socket_in);
+    TR_ASSERT(socket_in && socket_in->socket_address().is_valid());
     close(); // tear down the previous socket, if any
 
     socket_ = std::move(socket_in);

--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -188,6 +188,7 @@ void tr_peerIo::set_socket(std::shared_ptr<tr_peer_socket> socket_in)
     close(); // tear down the previous socket, if any
 
     socket_ = std::move(socket_in);
+    socket_address_ = socket_->socket_address();
 
     socket_->set_read_cb(
         [weak = weak_from_this()]
@@ -248,10 +249,9 @@ bool tr_peerIo::reconnect()
     auto const was_read_enabled = socket_->is_read_enabled();
     auto const was_write_enabled = socket_->is_write_enabled();
 
-    auto const sockaddr = socket_address();
     close();
 
-    auto s = tr_peer_socket_tcp::create(*session_, sockaddr, client_is_seed());
+    auto s = tr_peer_socket_tcp::create(*session_, socket_address(), client_is_seed());
     if (!s)
     {
         return false;

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -251,19 +251,19 @@ public:
         return is_incoming_;
     }
 
-    [[nodiscard]] auto const& address() const noexcept
+    [[nodiscard]] constexpr auto const& socket_address() const noexcept
     {
-        return socket_->address();
+        return socket_address_;
     }
 
-    [[nodiscard]] auto const& socket_address() const noexcept
+    [[nodiscard]] constexpr auto const& address() const noexcept
     {
-        return socket_->socket_address();
+        return socket_address().address();
     }
 
     [[nodiscard]] auto display_name() const
     {
-        return socket_->display_name();
+        return socket_address().display_name();
     }
 
     ///
@@ -353,6 +353,8 @@ private:
     std::deque<std::pair<size_t /*n_bytes*/, bool /*is_piece_data*/>> outbuf_info_;
 
     std::shared_ptr<tr_peer_socket> socket_;
+
+    tr_socket_address socket_address_;
 
     tr_bandwidth bandwidth_;
 


### PR DESCRIPTION
Regression from #8060.

Fix SEGV reported by @Noobsai at https://github.com/transmission/transmission/pull/8060#issuecomment-4578391974.

This happens if `tr_peerIo::reconnect()` fails:

1. `tr_peerIo::reconnect()` calls `tr_peerIo::close()`.
2. `tr_peer_socket_tcp::create()` returns `nullptr`.
3. `tr_peerIo::reconnect()` return `false` without a new socket.
4. `tr_handshake::on_error()` (caller of `tr_peerIo::reconnect()`) calls `on_handshake_done()`.
5. `on_handshake_done()` tries to dereference the null socket pointer to get the socket address.