### PR TITLE
Use timer initializer with block to prevent possible retain cycles.

### DIFF
--- a/macosx/AddWindowController.mm
+++ b/macosx/AddWindowController.mm
@@ -160,9 +160,11 @@ typedef NS_ENUM(NSUInteger, PopupPriority) {
         self.fLocationImageView.image = nil;
     }
 
-    self.fTimer = [NSTimer scheduledTimerWithTimeInterval:kUpdateSeconds target:self selector:@selector(updateFiles)
-                                                 userInfo:nil
-                                                  repeats:YES];
+    __weak __auto_type weakSelf = self;
+    self.fTimer = [NSTimer scheduledTimerWithTimeInterval:kUpdateSeconds repeats:YES block:^(NSTimer * _Nonnull timer) {
+        [weakSelf updateFiles];
+    }];
+    
     [self updateFiles];
 }
 

--- a/macosx/AddWindowController.mm
+++ b/macosx/AddWindowController.mm
@@ -161,10 +161,10 @@ typedef NS_ENUM(NSUInteger, PopupPriority) {
     }
 
     __weak __auto_type weakSelf = self;
-    self.fTimer = [NSTimer scheduledTimerWithTimeInterval:kUpdateSeconds repeats:YES block:^(NSTimer * _Nonnull timer) {
+    self.fTimer = [NSTimer scheduledTimerWithTimeInterval:kUpdateSeconds repeats:YES block:^(NSTimer* _Nonnull timer) {
         [weakSelf updateFiles];
     }];
-    
+
     [self updateFiles];
 }
 

--- a/macosx/BlocklistScheduler.mm
+++ b/macosx/BlocklistScheduler.mm
@@ -54,7 +54,7 @@ static NSTimeInterval const kFullWait = 60 * 60 * 24 * 7;
     NSDate* useDate = lastUpdateDate ? [lastUpdateDate laterDate:closeDate] : closeDate;
 
     __weak __auto_type weakSelf = self;
-    self.fTimer = [[NSTimer alloc] initWithFireDate:useDate interval:0 repeats:NO block:^(NSTimer * _Nonnull timer) {
+    self.fTimer = [[NSTimer alloc] initWithFireDate:useDate interval:0 repeats:NO block:^(NSTimer* _Nonnull timer) {
         [weakSelf runUpdater];
     }];
 

--- a/macosx/BlocklistScheduler.mm
+++ b/macosx/BlocklistScheduler.mm
@@ -19,16 +19,14 @@ static NSTimeInterval const kFullWait = 60 * 60 * 24 * 7;
 
 @implementation BlocklistScheduler
 
-BlocklistScheduler* fScheduler = nil;
-
 + (BlocklistScheduler*)scheduler
 {
-    if (!fScheduler)
-    {
-        fScheduler = [[BlocklistScheduler alloc] init];
-    }
-
-    return fScheduler;
+    static BlocklistScheduler* scheduler = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        scheduler = [[BlocklistScheduler alloc] init];
+    });
+    return scheduler;
 }
 
 - (void)updateSchedule
@@ -55,8 +53,10 @@ BlocklistScheduler* fScheduler = nil;
 
     NSDate* useDate = lastUpdateDate ? [lastUpdateDate laterDate:closeDate] : closeDate;
 
-    self.fTimer = [[NSTimer alloc] initWithFireDate:useDate interval:0 target:self selector:@selector(runUpdater) userInfo:nil
-                                            repeats:NO];
+    __weak __auto_type weakSelf = self;
+    self.fTimer = [[NSTimer alloc] initWithFireDate:useDate interval:0 repeats:NO block:^(NSTimer * _Nonnull timer) {
+        [weakSelf runUpdater];
+    }];
 
     //current run loop usually means a second update won't work
     NSRunLoop* loop = NSRunLoop.mainRunLoop;

--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -810,7 +810,7 @@ static void removeKeRangerRansomware()
 
     //timer to update the interface every second
     __weak __auto_type weakSelf = self;
-    self.fTimer = [NSTimer scheduledTimerWithTimeInterval:kUpdateUISeconds repeats:YES block:^(NSTimer * _Nonnull timer) {
+    self.fTimer = [NSTimer scheduledTimerWithTimeInterval:kUpdateUISeconds repeats:YES block:^(NSTimer* _Nonnull timer) {
         [weakSelf updateUI];
     }];
 
@@ -3555,7 +3555,7 @@ static void removeKeRangerRansomware()
 
     //check again in 10 seconds in case torrent file wasn't complete
     __weak __auto_type weakSelf = self;
-    self.fAutoImportTimer = [NSTimer scheduledTimerWithTimeInterval:10.0 repeats:NO block:^(NSTimer * _Nonnull timer){
+    self.fAutoImportTimer = [NSTimer scheduledTimerWithTimeInterval:10.0 repeats:NO block:^(NSTimer* _Nonnull timer) {
         [weakSelf checkAutoImportDirectory];
     }];
 

--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -809,8 +809,11 @@ static void removeKeRangerRansomware()
     [self updateMainWindow];
 
     //timer to update the interface every second
-    self.fTimer = [NSTimer scheduledTimerWithTimeInterval:kUpdateUISeconds target:self selector:@selector(updateUI) userInfo:nil
-                                                  repeats:YES];
+    __weak __auto_type weakSelf = self;
+    self.fTimer = [NSTimer scheduledTimerWithTimeInterval:kUpdateUISeconds repeats:YES block:^(NSTimer * _Nonnull timer) {
+        [weakSelf updateUI];
+    }];
+
     [NSRunLoop.currentRunLoop addTimer:self.fTimer forMode:NSModalPanelRunLoopMode];
     [NSRunLoop.currentRunLoop addTimer:self.fTimer forMode:NSEventTrackingRunLoopMode];
 
@@ -3551,10 +3554,10 @@ static void removeKeRangerRansomware()
     }
 
     //check again in 10 seconds in case torrent file wasn't complete
-    self.fAutoImportTimer = [NSTimer scheduledTimerWithTimeInterval:10.0 target:self
-                                                           selector:@selector(checkAutoImportDirectory)
-                                                           userInfo:nil
-                                                            repeats:NO];
+    __weak __auto_type weakSelf = self;
+    self.fAutoImportTimer = [NSTimer scheduledTimerWithTimeInterval:10.0 repeats:NO block:^(NSTimer * _Nonnull timer){
+        [weakSelf checkAutoImportDirectory];
+    }];
 
     [self checkAutoImportDirectory];
 }

--- a/macosx/CreatorWindowController.mm
+++ b/macosx/CreatorWindowController.mm
@@ -624,7 +624,7 @@ static NSMutableSet* creatorWindowControllerSet;
     self.fFuture = self.fBuilder->make_checksums();
 
     __weak __auto_type weakSelf = self;
-    self.fTimer = [NSTimer scheduledTimerWithTimeInterval:0.1 repeats:YES block:^(NSTimer * _Nonnull timer) {
+    self.fTimer = [NSTimer scheduledTimerWithTimeInterval:0.1 repeats:YES block:^(NSTimer* _Nonnull timer) {
         [weakSelf checkProgress];
     }];
 }

--- a/macosx/CreatorWindowController.mm
+++ b/macosx/CreatorWindowController.mm
@@ -622,8 +622,11 @@ static NSMutableSet* creatorWindowControllerSet;
     self.fBuilder->set_source(self.fSource.stringValue.UTF8String);
 
     self.fFuture = self.fBuilder->make_checksums();
-    self.fTimer = [NSTimer scheduledTimerWithTimeInterval:0.1 target:self selector:@selector(checkProgress) userInfo:nil
-                                                  repeats:YES];
+
+    __weak __auto_type weakSelf = self;
+    self.fTimer = [NSTimer scheduledTimerWithTimeInterval:0.1 repeats:YES block:^(NSTimer * _Nonnull timer) {
+        [weakSelf checkProgress];
+    }];
 }
 
 - (void)checkProgress

--- a/macosx/MessageWindowController.h
+++ b/macosx/MessageWindowController.h
@@ -6,8 +6,6 @@
 
 @interface MessageWindowController : NSWindowController
 
-- (void)updateLog:(NSTimer*)timer;
-
 - (IBAction)changeLevel:(id)sender;
 - (IBAction)changeFilter:(id)sender;
 - (IBAction)clearLog:(id)sender;

--- a/macosx/MessageWindowController.mm
+++ b/macosx/MessageWindowController.mm
@@ -39,6 +39,8 @@ static NSTimeInterval const kUpdateSeconds = 0.75;
 
 @property(nonatomic) NSLock* fLock;
 
+- (void)updateLog;
+
 @end
 
 @implementation MessageWindowController

--- a/macosx/MessageWindowController.mm
+++ b/macosx/MessageWindowController.mm
@@ -150,7 +150,7 @@ static NSTimeInterval const kUpdateSeconds = 0.75;
     if (!self.fTimer)
     {
         __weak __auto_type weakSelf = self;
-        self.fTimer = [NSTimer scheduledTimerWithTimeInterval:kUpdateSeconds repeats:YES block:^(NSTimer * _Nonnull timer) {
+        self.fTimer = [NSTimer scheduledTimerWithTimeInterval:kUpdateSeconds repeats:YES block:^(NSTimer* _Nonnull timer) {
             [weakSelf updateLog];
         }];
         [self updateLog];
@@ -177,7 +177,7 @@ static NSTimeInterval const kUpdateSeconds = 0.75;
 {
     [self.fTimer invalidate];
     __weak __auto_type weakSelf = self;
-    self.fTimer = [NSTimer scheduledTimerWithTimeInterval:kUpdateSeconds repeats:YES block:^(NSTimer * _Nonnull timer) {
+    self.fTimer = [NSTimer scheduledTimerWithTimeInterval:kUpdateSeconds repeats:YES block:^(NSTimer* _Nonnull timer) {
         [weakSelf updateLog];
     }];
     [self updateLog];

--- a/macosx/MessageWindowController.mm
+++ b/macosx/MessageWindowController.mm
@@ -149,10 +149,11 @@ static NSTimeInterval const kUpdateSeconds = 0.75;
 {
     if (!self.fTimer)
     {
-        self.fTimer = [NSTimer scheduledTimerWithTimeInterval:kUpdateSeconds target:self selector:@selector(updateLog:)
-                                                     userInfo:nil
-                                                      repeats:YES];
-        [self updateLog:nil];
+        __weak __auto_type weakSelf = self;
+        self.fTimer = [NSTimer scheduledTimerWithTimeInterval:kUpdateSeconds repeats:YES block:^(NSTimer * _Nonnull timer) {
+            [weakSelf updateLog];
+        }];
+        [self updateLog];
     }
 }
 
@@ -175,9 +176,11 @@ static NSTimeInterval const kUpdateSeconds = 0.75;
 - (void)window:(NSWindow*)window didDecodeRestorableState:(NSCoder*)coder
 {
     [self.fTimer invalidate];
-    self.fTimer = [NSTimer scheduledTimerWithTimeInterval:kUpdateSeconds target:self selector:@selector(updateLog:) userInfo:nil
-                                                  repeats:YES];
-    [self updateLog:nil];
+    __weak __auto_type weakSelf = self;
+    self.fTimer = [NSTimer scheduledTimerWithTimeInterval:kUpdateSeconds repeats:YES block:^(NSTimer * _Nonnull timer) {
+        [weakSelf updateLog];
+    }];
+    [self updateLog];
 }
 
 + (NSImage*)iconForLevel:(NSInteger)level
@@ -223,7 +226,7 @@ static NSTimeInterval const kUpdateSeconds = 0.75;
     return icon;
 }
 
-- (void)updateLog:(NSTimer*)timer
+- (void)updateLog
 {
     tr_log_message* messages;
     if ((messages = tr_logGetQueue()) == NULL)

--- a/macosx/PortChecker.mm
+++ b/macosx/PortChecker.mm
@@ -29,12 +29,12 @@ static NSTimeInterval const kCheckFireInterval = 3.0;
         _fDelegate = delegate;
 
         _fStatus = PortStatusChecking;
-        
+
         __weak __auto_type weakSelf = self;
-        _fTimer = [NSTimer scheduledTimerWithTimeInterval:0.1 repeats:YES block:^(NSTimer * _Nonnull timer) {
+        _fTimer = [NSTimer scheduledTimerWithTimeInterval:0.1 repeats:YES block:^(NSTimer* _Nonnull timer) {
             [weakSelf startProbe:portNumber];
         }];
-        
+
         if (!delay)
         {
             [_fTimer fire];

--- a/macosx/PortChecker.mm
+++ b/macosx/PortChecker.mm
@@ -31,7 +31,7 @@ static NSTimeInterval const kCheckFireInterval = 3.0;
         _fStatus = PortStatusChecking;
 
         __weak __auto_type weakSelf = self;
-        _fTimer = [NSTimer scheduledTimerWithTimeInterval:kCheckFireInterval repeats:YES block:^(NSTimer* _Nonnull timer) {
+        _fTimer = [NSTimer scheduledTimerWithTimeInterval:kCheckFireInterval repeats:NO block:^(NSTimer* _Nonnull timer) {
             [weakSelf startProbe:portNumber];
         }];
 

--- a/macosx/PortChecker.mm
+++ b/macosx/PortChecker.mm
@@ -31,7 +31,7 @@ static NSTimeInterval const kCheckFireInterval = 3.0;
         _fStatus = PortStatusChecking;
 
         __weak __auto_type weakSelf = self;
-        _fTimer = [NSTimer scheduledTimerWithTimeInterval:0.1 repeats:YES block:^(NSTimer* _Nonnull timer) {
+        _fTimer = [NSTimer scheduledTimerWithTimeInterval:kCheckFireInterval repeats:YES block:^(NSTimer* _Nonnull timer) {
             [weakSelf startProbe:portNumber];
         }];
 

--- a/macosx/PortChecker.mm
+++ b/macosx/PortChecker.mm
@@ -29,10 +29,12 @@ static NSTimeInterval const kCheckFireInterval = 3.0;
         _fDelegate = delegate;
 
         _fStatus = PortStatusChecking;
-
-        _fTimer = [NSTimer scheduledTimerWithTimeInterval:kCheckFireInterval target:self selector:@selector(startProbe:)
-                                                 userInfo:@(portNumber)
-                                                  repeats:NO];
+        
+        __weak __auto_type weakSelf = self;
+        _fTimer = [NSTimer scheduledTimerWithTimeInterval:0.1 repeats:YES block:^(NSTimer * _Nonnull timer) {
+            [weakSelf startProbe:portNumber];
+        }];
+        
         if (!delay)
         {
             [_fTimer fire];
@@ -62,11 +64,11 @@ static NSTimeInterval const kCheckFireInterval = 3.0;
 
 #pragma mark - Private
 
-- (void)startProbe:(NSTimer*)timer
+- (void)startProbe:(NSInteger)port
 {
     self.fTimer = nil;
 
-    NSString* urlString = [NSString stringWithFormat:@"https://portcheck.transmissionbt.com/%ld", [(NSNumber*)timer.userInfo integerValue]];
+    NSString* urlString = [NSString stringWithFormat:@"https://portcheck.transmissionbt.com/%ld", port];
     NSURLRequest* portProbeRequest = [NSURLRequest requestWithURL:[NSURL URLWithString:urlString]
                                                       cachePolicy:NSURLRequestReloadIgnoringLocalAndRemoteCacheData
                                                   timeoutInterval:15.0];

--- a/macosx/PrefsController.mm
+++ b/macosx/PrefsController.mm
@@ -249,7 +249,7 @@ static NSString* const kWebUIURLFormat = @"http://localhost:%ld/";
     [self updatePortStatus];
 
     __weak __auto_type weakSelf = self;
-    self.fPortStatusTimer = [NSTimer scheduledTimerWithTimeInterval:5.0 repeats:YES block:^(NSTimer * _Nonnull timer) {
+    self.fPortStatusTimer = [NSTimer scheduledTimerWithTimeInterval:5.0 repeats:YES block:^(NSTimer* _Nonnull timer) {
         [weakSelf updatePortStatus];
     }];
 

--- a/macosx/PrefsController.mm
+++ b/macosx/PrefsController.mm
@@ -247,9 +247,11 @@ static NSString* const kWebUIURLFormat = @"http://localhost:%ld/";
     self.fNatStatus = -1;
 
     [self updatePortStatus];
-    self.fPortStatusTimer = [NSTimer scheduledTimerWithTimeInterval:5.0 target:self selector:@selector(updatePortStatus)
-                                                           userInfo:nil
-                                                            repeats:YES];
+
+    __weak __auto_type weakSelf = self;
+    self.fPortStatusTimer = [NSTimer scheduledTimerWithTimeInterval:5.0 repeats:YES block:^(NSTimer * _Nonnull timer) {
+        [weakSelf updatePortStatus];
+    }];
 
     //set peer connections
     self.fPeersGlobalField.integerValue = [self.fDefaults integerForKey:@"PeersTotal"];

--- a/macosx/StatsWindowController.mm
+++ b/macosx/StatsWindowController.mm
@@ -31,8 +31,8 @@ static NSTimeInterval const kUpdateSeconds = 1.0;
 
 @implementation StatsWindowController
 
-StatsWindowController* fStatsWindowInstance = nil;
-tr_session* fLib = NULL;
+static StatsWindowController* fStatsWindowInstance = nil;
+static tr_session* fLib = NULL;
 
 + (StatsWindowController*)statsWindow
 {
@@ -56,9 +56,10 @@ tr_session* fLib = NULL;
     [super awakeFromNib];
     [self updateStats];
 
-    self.fTimer = [NSTimer scheduledTimerWithTimeInterval:kUpdateSeconds target:self selector:@selector(updateStats)
-                                                 userInfo:nil
-                                                  repeats:YES];
+    __weak __auto_type weakSelf = self;
+    self.fTimer = [NSTimer scheduledTimerWithTimeInterval:kUpdateSeconds repeats:YES block:^(NSTimer * _Nonnull timer) {
+        [weakSelf updateStats];
+    }];
     [NSRunLoop.currentRunLoop addTimer:self.fTimer forMode:NSModalPanelRunLoopMode];
     [NSRunLoop.currentRunLoop addTimer:self.fTimer forMode:NSEventTrackingRunLoopMode];
 

--- a/macosx/StatsWindowController.mm
+++ b/macosx/StatsWindowController.mm
@@ -57,7 +57,7 @@ static tr_session* fLib = NULL;
     [self updateStats];
 
     __weak __auto_type weakSelf = self;
-    self.fTimer = [NSTimer scheduledTimerWithTimeInterval:kUpdateSeconds repeats:YES block:^(NSTimer * _Nonnull timer) {
+    self.fTimer = [NSTimer scheduledTimerWithTimeInterval:kUpdateSeconds repeats:YES block:^(NSTimer* _Nonnull timer) {
         [weakSelf updateStats];
     }];
     [NSRunLoop.currentRunLoop addTimer:self.fTimer forMode:NSModalPanelRunLoopMode];


### PR DESCRIPTION
Timers are/were error-prone fiends in Apple platforms.
Use timer initializer with block and capture `weakSelf` to prevent possible retain cycles.

Notes: Improved UI code to use less CPU.