### PR TITLE
refactor: don't expose `<filesystem>` in `file.h`

### DIFF
--- a/gtk/FreeSpaceLabel.cc
+++ b/gtk/FreeSpaceLabel.cc
@@ -53,7 +53,7 @@ bool FreeSpaceLabel::Impl::on_freespace_timer()
         return false;
     }
 
-    auto const capacity = tr_sys_path_get_capacity(std::string_view{ dir_ });
+    auto const capacity = tr_sys_path_get_capacity(dir_);
     auto const text = capacity ?
         fmt::format(fmt::runtime(_("{disk_space} free")), fmt::arg("disk_space", tr_strlsize(capacity->available))) :
         _("Error");

--- a/libtransmission/file.cc
+++ b/libtransmission/file.cc
@@ -28,6 +28,19 @@ void maybe_set_error(tr_error* error, std::error_code const& ec)
     }
 }
 
+// Construct std::filesystem::path from UTF-8 char sequence.
+// https://stackoverflow.com/a/57635139/11390656
+template<typename InputIt>
+[[nodiscard]] std::filesystem::path tr_u8path(InputIt begin, InputIt end)
+{
+    auto const view = std::ranges::subrange(begin, end) | std::views::transform([](char const c) -> char8_t { return c; });
+    return { view.begin(), view.end() };
+}
+[[nodiscard]] std::filesystem::path tr_u8path(std::string_view const path)
+{
+    return tr_u8path(path.begin(), path.end());
+}
+
 } // namespace
 
 std::string tr_sys_path_resolve(std::string_view path, tr_error* error)
@@ -287,13 +300,13 @@ std::vector<std::string> tr_sys_dir_get_files(
     }
 }
 
-std::optional<std::filesystem::space_info> tr_sys_path_get_capacity(std::filesystem::path const& path, tr_error* error)
+std::optional<tr_sys_path_capacity> tr_sys_path_get_capacity(std::string_view const path, tr_error* error)
 {
     auto ec = std::error_code{};
-    auto space = std::filesystem::space(path, ec);
+    auto const space = std::filesystem::space(tr_u8path(path), ec);
     if (!ec)
     {
-        return space;
+        return tr_sys_path_capacity{ .available = space.available, .capacity = space.capacity };
     }
 
     maybe_set_error(error, ec);

--- a/libtransmission/file.h
+++ b/libtransmission/file.h
@@ -7,7 +7,6 @@
 
 #include <cstdint> // uint64_t
 #include <ctime> // time_t
-#include <filesystem>
 #include <functional>
 #include <optional>
 #include <ranges>
@@ -102,27 +101,11 @@ struct tr_sys_path_info
     }
 };
 
-/**
- * Temporary replacement of deprecated `std::filesystem::u8path()` while we migrate
- * from char to char8_t strings.
- *
- * https://stackoverflow.com/a/57635139/11390656
- * @{
- */
-
-template<typename InputIt>
-[[nodiscard]] std::filesystem::path tr_u8path(InputIt begin, InputIt end)
+struct tr_sys_path_capacity
 {
-    auto const view = std::ranges::subrange(begin, end) | std::views::transform([](char const c) -> char8_t { return c; });
-    return { view.begin(), view.end() };
-}
-
-[[nodiscard]] inline std::filesystem::path tr_u8path(std::string_view path)
-{
-    return tr_u8path(path.begin(), path.end());
-}
-
-/// @}
+    uintmax_t available = -1;
+    uintmax_t capacity = -1;
+};
 
 /**
  * @name Platform-specific wrapper functions
@@ -173,15 +156,7 @@ bool tr_sys_path_copy(std::string_view src_path, std::string_view dst_path, tr_e
  * @param[out] error Pointer to error object. Optional, pass `nullptr` if you
  *                   are not interested in error details.
  */
-[[nodiscard]] std::optional<std::filesystem::space_info> tr_sys_path_get_capacity(
-    std::filesystem::path const& path,
-    tr_error* error = nullptr);
-[[nodiscard]] inline std::optional<std::filesystem::space_info> tr_sys_path_get_capacity(
-    std::string_view path,
-    tr_error* error = nullptr)
-{
-    return tr_sys_path_get_capacity(tr_u8path(path), error);
-}
+[[nodiscard]] std::optional<tr_sys_path_capacity> tr_sys_path_get_capacity(std::string_view path, tr_error* error = nullptr);
 
 /**
  * @brief Portability wrapper for `access()`.

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -2265,7 +2265,7 @@ using SessionAccessors = std::pair<SessionGetter, SessionSetter>;
         [](tr_session const& src) -> tr_variant
         {
             // TODO(C++23): use std::optional::transform() instead
-            if (auto const space = tr_sys_path_get_capacity(std::string_view{ src.downloadDir() }))
+            if (auto const space = tr_sys_path_get_capacity(src.downloadDir()))
             {
                 return space->available;
             }


### PR DESCRIPTION
Part of https://github.com/transmission/transmission/issues/8263#issuecomment-4647211570.

Remove `<filesystem>` from `tr_sys_path_get_capacity()`'s interface.