### PR TITLE
Cache date formatter in tracker node (#8849)

### DIFF
--- a/macosx/TrackerNode.mm
+++ b/macosx/TrackerNode.mm
@@ -13,6 +13,20 @@
 
 @implementation TrackerNode
 
++ (NSDateFormatter*)dateFormatter
+{
+    static NSDateFormatter* formatter = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        formatter = [[NSDateFormatter alloc] init];
+        formatter.dateStyle = NSDateFormatterFullStyle;
+        formatter.timeStyle = NSDateFormatterShortStyle;
+        formatter.doesRelativeDateFormatting = YES;
+        formatter.timeZone = NSTimeZone.localTimeZone;
+    });
+    return formatter;
+}
+
 - (instancetype)initWithTrackerView:(tr_tracker_view const*)stat torrent:(Torrent*)torrent
 {
     if ((self = [super init]))
@@ -96,12 +110,7 @@
     NSString* dateString;
     if (self.fStat.hasAnnounced)
     {
-        NSDateFormatter* dateFormatter = [[NSDateFormatter alloc] init];
-        dateFormatter.dateStyle = NSDateFormatterFullStyle;
-        dateFormatter.timeStyle = NSDateFormatterShortStyle;
-        dateFormatter.doesRelativeDateFormatting = YES;
-
-        dateString = [dateFormatter stringFromDate:[NSDate dateWithTimeIntervalSince1970:self.fStat.lastAnnounceTime]];
+        dateString = [self.class.dateFormatter stringFromDate:[NSDate dateWithTimeIntervalSince1970:self.fStat.lastAnnounceTime]];
     }
     else
     {
@@ -190,12 +199,7 @@
     NSString* dateString;
     if (self.fStat.hasScraped)
     {
-        NSDateFormatter* dateFormatter = [[NSDateFormatter alloc] init];
-        dateFormatter.dateStyle = NSDateFormatterFullStyle;
-        dateFormatter.timeStyle = NSDateFormatterShortStyle;
-        dateFormatter.doesRelativeDateFormatting = YES;
-
-        dateString = [dateFormatter stringFromDate:[NSDate dateWithTimeIntervalSince1970:self.fStat.lastScrapeTime]];
+        dateString = [self.class.dateFormatter stringFromDate:[NSDate dateWithTimeIntervalSince1970:self.fStat.lastScrapeTime]];
     }
     else
     {


### PR DESCRIPTION
Reuse a cached date formatter instead of building a new one every time we need to format at date.

Cherry-pick of #8849 to `4.1.x`

Notes: Improved UI code to use less CPU.