### PR TITLE
feat: relocate completed torrents on a background thread

### DIFF
--- a/libtransmission/CMakeLists.txt
+++ b/libtransmission/CMakeLists.txt
@@ -81,6 +81,8 @@ target_sources(${TR_NAME}
         makemeta.cc
         makemeta.h
         mime-types.h
+        move.cc
+        move.h
         net.cc
         net.h
         open-files.cc

--- a/libtransmission/move.cc
+++ b/libtransmission/move.cc
@@ -4,47 +4,126 @@
 // License text can be found in the licenses/ folder.
 
 #include <chrono>
+#include <cstddef> // for std::size_t
+#include <exception>
 #include <iterator> // for std::empty()
 #include <memory>
 #include <mutex>
 #include <thread>
 #include <utility> // for std::move()
 
+#include <fmt/format.h>
+
 #include "libtransmission/error.h"
+#include "libtransmission/log.h"
 #include "libtransmission/move.h"
 
 using namespace std::chrono_literals;
 
+namespace
+{
+// module name attached to every log line emitted from the move worker, so that
+// these can be filtered with `transmission-* --log-level=debug` and grepped for
+auto constexpr LogName = "move";
+} // namespace
+
 void tr_move_worker::move_thread_func()
 {
-    for (;;)
-    {
-        {
-            auto const lock = std::scoped_lock{ move_mutex_ };
+    tr_logAddInfo("Background move worker thread started", LogName);
 
-            if (std::empty(todo_))
+    try
+    {
+        for (;;)
+        {
+            auto queue_depth = std::size_t{};
+
             {
-                current_.reset();
-                move_thread_id_.reset();
-                return;
+                auto const lock = std::scoped_lock{ move_mutex_ };
+
+                if (std::empty(todo_))
+                {
+                    // Reset the id atomically with the empty-queue check: a
+                    // concurrent add() either sees the id still set (and lets
+                    // this thread pick up its job) or sees it cleared (and
+                    // spawns a fresh thread). Splitting these would strand a
+                    // queued job with no thread to run it.
+                    current_.reset();
+                    move_thread_id_.reset();
+                    tr_logAddDebug("Move queue drained; worker thread exiting normally", LogName);
+                    return;
+                }
+
+                current_ = std::move(todo_.front());
+                todo_.pop_front();
+                queue_depth = std::size(todo_);
             }
 
-            current_ = std::move(todo_.front());
-            todo_.pop_front();
-        }
+            tr_logAddInfo(fmt::format("Starting a move job; {:d} more still queued", queue_depth), LogName);
 
-        // run the blocking relocation outside the lock so that add()/remove()
-        // stay responsive while a (potentially long) copy is in progress
-        current_->on_move_started();
-        auto error = tr_error{};
-        auto const ok = current_->move(&error);
-        current_->on_move_done(ok, error ? &error : nullptr);
+            // Run the blocking relocation outside the lock so that add()/remove()
+            // stay responsive while a (potentially long) copy is in progress.
+            //
+            // Guard the whole job: a throw escaping here would otherwise call
+            // std::terminate() (killing the daemon) or leave move_thread_id_ set
+            // with no running thread, silently wedging every future relocation.
+            try
+            {
+                current_->on_move_started();
 
-        {
-            auto const lock = std::scoped_lock{ move_mutex_ };
-            current_.reset();
-            done_current_cv_.notify_all();
+                auto error = tr_error{};
+                auto const ok = current_->move(&error);
+
+                if (ok)
+                {
+                    tr_logAddInfo("Move job completed successfully", LogName);
+                }
+                else
+                {
+                    tr_logAddError(
+                        fmt::format(
+                            "Move job failed: {:s} ({:d})",
+                            error ? error.message() : "unknown error",
+                            error ? error.code() : 0),
+                        LogName);
+                }
+
+                current_->on_move_done(ok, error ? &error : nullptr);
+            }
+            catch (std::exception const& e)
+            {
+                tr_logAddError(fmt::format("Move job threw an exception and was abandoned: {:s}", e.what()), LogName);
+            }
+            catch (...)
+            {
+                tr_logAddError("Move job threw an unknown exception and was abandoned", LogName);
+            }
+
+            {
+                auto const lock = std::scoped_lock{ move_mutex_ };
+                current_.reset();
+                done_current_cv_.notify_all();
+            }
         }
+    }
+    catch (...)
+    {
+        // Last-resort guard: an exception escaped even the per-job handlers
+        // (e.g. an allocation failure while touching the queue itself). Fall
+        // through to the cleanup below rather than terminating the process.
+        tr_logAddError("Background move worker thread aborting after an unexpected error", LogName);
+    }
+
+    // Reached only on the emergency path above. Make sure the worker can be
+    // restarted by the next add() and that any remove() waiter is released.
+    auto const lock = std::scoped_lock{ move_mutex_ };
+    current_.reset();
+    move_thread_id_.reset();
+    done_current_cv_.notify_all();
+    if (!std::empty(todo_))
+    {
+        tr_logAddWarn(
+            fmt::format("Move worker exited abnormally with {:d} job(s) still queued; they will run after the next move is added", std::size(todo_)),
+            LogName);
     }
 }
 
@@ -57,9 +136,14 @@ void tr_move_worker::add(std::unique_ptr<Mediator> mediator)
 
     if (!move_thread_id_)
     {
+        tr_logAddDebug("No move worker running; spawning one", LogName);
         auto thread = std::thread(&tr_move_worker::move_thread_func, this);
         move_thread_id_ = thread.get_id();
         thread.detach();
+    }
+    else
+    {
+        tr_logAddDebug(fmt::format("Move worker already running; {:d} job(s) now queued", std::size(todo_)), LogName);
     }
 }
 
@@ -68,22 +152,53 @@ void tr_move_worker::remove(tr_sha1_digest_t const& info_hash)
     auto lock = std::unique_lock{ move_mutex_ };
 
     // a move in progress can't be interrupted safely, so wait for it to finish
+    if (current_ && current_->info_hash() == info_hash)
+    {
+        tr_logAddInfo("Waiting for an in-progress move to finish before removing the torrent", LogName);
+    }
     done_current_cv_.wait(lock, [this, &info_hash]() { return !current_ || current_->info_hash() != info_hash; });
 
     // drop any not-yet-started job for this torrent
+    auto const before = std::size(todo_);
     todo_.remove_if([&info_hash](auto const& mediator) { return mediator->info_hash() == info_hash; });
+    if (auto const dropped = before - std::size(todo_); dropped != 0U)
+    {
+        tr_logAddDebug(fmt::format("Dropped {:d} queued move job(s) for the removed torrent", dropped), LogName);
+    }
 }
 
 tr_move_worker::~tr_move_worker()
 {
     {
         auto const lock = std::scoped_lock{ move_mutex_ };
+        if (!std::empty(todo_))
+        {
+            tr_logAddWarn(fmt::format("Discarding {:d} queued move job(s) during shutdown", std::size(todo_)), LogName);
+        }
         todo_.clear();
     }
 
-    // wait for any in-progress move to drain and the worker thread to exit
-    while (move_thread_id_.has_value())
+    // wait for any in-progress move to drain and the worker thread to exit.
+    // Read move_thread_id_ under the lock: the worker mutates it under the lock,
+    // so an unlocked read here would be a data race.
+    for (auto announced = false;;)
     {
+        {
+            auto const lock = std::scoped_lock{ move_mutex_ };
+            if (!move_thread_id_.has_value())
+            {
+                break;
+            }
+
+            if (!announced)
+            {
+                tr_logAddInfo("Waiting for the in-progress move to finish before shutting down", LogName);
+                announced = true;
+            }
+        }
+
         std::this_thread::sleep_for(20ms);
     }
+
+    tr_logAddDebug("Background move worker shut down", LogName);
 }

--- a/libtransmission/move.cc
+++ b/libtransmission/move.cc
@@ -1,0 +1,89 @@
+// This file Copyright © Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
+
+#include <chrono>
+#include <iterator> // for std::empty()
+#include <memory>
+#include <mutex>
+#include <thread>
+#include <utility> // for std::move()
+
+#include "libtransmission/error.h"
+#include "libtransmission/move.h"
+
+using namespace std::chrono_literals;
+
+void tr_move_worker::move_thread_func()
+{
+    for (;;)
+    {
+        {
+            auto const lock = std::scoped_lock{ move_mutex_ };
+
+            if (std::empty(todo_))
+            {
+                current_.reset();
+                move_thread_id_.reset();
+                return;
+            }
+
+            current_ = std::move(todo_.front());
+            todo_.pop_front();
+        }
+
+        // run the blocking relocation outside the lock so that add()/remove()
+        // stay responsive while a (potentially long) copy is in progress
+        current_->on_move_started();
+        auto error = tr_error{};
+        auto const ok = current_->move(&error);
+        current_->on_move_done(ok, error ? &error : nullptr);
+
+        {
+            auto const lock = std::scoped_lock{ move_mutex_ };
+            current_.reset();
+            done_current_cv_.notify_all();
+        }
+    }
+}
+
+void tr_move_worker::add(std::unique_ptr<Mediator> mediator)
+{
+    auto const lock = std::scoped_lock{ move_mutex_ };
+
+    mediator->on_move_queued();
+    todo_.emplace_back(std::move(mediator));
+
+    if (!move_thread_id_)
+    {
+        auto thread = std::thread(&tr_move_worker::move_thread_func, this);
+        move_thread_id_ = thread.get_id();
+        thread.detach();
+    }
+}
+
+void tr_move_worker::remove(tr_sha1_digest_t const& info_hash)
+{
+    auto lock = std::unique_lock{ move_mutex_ };
+
+    // a move in progress can't be interrupted safely, so wait for it to finish
+    done_current_cv_.wait(lock, [this, &info_hash]() { return !current_ || current_->info_hash() != info_hash; });
+
+    // drop any not-yet-started job for this torrent
+    todo_.remove_if([&info_hash](auto const& mediator) { return mediator->info_hash() == info_hash; });
+}
+
+tr_move_worker::~tr_move_worker()
+{
+    {
+        auto const lock = std::scoped_lock{ move_mutex_ };
+        todo_.clear();
+    }
+
+    // wait for any in-progress move to drain and the worker thread to exit
+    while (move_thread_id_.has_value())
+    {
+        std::this_thread::sleep_for(20ms);
+    }
+}

--- a/libtransmission/move.h
+++ b/libtransmission/move.h
@@ -1,0 +1,74 @@
+// This file Copyright © Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
+
+#pragma once
+
+#ifndef __TRANSMISSION__
+#error only libtransmission should #include this header.
+#endif
+
+#include <condition_variable>
+#include <list>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <thread>
+#include <utility> // std::move
+
+#include "libtransmission/types.h"
+
+struct tr_error;
+
+// Relocates a torrent's files from one parent directory to another on a
+// dedicated background thread so that long, cross-filesystem copies do not
+// block the session (libevent) thread. Jobs are run one at a time, in the
+// order they were added. Modeled after tr_verify_worker.
+class tr_move_worker
+{
+public:
+    class Mediator
+    {
+    public:
+        virtual ~Mediator() = default;
+
+        [[nodiscard]] virtual tr_sha1_digest_t const& info_hash() const = 0;
+
+        virtual void on_move_queued() = 0;
+        virtual void on_move_started() = 0;
+
+        // Performs the blocking relocation. Called on the worker thread.
+        [[nodiscard]] virtual bool move(tr_error* error) = 0;
+
+        // Called on the worker thread once move() returns. Implementations are
+        // expected to marshal any session-state changes back to the session thread.
+        virtual void on_move_done(bool ok, tr_error const* error) = 0;
+    };
+
+    tr_move_worker() = default;
+    ~tr_move_worker();
+
+    tr_move_worker(tr_move_worker const&) = delete;
+    tr_move_worker(tr_move_worker&&) = delete;
+    tr_move_worker& operator=(tr_move_worker const&) = delete;
+    tr_move_worker& operator=(tr_move_worker&&) = delete;
+
+    void add(std::unique_ptr<Mediator> mediator);
+
+    // If a job for `info_hash` is queued, drop it. If it is already running,
+    // block until it finishes (a move in progress cannot be interrupted safely).
+    void remove(tr_sha1_digest_t const& info_hash);
+
+private:
+    void move_thread_func();
+
+    std::mutex move_mutex_;
+
+    std::list<std::unique_ptr<Mediator>> todo_;
+    std::unique_ptr<Mediator> current_;
+
+    std::optional<std::thread::id> move_thread_id_;
+
+    std::condition_variable done_current_cv_;
+};

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -2065,6 +2065,22 @@ void tr_session::verify_add(tr_torrent* const tor)
     }
 }
 
