### PR TITLE
Cache date formatter in tracker node

### DIFF
--- a/macosx/TrackerNode.mm
+++ b/macosx/TrackerNode.mm
@@ -13,6 +13,19 @@
 
 @implementation TrackerNode
 
++ (NSDateFormatter*)dateFormatter
+{
+    static NSDateFormatter* formatter = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        formatter = [[NSDateFormatter alloc] init];
+        formatter.dateStyle = NSDateFormatterFullStyle;
+        formatter.timeStyle = NSDateFormatterShortStyle;
+        formatter.doesRelativeDateFormatting = YES;
+    });
+    return formatter;
+}
+
 - (instancetype)initWithTrackerView:(tr_tracker_view const*)stat torrent:(Torrent*)torrent
 {
     if ((self = [super init]))
@@ -96,12 +109,7 @@
     NSString* dateString;
     if (self.fStat.hasAnnounced)
     {
-        NSDateFormatter* dateFormatter = [[NSDateFormatter alloc] init];
-        dateFormatter.dateStyle = NSDateFormatterFullStyle;
-        dateFormatter.timeStyle = NSDateFormatterShortStyle;
-        dateFormatter.doesRelativeDateFormatting = YES;
-
-        dateString = [dateFormatter stringFromDate:[NSDate dateWithTimeIntervalSince1970:self.fStat.lastAnnounceTime]];
+        dateString = [self.class.dateFormatter stringFromDate:[NSDate dateWithTimeIntervalSince1970:self.fStat.lastAnnounceTime]];
     }
     else
     {
@@ -190,12 +198,7 @@
     NSString* dateString;
     if (self.fStat.hasScraped)
     {
-        NSDateFormatter* dateFormatter = [[NSDateFormatter alloc] init];
-        dateFormatter.dateStyle = NSDateFormatterFullStyle;
-        dateFormatter.timeStyle = NSDateFormatterShortStyle;
-        dateFormatter.doesRelativeDateFormatting = YES;
-
-        dateString = [dateFormatter stringFromDate:[NSDate dateWithTimeIntervalSince1970:self.fStat.lastScrapeTime]];
+        dateString = [self.class.dateFormatter stringFromDate:[NSDate dateWithTimeIntervalSince1970:self.fStat.lastScrapeTime]];
     }
     else
     {

--- a/macosx/TrackerNode.mm
+++ b/macosx/TrackerNode.mm
@@ -22,6 +22,7 @@
         formatter.dateStyle = NSDateFormatterFullStyle;
         formatter.timeStyle = NSDateFormatterShortStyle;
         formatter.doesRelativeDateFormatting = YES;
+        formatter.timeZone = NSTimeZone.localTimeZone;
     });
     return formatter;
 }


### PR DESCRIPTION
Date formatter initialization is very expensive so it is better to cache it.

```
WAS
TIME: 0.00027299
TIME: 0.00029099
TIME: 0.00027001
TIME: 0.00027907

NOW
TIME: 0.00002599
TIME: 0.00002301
TIME: 0.00002599
TIME: 0.00002205
```