### PR TITLE
feat #8326: Expose known peer counts over RPC

### DIFF
--- a/docs/rpc-spec.md
+++ b/docs/rpc-spec.md
@@ -268,6 +268,7 @@ The 'source' column here corresponds to the data structure there.
 | `is_finished` | boolean| tr_stat
 | `is_private` | boolean| tr_torrent
 | `is_stalled` | boolean| tr_stat
+| `known_peers_from` | object (see below)| tr_stat
 | `labels` | array of strings | tr_torrent
 | `left_until_done` | number| tr_stat
 | `magnet_link` | string| n/a
@@ -365,7 +366,7 @@ Files are returned in the order they are laid out in the torrent. References to 
 | `rate_to_client` (B/s) | number     | tr_peer_stat
 | `rate_to_peer` (B/s)   | number     | tr_peer_stat
 
-`peers_from`: an object containing:
+`peers_from`: an object containing counts of connected peers by discovery source:
 
 | Key | Value Type | transmission.h source
 |:--|:--|:--
@@ -376,6 +377,8 @@ Files are returned in the order they are laid out in the torrent. References to 
 | `from_ltep`     | number     | tr_stat
 | `from_pex`      | number     | tr_stat
 | `from_tracker`  | number     | tr_stat
+
+`known_peers_from`: an object containing counts of known peers by discovery source. It has the same keys as `peers_from`.
 
 
 `pieces`: A bitfield holding `piece_count` flags which are set to 'true' if we have the piece matching that position. JSON doesn't allow raw binary data, so this is a base64-encoded string. (Source: tr_torrent)

--- a/libtransmission/quark.cc
+++ b/libtransmission/quark.cc
@@ -278,6 +278,7 @@ auto constexpr MyStatic = std::array<std::string_view, TR_N_KEYS>{
     "is_uploading_to"sv, // rpc
     "is_utp"sv, // rpc
     "jsonrpc"sv, // json-rpc
+    "known_peers_from"sv, // rpc
     "labels"sv, // .resume, rpc
     "lastAnnouncePeerCount"sv, // rpc
     "lastAnnounceResult"sv, // rpc

--- a/libtransmission/quark.h
+++ b/libtransmission/quark.h
@@ -289,6 +289,7 @@ enum // NOLINT(performance-enum-size)
     TR_KEY_is_uploading_to,
     TR_KEY_is_utp,
     TR_KEY_jsonrpc,
+    TR_KEY_known_peers_from,
     TR_KEY_labels,
     TR_KEY_last_announce_peer_count_camel_APICOMPAT,
     TR_KEY_last_announce_result_camel_APICOMPAT,

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -666,9 +666,8 @@ namespace make_torrent_field_helpers
     return tr_variant{ std::move(peers_vec) };
 }
 
