### PR TITLE
fixup! fix: show translated logging level strings (#8609) (#8615)

### DIFF
--- a/gtk/MessageLogWindow.cc
+++ b/gtk/MessageLogWindow.cc
@@ -46,8 +46,6 @@
 
 namespace
 {
-auto constexpr LoggingLevelContext = "Logging level";
-
 class MessageLogColumnsModel : public Gtk::TreeModelColumnRecord
 {
 public:
@@ -109,11 +107,11 @@ private:
     sigc::connection refresh_tag_;
 
     static auto constexpr level_names_ = std::array<std::pair<tr_log_level, char const*>, 5U>{ {
-        { TR_LOG_CRITICAL, NC_(LoggingLevelContext, "Critical") },
-        { TR_LOG_ERROR, NC_(LoggingLevelContext, "Error") },
-        { TR_LOG_WARN, NC_(LoggingLevelContext, "Warning") },
-        { TR_LOG_INFO, NC_(LoggingLevelContext, "Information") },
-        { TR_LOG_DEBUG, NC_(LoggingLevelContext, "Debug") },
+        { TR_LOG_CRITICAL, NC_("Logging level", "Critical") },
+        { TR_LOG_ERROR, NC_("Logging level", "Error") },
+        { TR_LOG_WARN, NC_("Logging level", "Warning") },
+        { TR_LOG_INFO, NC_("Logging level", "Information") },
+        { TR_LOG_DEBUG, NC_("Logging level", "Debug") },
     } };
 };
 
@@ -186,7 +184,7 @@ void MessageLogWindow::Impl::level_combo_init(Gtk::ComboBox* level_combo)
     items.reserve(std::size(level_names_));
     for (auto const& [level, name] : level_names_)
     {
-        items.emplace_back(g_dpgettext2(nullptr, LoggingLevelContext, name), level);
+        items.emplace_back(g_dpgettext2(nullptr, "Logging level", name), level);
         has_pref_level |= level == pref_level;
     }
 
@@ -239,7 +237,7 @@ void MessageLogWindow::Impl::doSave(std::string const& filename)
                 level_names_,
                 [key = node->level](auto const& item) { return item.first == key; });
             auto const level_str = iter != std::ranges::end(level_names_) ?
-                Glib::ustring(g_dpgettext2(nullptr, LoggingLevelContext, iter->second)) :
+                Glib::ustring(g_dpgettext2(nullptr, "Logging level", iter->second)) :
                 Glib::ustring("???");
 
             fmt::print(stream, "{}\t{}\t{}\t{}\n", date, level_str, node->name, node->message);


### PR DESCRIPTION
Fixup to #8615, which was a fixup to #8609 :3rd_place_medal:  