### PR TITLE
fix: don't fail directory creation when chmod is rejected but the directory is usable

### DIFF
--- a/libtransmission/file.cc
+++ b/libtransmission/file.cc
@@ -12,6 +12,7 @@
 
 #ifndef _WIN32
 #include <sys/stat.h>
+#include <unistd.h> // access(), W_OK, X_OK
 #endif
 
 #include "libtransmission/error.h"
@@ -224,13 +225,26 @@ bool tr_sys_dir_create(std::string_view path, int flags, [[maybe_unused]] int pe
         {
             auto perm_ec = std::error_code{};
             std::filesystem::permissions(target, final_perms, std::filesystem::perm_options::replace, perm_ec);
-            if (perm_ec)
+            if (!perm_ec)
             {
-                maybe_set_error(error, perm_ec);
-                return false;
+                return true;
             }
 
-            return true;
+            // The directory was created but chmod was rejected. Some filesystems
+            // (e.g. CIFS/SMB mounted with forced uid/gid/mode, FAT, or certain
+            // NFS exports) refuse chmod with EPERM/EACCES even though the
+            // directory is created and fully usable. Treat the umask-adjusted
+            // permissions as best-effort in that case -- but only if the
+            // directory really is a usable (writable, searchable) directory.
+            // If it isn't, the chmod failure is a real problem, so report it.
+            auto check_ec = std::error_code{};
+            if (std::filesystem::is_directory(target, check_ec) && ::access(target.c_str(), W_OK | X_OK) == 0)
+            {
+                return true;
+            }
+
+            maybe_set_error(error, perm_ec);
+            return false;
         };
 
         if (parents)

--- a/tests/libtransmission/file-test.cc
+++ b/tests/libtransmission/file-test.cc
@@ -1294,6 +1294,15 @@ TEST_F(FileTest, dirCreate)
     EXPECT_TRUE(validatePermissions(path1, 0751));
     EXPECT_TRUE(validatePermissions(path2, 0751));
 
+    // A created directory must be usable: we must be able to create a file in
+    // it. tr_sys_dir_create() treats a post-mkdir chmod failure as non-fatal on
+    // filesystems that reject chmod (CIFS forced-mode, FAT, some NFS), but only
+    // when the directory is genuinely writable -- as asserted here.
+    auto const child = tr_pathbuf{ path2, "/child"sv };
+    createFileWithContents(child, "x");
+    EXPECT_TRUE(tr_sys_path_exists(child));
+    tr_sys_path_remove(child);
+
     // Can create existing directory (no-op)
     EXPECT_TRUE(tr_sys_dir_create(path1, 0, 0700, &error));
     EXPECT_FALSE(error) << error;


### PR DESCRIPTION
## What

  `tr_sys_dir_create()` creates the directory and then applies the umask-adjusted
  permissions with `std::filesystem::permissions(..., perm_options::replace)`
  (behaviour added in #8574). If that permission call fails, the function returns
  an error — even though the directory itself was created successfully.

  On filesystems that don't allow `chmod` — CIFS/SMB mounted with forced
  `uid`/`gid`/`file_mode`/`dir_mode`, FAT, and some NFS exports —
  `std::filesystem::permissions()` fails with `EPERM`/`EACCES` while the directory
  is created and perfectly usable. The whole call then reports failure, which
  breaks any feature that creates destination directories.

  ## Symptom

  Relocating a completed torrent to a download directory on such a share creates
  the destination directory but then aborts before moving any files, surfacing as:

  Unable to create directory for new file: Operation not permitted

  The directory appears on the share, but no files are moved into it.

  ## Steps to reproduce

  1. Mount a CIFS/SMB share with forced ownership/modes, so the server rejects
     `chmod` (a very common NAS setup):

```
sh mount -t cifs //nas/share /mnt/share -o \
username=me,uid=1000,gid=1000,forceuid,forcegid,file_mode=0664,dir_mode=0775,nounix,vers=2.0
```

  2. Confirm the share rejects chmod (the trigger):

```
  mkdir /mnt/share/testdir        # succeeds
  chmod 0777 /mnt/share/testdir   # chmod: ... Operation not permitted   (EPERM)
  rmdir /mnt/share/testdir
```

  3. Point Transmission's download directory at the share (`/mnt/share`) and keep
  the incomplete directory on a normal local filesystem, so completion triggers
  a move onto the share.
  4. Add a torrent whose payload lives in its own folder, so the move has to
  create a new destination subdirectory.
  5. Let it finish (or trigger `Set Location / transmission-remote --move`).

  Before this change: the destination directory appears on the share but no
  files are moved into it, and the torrent stops with the error above.

  After this change: the directory is created and the files are moved into it;
  the torrent completes normally.

  Cause

  A regression from #8574 ("respect umask when creating directories"). Before that
  `change tr_sys_dir_create()` only created the directory; afterwards it also
  chmods each newly created directory and treats a chmod failure as fatal.
  Affects main / 4.2.0-dev (nightly); released 4.1.x is not affected.

  Fix

  Make applying the permissions best-effort. When `std::filesystem::permissions()`
  fails, verify the directory is actually usable — it is a directory and is
  writable + searchable (`access(W_OK | X_OK)`) — before ignoring the failure. If
  the directory is genuinely unusable, the original error is still returned, so
  real failures are not masked. Filesystems that support chmod are unaffected
  and keep the umask-respecting behaviour from #8574. The change is confined to
  the existing POSIX (`#ifndef _WIN32`) block; Windows behaviour is unchanged.

  Test plan

  - [x] `FileTest.dirCreate` passes (extended to assert a freshly created
  directory is usable — a file can be created inside it).
  - [x] On a normal local filesystem, behaviour is unchanged: created directories
  still receive the umask-adjusted permissions from #8574.
  - [x] clang-format-20 and clang-tidy-20 are clean on the changed files.
  - [x] Verified manually against a forced-mode CIFS mount: the relocation that
  previously failed now completes.