### PR TITLE
fix: FTBFS from c++20 header

### DIFF
--- a/tests/libtransmission/torrent-test.cc
+++ b/tests/libtransmission/torrent-test.cc
@@ -5,7 +5,6 @@
 
 #include <array>
 #include <cstddef>
-#include <ranges>
 
 #include <libtransmission/torrent.h>
 


### PR DESCRIPTION
Fixes #8877.

Notes: Fixed FTBFS in tests from including a C++20 header.