### PR TITLE
l10n(zh-CN): Optimize macOS localized terms ("General" and "Finder")

### DIFF
--- a/macosx/zh-CN.lproj/Localizable.strings
+++ b/macosx/zh-CN.lproj/Localizable.strings
@@ -903,7 +903,7 @@
 "Show Filter Bar" = "显示筛选栏";
 
 /* File Outline -> Menu */
-"Show in Finder" = "在 Finder 中显示";
+"Show in Finder" = "在访达中显示";
 
 /* View menu -> Inspector */
 "Show Inspector" = "显示嗅探器";
@@ -912,7 +912,7 @@
 "Show Status Bar" = "显示状态栏";
 
 /* Torrent cell -> button info */
-"Show the data file in Finder" = "在 Finder 中显示数据文件";
+"Show the data file in Finder" = "在访达中显示数据文件";
 
 /* View menu -> Toolbar */
 "Show Toolbar" = "显示工具栏";

--- a/macosx/zh-CN.lproj/Localizable.strings
+++ b/macosx/zh-CN.lproj/Localizable.strings
@@ -434,7 +434,7 @@
 "GB/s" = "GB/秒";
 
 /* Preferences -> toolbar item title */
-"General" = "一般";
+"General" = "通用";
 
 /* Inspector -> tab
    Inspector view -> title */


### PR DESCRIPTION
### Purpose
This PR optimizes the Simplified Chinese (`zh-CN`) localization for macOS users by aligning interface terms with modern platform standards and Apple's official guidelines.

### Changes
1. **"General" -> "通用"**: Updated from "一般" to "通用", which is the standard and widely accepted term for "General Settings" in modern Simplified Chinese UI/UX design.
2. **"Finder" terms alignment**: Updated the following two strings to align with Apple's official system-level branding:
   - `"Show in Finder" = "在 Finder 中显示";` -> `"在访达中显示";`
   - `"Show the data file in Finder" = "在 Finder 中显示数据文件";` -> `"在访达中显示数据文件";`

### Context
Apple officially introduced this translation back in **2017 (with macOS High Sierra)**. It has been a standard system term for **nearly a decade**. Keeping the raw English word "Finder" feels inconsistent with the rest of the macOS system environment. Updating it ensures a seamless, highly professional, and native experience for Simplified Chinese users.