### PR TITLE
fix: serialize `tr_preferred_transport` to string keys

### DIFF
--- a/libtransmission/serializer.cc
+++ b/libtransmission/serializer.cc
@@ -386,7 +386,7 @@ tr_variant from_preferred_transport(small::max_size_vector<tr_preferred_transpor
 {
     static auto constexpr SaveSingle = [](tr_preferred_transport const ele) -> tr_variant
     {
-        return static_cast<int64_t>(ele);
+        return from_enum_or_integral_with_lookup(PreferredTransportKeys, ele);
     };
 
     auto ret = tr_variant::Vector{};

--- a/tests/libtransmission/settings-test.cc
+++ b/tests/libtransmission/settings-test.cc
@@ -508,10 +508,7 @@ TEST_F(SettingsTest, canLoadPreferredTransport)
 TEST_F(SettingsTest, canSavePreferredTransport)
 {
     static auto constexpr Key = TR_KEY_preferred_transports;
-    static auto constexpr ExpectedValue = std::array<int64_t, PreferredTransportCount>{
-        static_cast<int64_t>(tr_preferred_transport::TCP),
-        static_cast<int64_t>(tr_preferred_transport::UTP),
-    };
+    static auto constexpr ExpectedValue = std::array<std::string_view, PreferredTransportCount>{ "tcp"sv, "utp"sv };
     auto const setting_value = small::max_size_vector<tr_preferred_transport, PreferredTransportCount>{
         tr_preferred_transport::TCP,
         tr_preferred_transport::UTP,
@@ -530,8 +527,7 @@ TEST_F(SettingsTest, canSavePreferredTransport)
     {
         auto const expected = ExpectedValue[i];
         auto const& actual = (*l)[i];
-        ASSERT_TRUE(actual.holds_alternative<int64_t>());
-        EXPECT_EQ(expected, actual.value_if<int64_t>());
+        EXPECT_EQ(expected, actual.value_if<std::string_view>());
     }
 }
 


### PR DESCRIPTION
Reverse a change from #8811 that serialized `tr_preferred_transport` to an integer instead of its corresponding string key.

I'm not sure this is intended or an accident. So I'm just leaving this PR here in case it was an accident.