+void tr_session::move_add(std::unique_ptr<tr_move_worker::Mediator> mediator)
+{
+    if (mover_)
+    {
+        mover_->add(std::move(mediator));
+    }
+}
+
+void tr_session::move_remove(tr_torrent const* const tor)
+{
+    if (mover_)
+    {
+        mover_->remove(tor->info_hash());
+    }
+}
+
 // ---
 
 void tr_session::close_torrent_files(tr_torrent_id_t const tor_id) noexcept

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -46,6 +46,7 @@
 #include "libtransmission/ip-cache.h"
 #include "libtransmission/local-data.h"
 #include "libtransmission/log.h" // for tr_log_level
+#include "libtransmission/move.h"
 #include "libtransmission/net.h" // for tr_port, tr_tos_t
 #include "libtransmission/open-files.h"
 #include "libtransmission/platform.h"
@@ -1015,6 +1016,11 @@ public:
     void verify_add(tr_torrent* tor);
     void verify_remove(tr_torrent const* tor);
 
+    // Relocate a finished torrent's files to their destination on a background
+    // thread so that a long copy doesn't block the session thread.
+    void move_add(std::unique_ptr<tr_move_worker::Mediator> mediator);
+    void move_remove(tr_torrent const* tor);
+
     void fetch(tr_web::FetchOptions&& options) const
     {
         if (web_)
@@ -1349,6 +1355,9 @@ private:
     std::unique_ptr<tr::Timer> save_timer_;
 
     std::unique_ptr<tr_verify_worker> verifier_ = std::make_unique<tr_verify_worker>();
+
+    // depends-on: torrents_ (mediators hold raw torrent pointers)
+    std::unique_ptr<tr_move_worker> mover_ = std::make_unique<tr_move_worker>();
 
 public:
     std::unique_ptr<tr::Timer> utp_timer;

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1764,7 +1764,7 @@ tr_sha1_digest_t const& tr_torrent::MoveMediator::info_hash() const
 
 void tr_torrent::MoveMediator::on_move_queued()
 {
-    tr_logAddTraceTor(tor_, "Queued to move files");
+    tr_logAddDebugTor(tor_, fmt::format("Queued to move files from '{:s}' to '{:s}'", source_, dest_));
 }
 
 // (called from tr_move_worker's thread)
@@ -1789,6 +1789,7 @@ void tr_torrent::MoveMediator::on_move_done(bool const ok, tr_error const* const
         [tor_id = tor_->id(),
          session = tor_->session,
          ok,
+         source = source_,
          dest = dest_,
          move_from_old_path = move_from_old_path_,
          setme_state = setme_state_,
@@ -1798,11 +1799,17 @@ void tr_torrent::MoveMediator::on_move_done(bool const ok, tr_error const* const
             auto* const tor = session->torrents().get(tor_id);
             if (tor == nullptr || tor->is_deleting_)
             {
+                // The torrent was removed while its move was in flight. The
+                // files themselves were already relocated (or not) by the move;
+                // there's just no torrent left to update.
+                tr_logAddInfo(
+                    fmt::format("Move of '{:s}' -> '{:s}' finished, but the torrent is gone; skipping bookkeeping", source, dest));
                 return;
             }
 
             if (ok)
             {
+                tr_logAddInfoTor(tor, fmt::format("Finished moving files from '{:s}' to '{:s}'", source, dest));
                 tor->set_download_dir(dest);
 
                 if (move_from_old_path)
@@ -1813,13 +1820,17 @@ void tr_torrent::MoveMediator::on_move_done(bool const ok, tr_error const* const
             }
             else
             {
-                tor->error().set_local_error(
-                    fmt::format(
-                        fmt::runtime(_("Couldn't move '{old_path}' to '{path}': {error} ({error_code})")),
-                        fmt::arg("old_path", tor->current_dir()),
-                        fmt::arg("path", dest),
-                        fmt::arg("error", error_message),
-                        fmt::arg("error_code", error_code)));
+                // Report the directory the move actually started from (`source`),
+                // not current_dir(): the latter may have drifted while the copy
+                // ran on the worker thread, which would make the message lie.
+                auto const message = fmt::format(
+                    fmt::runtime(_("Couldn't move '{old_path}' to '{path}': {error} ({error_code})")),
+                    fmt::arg("old_path", source),
+                    fmt::arg("path", dest),
+                    fmt::arg("error", error_message),
+                    fmt::arg("error_code", error_code));
+                tr_logAddErrorTor(tor, std::string{ message });
+                tor->error().set_local_error(message);
                 tr_torrentStop(tor);
             }
 

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -585,6 +585,10 @@ void freeTorrent(tr_torrent* tor)
 
     tr_session* session = tor->session;
 
+    // make sure no background move is still relocating this torrent's files,
+    // since the move worker holds a raw pointer to it
+    session->move_remove(tor);
+
     tor->doomed_(tor);
 
     session->announcer_->removeTorrent(tor);
@@ -1090,49 +1094,48 @@ void tr_torrent::set_location_in_session_thread(std::string_view const path, boo
 {
     TR_ASSERT(session->am_in_session_thread());
 
-    auto ok = true;
-    if (move_from_old_path)
+    // a relocation is already in flight; ignore the duplicate request rather
+    // than racing two moves or repointing the directory mid-copy
+    if (is_moving())
     {
+        tr_logAddWarnTor(this, "Ignoring location change: a move is already in progress");
+
         if (setme_state != nullptr)
         {
-            *setme_state = TR_LOC_MOVING;
+            *setme_state = TR_LOC_ERROR;
         }
 
-        // ensure the files are all closed and idle before moving
-        session->close_torrent_files(id());
-        session->verify_remove(this);
-
-        auto error = tr_error{};
-        ok = files().move(current_dir(), path, name(), &error);
-        if (error)
-        {
-            this->error().set_local_error(
-                fmt::format(
-                    fmt::runtime(_("Couldn't move '{old_path}' to '{path}': {error} ({error_code})")),
-                    fmt::arg("old_path", current_dir()),
-                    fmt::arg("path", path),
-                    fmt::arg("error", error.message()),
-                    fmt::arg("error_code", error.code())));
-            tr_torrentStop(this);
-        }
+        return;
     }
 
-    // tell the torrent where the files are
-    if (ok)
+    if (!move_from_old_path)
     {
+        // just point the torrent at the new directory; nothing to relocate
         set_download_dir(path);
 
-        if (move_from_old_path)
+        if (setme_state != nullptr)
         {
-            incomplete_dir_.clear();
-            current_dir_ = download_dir();
+            *setme_state = TR_LOC_DONE;
         }
+
+        return;
     }
+
+    // ensure the files are all closed and idle before moving
+    session->close_torrent_files(id());
+    session->verify_remove(this);
+
+    // Relocate on the background move thread so that a long (cross-filesystem)
+    // copy doesn't block the session thread. The bookkeeping is finished in
+    // MoveMediator::on_move_done() once the copy completes.
+    set_location_state(LocationState::Moving);
 
     if (setme_state != nullptr)
     {
-        *setme_state = ok ? TR_LOC_DONE : TR_LOC_ERROR;
+        *setme_state = TR_LOC_MOVING;
     }
+
+    session->move_add(std::make_unique<MoveMediator>(this, current_dir().sv(), path, move_from_old_path, setme_state));
 }
 
 namespace
@@ -1748,6 +1751,101 @@ void tr_torrent::VerifyMediator::on_verify_done(bool const aborted)
 
 // ---
 
+void tr_torrent::set_location_state(LocationState const state)
+{
+    location_state_ = state;
+    mark_changed();
+}
+
+tr_sha1_digest_t const& tr_torrent::MoveMediator::info_hash() const
+{
+    return tor_->info_hash();
+}
+
+void tr_torrent::MoveMediator::on_move_queued()
+{
+    tr_logAddTraceTor(tor_, "Queued to move files");
+}
+
+// (called from tr_move_worker's thread)
+void tr_torrent::MoveMediator::on_move_started()
+{
+    tr_logAddDebugTor(tor_, fmt::format("Moving files from '{:s}' to '{:s}'", source_, dest_));
+}
+
+// (called from tr_move_worker's thread)
+bool tr_torrent::MoveMediator::move(tr_error* const error)
+{
+    return tor_->files().move(source_, dest_, tor_->name(), error);
+}
+
+// (called from tr_move_worker's thread)
+void tr_torrent::MoveMediator::on_move_done(bool const ok, tr_error const* const error)
+{
+    // Finish the relocation bookkeeping on the session thread. Capture the
+    // torrent id (not the pointer) so we never touch a torrent that has been
+    // freed while the move was running.
+    tor_->session->run_in_session_thread(
+        [tor_id = tor_->id(),
+         session = tor_->session,
+         ok,
+         dest = dest_,
+         move_from_old_path = move_from_old_path_,
+         setme_state = setme_state_,
+         error_message = error != nullptr ? std::string{ error->message() } : std::string{},
+         error_code = error != nullptr ? error->code() : 0]()
+        {
+            auto* const tor = session->torrents().get(tor_id);
+            if (tor == nullptr || tor->is_deleting_)
+            {
+                return;
+            }
+
+            if (ok)
+            {
+                tor->set_download_dir(dest);
+
+                if (move_from_old_path)
+                {
+                    tor->incomplete_dir_.clear();
+                    tor->current_dir_ = tor->download_dir();
+                }
+            }
+            else
+            {
+                tor->error().set_local_error(
+                    fmt::format(
+                        fmt::runtime(_("Couldn't move '{old_path}' to '{path}': {error} ({error_code})")),
+                        fmt::arg("old_path", tor->current_dir()),
+                        fmt::arg("path", dest),
+                        fmt::arg("error", error_message),
+                        fmt::arg("error_code", error_code)));
+                tr_torrentStop(tor);
+            }
+
+            tor->set_location_state(LocationState::None);
+
+            if (setme_state != nullptr)
+            {
+                *setme_state = ok ? TR_LOC_DONE : TR_LOC_ERROR;
+            }
+
+            tor->set_dirty();
+            tor->save_resume_file();
+
+            // run the deferred post-completion script now that the files are
+            // at their final location (see recheck_completeness())
+            auto const run_done_script = ok && tor->done_script_after_move_;
+            tor->done_script_after_move_ = false;
+            if (run_done_script)
+            {
+                callScriptIfEnabled(tor, TR_SCRIPT_ON_TORRENT_DONE);
+            }
+        });
+}
+
+// ---
+
 void tr_torrent::save_resume_file()
 {
     if (!is_dirty())
@@ -1866,6 +1964,10 @@ void tr_torrent::recheck_completeness()
 
             if (current_dir() == incomplete_dir())
             {
+                // The files are relocated to their final home on a background
+                // thread; defer the "done" bookkeeping (resume save + script)
+                // until the move finishes so the script sees the final location.
+                done_script_after_move_ = true;
                 set_location(download_dir(), true, nullptr);
             }
 
@@ -1877,7 +1979,7 @@ void tr_torrent::recheck_completeness()
         set_dirty();
         mark_changed();
 
-        if (is_done())
+        if (is_done() && !is_moving())
         {
             save_resume_file();
             callScriptIfEnabled(this, TR_SCRIPT_ON_TORRENT_DONE);

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -32,6 +32,7 @@
 #include "libtransmission/file-piece-map.h"
 #include "libtransmission/interned-string.h"
 #include "libtransmission/log.h"
+#include "libtransmission/move.h"
 #include "libtransmission/session.h"
 #include "libtransmission/torrent-files.h"
 #include "libtransmission/torrent-magnet.h"
@@ -169,6 +170,44 @@ struct tr_torrent
     private:
         tr_torrent* const tor_;
         std::optional<time_t> time_started_;
+    };
+
+    // Relocates a torrent's files on tr_move_worker's background thread.
+    // Lifetime safety mirrors VerifyMediator: the raw torrent pointer stays
+    // valid because tr_session::move_remove() is called before the torrent is
+    // freed and blocks until any in-progress move finishes.
+    class MoveMediator : public tr_move_worker::Mediator
+    {
+    public:
+        MoveMediator(
+            tr_torrent* tor,
+            std::string_view source,
+            std::string_view dest,
+            bool move_from_old_path,
+            int volatile* setme_state)
+            : tor_{ tor }
+            , source_{ source }
+            , dest_{ dest }
+            , move_from_old_path_{ move_from_old_path }
+            , setme_state_{ setme_state }
+        {
+        }
+
+        ~MoveMediator() override = default;
+
+        [[nodiscard]] tr_sha1_digest_t const& info_hash() const override;
+
+        void on_move_queued() override;
+        void on_move_started() override;
+        [[nodiscard]] bool move(tr_error* error) override;
+        void on_move_done(bool ok, tr_error const* error) override;
+
+    private:
+        tr_torrent* const tor_;
+        std::string const source_;
+        std::string const dest_;
+        bool const move_from_old_path_;
+        int volatile* const setme_state_;
     };
 
     // ---
@@ -691,6 +730,12 @@ struct tr_torrent
         return this->is_piece_transfer_allowed(tr_direction::ClientToPeer);
     }
 
+    // true while the torrent's files are being relocated on the background move thread
+    [[nodiscard]] constexpr bool is_moving() const noexcept
+    {
+        return location_state_ == LocationState::Moving;
+    }
+
     void set_download_dir(std::string_view path, bool is_new_torrent = false);
 
     void refresh_current_dir();
@@ -1063,6 +1108,13 @@ private:
         Active
     };
 
+    enum class LocationState : uint8_t
+    {
+        None,
+        // files are being relocated on the background move thread
+        Moving
+    };
+
     // Tracks a torrent's error state, either local (e.g. file IO errors)
     // or tracker errors (e.g. warnings returned by a tracker).
     class Error
@@ -1226,6 +1278,13 @@ private:
 
     [[nodiscard]] constexpr bool is_piece_transfer_allowed(tr_direction direction) const noexcept
     {
+        // don't serve data while the files are being relocated: the file
+        // currently being copied is only partially present at its destination
+        if (is_moving())
+        {
+            return false;
+        }
+
         if (uses_speed_limit(direction) && speed_limit(direction).is_zero())
         {
             return false;
@@ -1263,6 +1322,8 @@ private:
     }
 
     void set_verify_state(VerifyState state);
+
+    void set_location_state(LocationState state);
 
     [[nodiscard]] constexpr std::optional<float> verify_progress() const noexcept
     {
@@ -1426,11 +1487,16 @@ private:
 
     VerifyState verify_state_ = VerifyState::None;
 
+    LocationState location_state_ = LocationState::None;
+
     tr_completeness completeness_ = TR_LEECH;
 
     uint16_t idle_limit_minutes_ = 0;
 
     uint16_t max_connected_peers_ = TrDefaultPeerLimitTorrent;
+
+    // when true, run TR_SCRIPT_ON_TORRENT_DONE once the post-completion move finishes
+    bool done_script_after_move_ = false;
 
     bool is_deleting_ = false;
     bool is_dirty_ = false;

--- a/tests/libtransmission/move-test.cc
+++ b/tests/libtransmission/move-test.cc
@@ -4,22 +4,33 @@
 // License text can be found in the licenses/ folder.
 
 #include <algorithm>
+#include <atomic>
+#include <cerrno>
+#include <chrono>
+#include <cstddef> // std::byte
+#include <cstdint>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <string_view>
+#include <thread>
 #include <utility>
+#include <vector>
 
 #include <gtest/gtest.h>
 
 #include <libtransmission/transmission.h>
 
 #include <libtransmission/block-info.h>
+#include <libtransmission/error.h>
 #include <libtransmission/file.h> // tr_sys_path_*()
 #include <libtransmission/inout.h>
+#include <libtransmission/move.h>
 #include <libtransmission/quark.h>
 #include <libtransmission/torrent-files.h>
 #include <libtransmission/torrent.h>
 #include <libtransmission/tr-strbuf.h>
+#include <libtransmission/types.h>
 #include <libtransmission/variant.h>
 
 #include "test-fixtures.h"
@@ -309,6 +320,451 @@ TEST_F(MoveTest, setLocationWithoutMovingUpdatesDownloadDir)
     EXPECT_EQ(target_dir.sv(), tr_torrentGetDownloadDir(tor));
 
     tr_torrentRemove(tor, true);
+}
+
+// When the relocation fails, the torrent must end up in the error state, be
+// stopped, keep its files where they were, and report a message that names the
+// directory the move actually started from (not a drifted current_dir()).
+TEST_F(MoveTest, setLocationFailureReportsErrorAndStops)
+{
+    // make the destination impossible to create: drop a regular file exactly
+    // where the destination directory would have to be created. This fails
+    // deterministically regardless of the uid the tests run as (so it's stable
+    // even under a root CI), unlike chmod-based permission tricks.
+    auto const blocker = tr_pathbuf{ session_->configDir(), "/blocked"sv };
+    createFileWithContents(blocker.sv(), "not a directory"sv);
+    EXPECT_TRUE(tr_sys_path_exists(blocker));
+
+    auto* const tor = zeroTorrentInit(ZeroTorrentState::Complete);
+    blockingTorrentVerify(tor);
+    EXPECT_EQ(0, tr_torrentStat(tor).left_until_done);
+
+    auto const source_dir = std::string{ tr_torrentGetDownloadDir(tor) };
+
+    auto state = -1;
+    tr_torrentSetLocation(tor, blocker, true, &state);
+    EXPECT_TRUE(waitFor([&state]() { return state == TR_LOC_ERROR; }, MaxWaitMsec));
+    EXPECT_EQ(TR_LOC_ERROR, state);
+
+    // the failed move must surface as a local error on the torrent...
+    auto const stat = tr_torrentStat(tor);
+    EXPECT_EQ(tr_stat::Error::LocalError, stat.error);
+    // ...whose message names the real source directory, not current_dir()
+    EXPECT_NE(std::string::npos, stat.error_string.find(source_dir)) << "error was: " << stat.error_string;
+
+    // ...and the data must still be at its original location, untouched
+    sync();
+    auto const n = tr_torrentFileCount(tor);
+    for (tr_file_index_t i = 0; i < n; ++i)
+    {
+        auto const expected = tr_pathbuf{ source_dir, '/', tr_torrentFile(tor, i).name };
+        EXPECT_EQ(expected, tr_torrentFindFile(tor, i));
+    }
+
+    tr_torrentRemove(tor, true);
+}
+
+/***
+****  tr_move_worker unit tests
+****
+****  These exercise the background mover in isolation with a mock Mediator, so
+****  the failure/exception/teardown paths can be tested deterministically
+****  without touching the filesystem or a live session.
+***/
+
+namespace
+{
+
+[[nodiscard]] tr_sha1_digest_t make_info_hash(uint8_t const seed)
+{
+    auto hash = tr_sha1_digest_t{};
+    hash[0] = std::byte{ seed };
+    return hash;
+}
+
+// Shared, thread-safe record of what the worker did. Must outlive the worker
+// (the worker owns the mediators and may touch them on its own thread), so in
+// every test it is declared before the tr_move_worker.
+struct Recorder
+{
+    std::mutex mutex;
+    std::vector<std::string> events;
+
+    std::atomic<int> queued = 0;
+    std::atomic<int> started = 0;
+    std::atomic<int> moved = 0;
+    std::atomic<int> done = 0;
+    std::atomic<int> ok_count = 0;
+    std::atomic<int> fail_count = 0;
+
+    std::atomic<int> active = 0; // moves currently executing
+    std::atomic<int> max_active = 0; // high-water mark; must stay 1 (serialized)
+
+    std::atomic<bool> gate_open = true; // gated mediators block in move() until true
+
+    void push(std::string event)
+    {
+        auto const lock = std::scoped_lock{ mutex };
+        events.push_back(std::move(event));
+    }
+
+    void enter_move()
+    {
+        auto const n = ++active;
+        auto prev = max_active.load();
+        while (prev < n && !max_active.compare_exchange_weak(prev, n))
+        {
+        }
+    }
+
+    void leave_move()
+    {
+        --active;
+    }
+
+    [[nodiscard]] std::vector<std::string> started_tags()
+    {
+        auto const lock = std::scoped_lock{ mutex };
+        auto tags = std::vector<std::string>{};
+        for (auto const& event : events)
+        {
+            if (auto constexpr Prefix = "started:"sv; event.starts_with(Prefix))
+            {
+                tags.emplace_back(event.substr(std::size(Prefix)));
+            }
+        }
+        return tags;
+    }
+};
+
+class MockMediator final : public tr_move_worker::Mediator
+{
+public:
+    enum class Fault : uint8_t
+    {
+        None,
+        MoveReturnsFalse,
+        ThrowInStarted,
+        ThrowInMove,
+        ThrowInDone,
+    };
+
+    MockMediator(uint8_t const seed, Recorder* const rec, Fault const fault = Fault::None, bool const gated = false)
+        : hash_{ make_info_hash(seed) }
+        , tag_{ std::to_string(seed) }
+        , rec_{ rec }
+        , fault_{ fault }
+        , gated_{ gated }
+    {
+    }
+
+    [[nodiscard]] tr_sha1_digest_t const& info_hash() const override
+    {
+        return hash_;
+    }
+
+    void on_move_queued() override
+    {
+        ++rec_->queued;
+        rec_->push("queued:" + tag_);
+    }
+
+    void on_move_started() override
+    {
+        ++rec_->started;
+        rec_->push("started:" + tag_);
+        if (fault_ == Fault::ThrowInStarted)
+        {
+            throw std::runtime_error{ "on_move_started boom" };
+        }
+    }
+
+    bool move(tr_error* const error) override
+    {
+        rec_->push("move:" + tag_);
+        ++rec_->moved;
+
+        rec_->enter_move();
+        // make sure the decrement happens even if we throw below
+        auto const guard = MoveGuard{ rec_ };
+
+        if (gated_)
+        {
+            auto const deadline = std::chrono::steady_clock::now() + 5s;
+            while (!rec_->gate_open.load() && std::chrono::steady_clock::now() < deadline)
+            {
+                std::this_thread::sleep_for(1ms);
+            }
+        }
+
+        if (fault_ == Fault::ThrowInMove)
+        {
+            throw std::runtime_error{ "move boom" };
+        }
+
+        if (fault_ == Fault::MoveReturnsFalse)
+        {
+            if (error != nullptr)
+            {
+                error->set(EACCES, "mock move failure"sv);
+            }
+            return false;
+        }
+
+        return true;
+    }
+
+    void on_move_done(bool const ok, tr_error const* const /*error*/) override
+    {
+        ++rec_->done;
+        if (ok)
+        {
+            ++rec_->ok_count;
+        }
+        else
+        {
+            ++rec_->fail_count;
+        }
+        rec_->push("done:" + tag_ + (ok ? ":ok" : ":fail"));
+
+        if (fault_ == Fault::ThrowInDone)
+        {
+            throw std::runtime_error{ "on_move_done boom" };
+        }
+    }
+
+private:
+    struct MoveGuard
+    {
+        Recorder* rec;
+        ~MoveGuard()
+        {
+            rec->leave_move();
+        }
+    };
+
+    tr_sha1_digest_t const hash_;
+    std::string const tag_;
+    Recorder* const rec_;
+    Fault const fault_;
+    bool const gated_;
+};
+
+} // namespace
+
+using namespace std::chrono_literals;
+
+using MoveWorkerTest = TransmissionTest;
+
+TEST_F(MoveWorkerTest, runsSingleJobToCompletion)
+{
+    auto rec = Recorder{};
+    {
+        auto worker = tr_move_worker{};
+        worker.add(std::make_unique<MockMediator>(1, &rec));
+        EXPECT_TRUE(waitFor([&rec]() { return rec.done.load() == 1; }, MaxWaitMsec));
+    }
+
+    EXPECT_EQ(1, rec.queued.load());
+    EXPECT_EQ(1, rec.started.load());
+    EXPECT_EQ(1, rec.moved.load());
+    EXPECT_EQ(1, rec.done.load());
+    EXPECT_EQ(1, rec.ok_count.load());
+    EXPECT_EQ((std::vector<std::string>{ "queued:1", "started:1", "move:1", "done:1:ok" }), rec.events);
+}
+
+TEST_F(MoveWorkerTest, queuesAndRunsInFifoOrder)
+{
+    auto rec = Recorder{};
+    rec.gate_open.store(false);
+    {
+        auto worker = tr_move_worker{};
+        worker.add(std::make_unique<MockMediator>(1, &rec, MockMediator::Fault::None, /*gated=*/true));
+        worker.add(std::make_unique<MockMediator>(2, &rec));
+        worker.add(std::make_unique<MockMediator>(3, &rec));
+
+        // job 1 is parked in move(); 2 and 3 must be sitting in the queue
+        EXPECT_TRUE(waitFor([&rec]() { return rec.moved.load() == 1; }, MaxWaitMsec));
+        EXPECT_EQ(3, rec.queued.load());
+        EXPECT_EQ(1, rec.started.load());
+        EXPECT_EQ(0, rec.done.load());
+
+        rec.gate_open.store(true);
+        EXPECT_TRUE(waitFor([&rec]() { return rec.done.load() == 3; }, MaxWaitMsec));
+    }
+
+    EXPECT_EQ(3, rec.ok_count.load());
+    EXPECT_EQ(1, rec.max_active.load()); // never two moves running at once
+    EXPECT_EQ((std::vector<std::string>{ "1", "2", "3" }), rec.started_tags());
+}
+
+TEST_F(MoveWorkerTest, failingMoveDoesNotStopTheQueue)
+{
+    auto rec = Recorder{};
+    {
+        auto worker = tr_move_worker{};
+        worker.add(std::make_unique<MockMediator>(1, &rec, MockMediator::Fault::MoveReturnsFalse));
+        worker.add(std::make_unique<MockMediator>(2, &rec));
+        EXPECT_TRUE(waitFor([&rec]() { return rec.done.load() == 2; }, MaxWaitMsec));
+    }
+
+    EXPECT_EQ(2, rec.done.load());
+    EXPECT_EQ(1, rec.ok_count.load()); // only job 2 succeeded
+    EXPECT_EQ(1, rec.fail_count.load()); // job 1 reported failure but didn't stall the queue
+}
+
+// The headline robustness test: a move() that throws must NOT terminate the
+// process or wedge the worker. Before the fix this crashed (std::terminate) or
+// left every future relocation queued forever.
+TEST_F(MoveWorkerTest, throwingMoveDoesNotWedgeWorker)
+{
+    auto rec = Recorder{};
+    {
+        auto worker = tr_move_worker{};
+        worker.add(std::make_unique<MockMediator>(1, &rec, MockMediator::Fault::ThrowInMove));
+        worker.add(std::make_unique<MockMediator>(2, &rec));
+        // job 2 must still run to completion even though job 1 threw
+        EXPECT_TRUE(waitFor([&rec]() { return rec.ok_count.load() == 1; }, MaxWaitMsec));
+    }
+
+    EXPECT_EQ(2, rec.started.load()); // both jobs were picked up
+    EXPECT_EQ(1, rec.ok_count.load()); // job 2 finished cleanly
+}
+
+TEST_F(MoveWorkerTest, throwingOnMoveStartedDoesNotWedgeWorker)
+{
+    auto rec = Recorder{};
+    {
+        auto worker = tr_move_worker{};
+        worker.add(std::make_unique<MockMediator>(1, &rec, MockMediator::Fault::ThrowInStarted));
+        worker.add(std::make_unique<MockMediator>(2, &rec));
+        EXPECT_TRUE(waitFor([&rec]() { return rec.ok_count.load() == 1; }, MaxWaitMsec));
+    }
+
+    EXPECT_EQ(2, rec.started.load());
+    EXPECT_EQ(1, rec.moved.load()); // job 1 threw before its move() ran
+    EXPECT_EQ(1, rec.ok_count.load());
+}
+
+TEST_F(MoveWorkerTest, throwingOnMoveDoneDoesNotWedgeWorker)
+{
+    auto rec = Recorder{};
+    {
+        auto worker = tr_move_worker{};
+        worker.add(std::make_unique<MockMediator>(1, &rec, MockMediator::Fault::ThrowInDone));
+        worker.add(std::make_unique<MockMediator>(2, &rec));
+        EXPECT_TRUE(waitFor([&rec]() { return rec.done.load() == 2; }, MaxWaitMsec));
+    }
+
+    EXPECT_EQ(2, rec.done.load());
+    EXPECT_EQ(2, rec.ok_count.load()); // both moves succeeded; job 1 just threw afterwards
+}
+
+TEST_F(MoveWorkerTest, removeDropsQueuedJob)
+{
+    auto rec = Recorder{};
+    rec.gate_open.store(false);
+    {
+        auto worker = tr_move_worker{};
+        worker.add(std::make_unique<MockMediator>(1, &rec, MockMediator::Fault::None, /*gated=*/true));
+        worker.add(std::make_unique<MockMediator>(2, &rec));
+
+        // job 1 is running (gated); job 2 is still queued
+        EXPECT_TRUE(waitFor([&rec]() { return rec.moved.load() == 1; }, MaxWaitMsec));
+
+        // drop job 2 before it ever starts
+        worker.remove(make_info_hash(2));
+
+        rec.gate_open.store(true);
+        EXPECT_TRUE(waitFor([&rec]() { return rec.done.load() == 1; }, MaxWaitMsec));
+        std::this_thread::sleep_for(50ms); // give a removed job a chance to (wrongly) run
+    }
+
+    EXPECT_EQ(2, rec.queued.load()); // both were enqueued
+    EXPECT_EQ(1, rec.started.load()); // but job 2 never started
+    EXPECT_EQ(1, rec.done.load());
+}
+
+TEST_F(MoveWorkerTest, removeWaitsForInProgressJob)
+{
+    auto rec = Recorder{};
+    rec.gate_open.store(false);
+
+    auto worker = tr_move_worker{};
+    worker.add(std::make_unique<MockMediator>(1, &rec, MockMediator::Fault::None, /*gated=*/true));
+    EXPECT_TRUE(waitFor([&rec]() { return rec.moved.load() == 1; }, MaxWaitMsec));
+
+    // removing the in-flight torrent must block until its move finishes
+    auto remove_returned = std::atomic<bool>{ false };
+    auto remover = std::thread(
+        [&worker, &remove_returned]()
+        {
+            worker.remove(make_info_hash(1));
+            remove_returned.store(true);
+        });
+
+    std::this_thread::sleep_for(100ms);
+    EXPECT_FALSE(remove_returned.load()); // still blocked while the move runs
+    EXPECT_EQ(0, rec.done.load());
+
+    rec.gate_open.store(true);
+    EXPECT_TRUE(waitFor([&remove_returned]() { return remove_returned.load(); }, MaxWaitMsec));
+    EXPECT_EQ(1, rec.done.load()); // the move completed before remove() returned
+
+    remover.join();
+}
+
+TEST_F(MoveWorkerTest, destructorDrainsInFlightJob)
+{
+    auto rec = Recorder{};
+    rec.gate_open.store(false);
+
+    auto opener = std::thread{};
+    {
+        auto worker = tr_move_worker{};
+        worker.add(std::make_unique<MockMediator>(1, &rec, MockMediator::Fault::None, /*gated=*/true));
+        EXPECT_TRUE(waitFor([&rec]() { return rec.moved.load() == 1; }, MaxWaitMsec));
+
+        // release the gate slightly later so the job is genuinely in-flight as
+        // ~tr_move_worker begins draining
+        opener = std::thread(
+            [&rec]()
+            {
+                std::this_thread::sleep_for(50ms);
+                rec.gate_open.store(true);
+            });
+
+        // leaving this scope destroys the worker, which must block until the
+        // in-flight move drains rather than abandoning it
+    }
+
+    opener.join();
+    EXPECT_EQ(1, rec.done.load());
+    EXPECT_EQ(1, rec.ok_count.load());
+}
+
+TEST_F(MoveWorkerTest, workerRestartsAfterQueueDrains)
+{
+    auto rec = Recorder{};
+    auto worker = tr_move_worker{};
+
+    worker.add(std::make_unique<MockMediator>(1, &rec));
+    EXPECT_TRUE(waitFor([&rec]() { return rec.done.load() == 1; }, MaxWaitMsec));
+
+    // let the worker thread notice the empty queue and exit
+    std::this_thread::sleep_for(50ms);
+
+    // a fresh add() must spin the worker back up
+    worker.add(std::make_unique<MockMediator>(2, &rec));
+    EXPECT_TRUE(waitFor([&rec]() { return rec.done.load() == 2; }, MaxWaitMsec));
+    EXPECT_EQ(2, rec.ok_count.load());
+}
+
+TEST_F(MoveWorkerTest, removeOnIdleWorkerIsNoop)
+{
+    auto worker = tr_move_worker{};
+    worker.remove(make_info_hash(42)); // must return immediately, not hang or crash
+    SUCCEED();
 }
 
 } // namespace tr::test

--- a/tests/libtransmission/move-test.cc
+++ b/tests/libtransmission/move-test.cc
@@ -131,12 +131,22 @@ TEST_P(IncompleteDirTest, incompleteDir)
     EXPECT_TRUE(waitFor(test, MaxWaitMsec));
     EXPECT_EQ(TR_SEED, completeness);
 
+    // the files are relocated to the download dir on a background thread,
+    // so wait for the move to finish before checking their final location
     auto const n = tr_torrentFileCount(tor);
-    for (tr_file_index_t i = 0; i < n; ++i)
+    auto const files_moved = [tor, &download_dir, n]()
     {
-        auto const expected = tr_pathbuf{ download_dir, '/', tr_torrentFile(tor, i).name };
-        EXPECT_EQ(expected, tr_torrentFindFile(tor, i));
-    }
+        for (tr_file_index_t i = 0; i < n; ++i)
+        {
+            auto const expected = tr_pathbuf{ download_dir, '/', tr_torrentFile(tor, i).name };
+            if (expected != tr_torrentFindFile(tor, i))
+            {
+                return false;
+            }
+        }
+        return true;
+    };
+    EXPECT_TRUE(waitFor(files_moved, MaxWaitMsec));
 
     // cleanup
     tr_torrentRemove(tor, true);
@@ -193,6 +203,111 @@ TEST_F(MoveTest, setLocation)
     }
 
     // cleanup
+    tr_torrentRemove(tor, true);
+}
+
+// The relocation runs on a background thread and is expected to create the
+// destination directory tree if it does not already exist.
+TEST_F(MoveTest, setLocationCreatesDestination)
+{
+    // a deliberately not-yet-existing, nested destination
+    auto const target_dir = tr_pathbuf{ session_->configDir(), "/new/nested/target"sv };
+    EXPECT_FALSE(tr_sys_path_exists(target_dir));
+
+    auto* const tor = zeroTorrentInit(ZeroTorrentState::Complete);
+    blockingTorrentVerify(tor);
+    EXPECT_EQ(0, tr_torrentStat(tor).left_until_done);
+
+    // move it; the background move thread should create the destination
+    auto state = -1;
+    tr_torrentSetLocation(tor, target_dir, true, &state);
+    auto const moved = [&state]()
+    {
+        return state == TR_LOC_DONE;
+    };
+    EXPECT_TRUE(waitFor(moved, MaxWaitMsec));
+    EXPECT_EQ(TR_LOC_DONE, state);
+
+    // confirm the files ended up at the new location...
+    sync();
+    auto const n = tr_torrentFileCount(tor);
+    for (tr_file_index_t i = 0; i < n; ++i)
+    {
+        auto const expected = tr_pathbuf{ target_dir, '/', tr_torrentFile(tor, i).name };
+        EXPECT_EQ(expected, tr_torrentFindFile(tor, i));
+    }
+
+    // ...and that the torrent is still complete
+    blockingTorrentVerify(tor);
+    EXPECT_EQ(0, tr_torrentStat(tor).left_until_done);
+
+    tr_torrentRemove(tor, true);
+}
+
+// Two relocations of the same torrent are serialized through the move worker;
+// the second one must observe the bookkeeping left by the first.
+TEST_F(MoveTest, setLocationMoveBackAndForth)
+{
+    auto const original_dir = tr_pathbuf{ tr_sessionGetDownloadDir(session_) };
+    auto const target_dir = tr_pathbuf{ session_->configDir(), "/elsewhere"sv };
+    tr_sys_dir_create(target_dir, TR_SYS_DIR_CREATE_PARENTS, 0777, nullptr);
+
+    auto* const tor = zeroTorrentInit(ZeroTorrentState::Complete);
+    blockingTorrentVerify(tor);
+    EXPECT_EQ(0, tr_torrentStat(tor).left_until_done);
+
+    auto const n = tr_torrentFileCount(tor);
+    auto const files_in = [tor, n](tr_pathbuf const& dir)
+    {
+        for (tr_file_index_t i = 0; i < n; ++i)
+        {
+            if (tr_pathbuf{ dir, '/', tr_torrentFile(tor, i).name } != tr_torrentFindFile(tor, i))
+            {
+                return false;
+            }
+        }
+        return true;
+    };
+
+    // move out...
+    auto state = -1;
+    tr_torrentSetLocation(tor, target_dir, true, &state);
+    EXPECT_TRUE(waitFor([&state]() { return state == TR_LOC_DONE; }, MaxWaitMsec));
+    sync();
+    EXPECT_TRUE(files_in(target_dir));
+
+    // ...and back again
+    state = -1;
+    tr_torrentSetLocation(tor, original_dir, true, &state);
+    EXPECT_TRUE(waitFor([&state]() { return state == TR_LOC_DONE; }, MaxWaitMsec));
+    sync();
+    EXPECT_TRUE(files_in(original_dir));
+
+    // the round trip preserved the data
+    blockingTorrentVerify(tor);
+    EXPECT_EQ(0, tr_torrentStat(tor).left_until_done);
+
+    tr_torrentRemove(tor, true);
+}
+
+// When move_from_old_path is false the files are left in place and only the
+// torrent's download dir is repointed.
+TEST_F(MoveTest, setLocationWithoutMovingUpdatesDownloadDir)
+{
+    auto const target_dir = tr_pathbuf{ session_->configDir(), "/already-there"sv };
+    tr_sys_dir_create(target_dir, TR_SYS_DIR_CREATE_PARENTS, 0777, nullptr);
+
+    auto* const tor = zeroTorrentInit(ZeroTorrentState::Complete);
+    blockingTorrentVerify(tor);
+
+    auto state = -1;
+    tr_torrentSetLocation(tor, target_dir, false, &state);
+    EXPECT_TRUE(waitFor([&state]() { return state == TR_LOC_DONE; }, MaxWaitMsec));
+    EXPECT_EQ(TR_LOC_DONE, state);
+
+    // the torrent now points at the new dir even though nothing was relocated
+    EXPECT_EQ(target_dir.sv(), tr_torrentGetDownloadDir(tor));
+
     tr_torrentRemove(tor, true);
 }
 


### PR DESCRIPTION
## Motivation

When an incomplete directory is configured, Transmission moves a torrent's files
from the incomplete dir to the download dir as soon as the download completes.
That move currently runs **synchronously on the session (libevent) thread**.

When the two directories live on different filesystems (SSD → HDD, local disk →
NAS/SMB share, a different LUKS volume, etc.), `rename()` returns `EXDEV` and
Transmission falls back to copy-then-delete. The copy can take anywhere from a
few seconds to several minutes, and for its **entire duration the session thread
is blocked**: RPC stops answering, the GUI/daemon appears frozen, peer messaging
stalls, and every other torrent makes no progress until the copy finishes.

This PR moves that relocation onto a dedicated background worker so the session
thread — and therefore the whole client — stays responsive while the copy runs.

## Approach

The change mirrors the existing `tr_verify_worker`, which already solves the same
shape of problem (a long, blocking, I/O-bound, per-torrent job) by running it on a
dedicated background thread with a `Mediator` callback interface and marshalling
results back to the session thread.

- **New `tr_move_worker`** (`libtransmission/move.{h,cc}`): a serialized
  background mover (one move at a time, to avoid thrashing the disk with
  concurrent copies — same rationale as serialized verification) with a
  `Mediator` interface, drain-on-destroy, and `add`/`remove` semantics.
- **`set_location_in_session_thread` split into three phases**: *prep* on the
  session thread (close files, cancel verification, mark the torrent as moving),
  *copy* on the worker thread (`tr_torrent_files::move`), and *finalize* back on
  the session thread (repoint the download dir, clear the incomplete dir, update
  status, save resume, handle errors). The finalize re-resolves the torrent by id
  so it can never touch a torrent that was freed while the copy was running.
- **Piece transfers are gated while a torrent is moving**, so a peer is never
  served the single file that is currently only partially present at its
  destination.
- **`TR_SCRIPT_ON_TORRENT_DONE` and the final resume-save are deferred** until the
  relocation finishes, so the "done" script still sees the files at their final
  location (preserving the previous ordering).
- **Torrent teardown blocks on any in-flight move** for that torrent before the
  object is freed (the worker holds a raw torrent pointer, exactly like the
  verifier).

The public API (`tr_torrentSetLocation`, the RPC `torrent-set-location`) is
unchanged; manual relocations benefit from the same non-blocking behavior.

## Notes / edge cases

- Same-filesystem moves remain fast `rename()`s; they simply run on the worker
  thread now (negligible overhead, no blocking).
- A relocation requested while one is already in flight for the same torrent is
  rejected rather than racing two moves.
- On move failure the torrent is stopped with a local error, as before.

## Testing

Unit tests (gtest, `tests/libtransmission/move-test.cc`):

- `IncompleteDirTest` updated to await the now-asynchronous auto-move.
- `setLocationCreatesDestination` — the background move creates a missing nested
  destination tree.
- `setLocationMoveBackAndForth` — two serialized relocations; the second observes
  the first's bookkeeping.
- `setLocationWithoutMovingUpdatesDownloadDir` — `move_from_old_path = false`
  repoints without relocating.

The full `libtransmission` suite passes (579/579) and matches the pre-change
baseline plus the three new tests.

## Real-world validation

`transmission-daemon` built from this change was run in an isolated container with
the **incomplete-dir on a local ext4 filesystem** and the **download-dir on a
separate SMB/CIFS network share**, so completion triggers a genuine cross-device
copy (the worst case). A 1 GiB torrent was downloaded to completion (via an HTTP
webseed), and three independent probes recorded the daemon's responsiveness for
the **entire 95.4 s copy**:

**A. Session-thread liveness** — a bare HTTP request to the RPC endpoint every
~40 ms (the RPC server runs on the session thread, so this directly measures
whether its event loop is alive):

| samples | avg | p50 | p99 | max | not-responding | stalls > 1 s |
|--------:|-----:|----:|-----:|------:|---------------:|-------------:|
| 2269 | 1.35 ms | 0.9 ms | 10.4 ms | 60.6 ms | 0 | 0 |

**B. Functional RPC** — a real `torrent-list` query every ~250 ms:
335 calls · avg 23.7 ms · max 123.4 ms · **0 failures**.

**C. Session-thread heartbeat** — the daemon's internal ~500 ms loop log:
1164 ticks · **max inter-tick gap 505 ms** (never paused beyond its normal cadence).

Post-move: the source was removed from the incomplete dir, the torrent's location
was updated to the download dir, and the destination file's SHA-1 matched the
source byte-for-byte.

Across 2269 consecutive probes spanning the full 95-second cross-filesystem copy,
the worst single RPC round-trip was 60.6 ms, with zero stalls and zero failures,
and the event loop never skipped a beat. With the previous synchronous code this
same copy blocks the session thread for the full ~95 s — the heartbeat shows a
single ~95 s gap and every probe times out for that window.

## Checklist

- Code formatted with `./code_style.sh` (clang-format 20); the full check passes.
- No new compiler warnings in the added code.
- New + existing `libtransmission` tests pass (579/579).

Notes: Fixed the app freezing while moving a completed torrent to a download directory on a different filesystem.