-[[nodiscard]] auto make_peer_counts_map(tr_stat const& st)
+[[nodiscard]] auto make_peer_counts_map(std::array<uint16_t, TR_PEER_FROM_N_TYPES> const& from)
 {
-    auto const& from = st.peers_from;
     auto peer_counts_map = tr_variant::Map{ 7U };
     peer_counts_map.try_emplace(TR_KEY_from_cache, from[TR_PEER_FROM_RESUME]);
     peer_counts_map.try_emplace(TR_KEY_from_dht, from[TR_PEER_FROM_DHT]);
@@ -740,6 +739,7 @@ namespace make_torrent_field_helpers
     case TR_KEY_is_finished:
     case TR_KEY_is_private:
     case TR_KEY_is_stalled:
+    case TR_KEY_known_peers_from:
     case TR_KEY_labels:
     case TR_KEY_left_until_done:
     case TR_KEY_magnet_link:
@@ -889,7 +889,9 @@ namespace make_torrent_field_helpers
     case TR_KEY_peers_connected:
         return st.peers_connected;
     case TR_KEY_peers_from:
-        return make_peer_counts_map(st);
+        return make_peer_counts_map(st.peers_from);
+    case TR_KEY_known_peers_from:
+        return make_peer_counts_map(st.known_peers_from);
     case TR_KEY_peers_getting_from_us:
         return st.peers_getting_from_us;
     case TR_KEY_peers_sending_to_us:

--- a/tests/libtransmission/rpc-test.cc
+++ b/tests/libtransmission/rpc-test.cc
@@ -700,6 +700,7 @@ TEST_F(RpcTest, torrentGet)
     auto params = tr_variant::Map{ 1U };
     auto fields = tr_variant::Vector{};
     fields.emplace_back(tr_quark_get_string_view(TR_KEY_id));
+    fields.emplace_back(tr_quark_get_string_view(TR_KEY_known_peers_from));
     params.try_emplace(TR_KEY_fields, std::move(fields));
     request_map.try_emplace(TR_KEY_params, std::move(params));
 
@@ -721,6 +722,24 @@ TEST_F(RpcTest, torrentGet)
     auto first_torrent_id = first_torrent->value_if<int64_t>(TR_KEY_id);
     ASSERT_TRUE(first_torrent_id);
     EXPECT_EQ(1, *first_torrent_id);
+
+    auto* known_peers_from = first_torrent->find_if<tr_variant::Map>(TR_KEY_known_peers_from);
+    ASSERT_NE(known_peers_from, nullptr);
+
+    for (auto const key : {
+             TR_KEY_from_cache,
+             TR_KEY_from_dht,
+             TR_KEY_from_incoming,
+             TR_KEY_from_lpd,
+             TR_KEY_from_ltep,
+             TR_KEY_from_pex,
+             TR_KEY_from_tracker,
+         })
+    {
+        auto const count = known_peers_from->value_if<int64_t>(key);
+        ASSERT_TRUE(count);
+        EXPECT_EQ(0, *count);
+    }
 
     // cleanup
     tr_torrentRemove(tor, false);

--- a/web/assets/css/transmission-app.scss
+++ b/web/assets/css/transmission-app.scss
@@ -1216,6 +1216,13 @@ a {
     white-space: nowrap;
   }
 
+  .known-peer-row td {
+    color: var(--color-fg-secondary);
+    font-size: smaller;
+    padding: 4px 10px;
+    text-align: center;
+  }
+
   .encryption[data-encrypted='true'] {
     background-color: var(--color-border-starkest);
     -webkit-mask: var(--image-lock-fill) no-repeat center / 14px;
@@ -1617,7 +1624,8 @@ dialog {
 }
 
 .dialog-logo {
-  background: transparent url('../../public_html/images/favicon.svg') top left no-repeat;
+  background: transparent url('../../public_html/images/favicon.svg') top left
+    no-repeat;
   background-size: contain;
   grid-area: icon;
   height: var(--logo-size);

--- a/web/src/inspector.js
+++ b/web/src/inspector.js
@@ -20,6 +20,16 @@ const peer_column_classes = [
 
 const webseed_column_classes = ['url', 'speed-down'];
 
+const known_peer_sources = [
+  ['from_tracker', 'tracker'],
+  ['from_pex', 'PEX'],
+  ['from_dht', 'DHT'],
+  ['from_lpd', 'LPD'],
+  ['from_ltep', 'LTEP'],
+  ['from_incoming', 'incoming'],
+  ['from_cache', 'cache'],
+];
+
 export class Inspector extends EventTarget {
   constructor(controller) {
     super();
@@ -720,6 +730,19 @@ export class Inspector extends EventTarget {
       tortr.firstChild.setAttribute('colspan', cell_setters.length);
       peersRows.push(tortr);
 
+      const knownPeersText = Inspector._knownPeersTitle(
+        tor.getKnownPeersFrom(),
+      );
+      if (knownPeersText) {
+        const knownPeersTr = document.createElement('tr');
+        knownPeersTr.classList.add('known-peer-row');
+        const knownPeersTd = document.createElement('td');
+        knownPeersTd.setAttribute('colspan', cell_setters.length);
+        setTextContent(knownPeersTd, knownPeersText);
+        knownPeersTr.append(knownPeersTd);
+        peersRows.push(knownPeersTr);
+      }
+
       // peers
       for (const peer of tor.getPeers()) {
         const tr = document.createElement('tr');
@@ -746,6 +769,19 @@ export class Inspector extends EventTarget {
       tbody.firstChild.remove();
     }
     tbody.append(...peersRows);
+  }
+
+  static _knownPeersTitle(knownPeersFrom) {
+    const parts = [];
+
+    for (const [key, label] of known_peer_sources) {
+      const count = knownPeersFrom[key] || 0;
+      if (count > 0) {
+        parts.push(`${count} ${label}`);
+      }
+    }
+
+    return parts.length > 0 ? `(known: ${parts.join(', ')})` : '';
   }
 
   /// TRACKERS PAGE

--- a/web/src/torrent.js
+++ b/web/src/torrent.js
@@ -195,6 +195,9 @@ export class Torrent extends EventTarget {
   getPeersConnected() {
     return this.fields.peers_connected;
   }
+  getKnownPeersFrom() {
+    return this.fields.known_peers_from || {};
+  }
   getPeersGettingFromUs() {
     return this.fields.peers_getting_from_us;
   }
@@ -653,6 +656,7 @@ Torrent.Fields.StatsExtra = [
   'file_stats',
   'have_unchecked',
   'have_valid',
+  'known_peers_from',
   'peers',
   'start_date',
   'tracker_stats',


### PR DESCRIPTION
Add the existing per-source known peer counters to torrent-get responses as known_peers_from, using the same source breakdown as peers_from. This lets RPC clients and the web inspector show peers discovered from tracker, DHT, PEX, cache, and related sources even when those peers are not currently connected.

For example, a torrent-get request for known_peers_from can now return: {"from_tracker":53,"from_dht":153,"from_pex":25,"from_cache":150,...}

Frontend implementation located in the peers tab of a torrent inspector:

<img width="550" height="920" alt="Screenshot from 2026-06-08 12-32-38" src="https://github.com/user-attachments/assets/99595252-77d4-4514-b114-e7ce97a8affa" />

Closes https://github.com/transmission/transmission/issues/8326
Co-authored-by: João Lourenço <joaolourenco05@tecnico.ulisboa.pt>