### PR TITLE
refactor: use std tools for the log message queue

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -579,8 +579,10 @@ jobs:
           set -ex
           apk update
           apk add \
-            ca-certificates \
             bash \
+            binutils \
+            build-base \
+            ca-certificates \
             clang \
             cmake \
             curl-dev \

--- a/daemon/daemon.cc
+++ b/daemon/daemon.cc
@@ -362,11 +362,9 @@ void printMessage(
 
 void pumpLogMessages(FILE* log_stream)
 {
-    tr_log_message* list = tr_logGetQueue();
-
-    for (tr_log_message const* l = list; l != nullptr; l = l->next)
+    for (auto const& l : tr_logGetQueue())
     {
-        printMessage(log_stream, l->when, l->level, l->name, l->message, l->file, l->line);
+        printMessage(log_stream, l.when, l.level, l.name, l.message, l.file, l.line);
     }
 
     // two reasons to not flush stderr:
@@ -376,8 +374,6 @@ void pumpLogMessages(FILE* log_stream)
     {
         fflush(log_stream);
     }
-
-    tr_logFreeQueue(list);
 }
 
 void periodic_update(evutil_socket_t /*fd*/, short /*what*/, void* arg)

--- a/gtk/MessageLogWindow.cc
+++ b/gtk/MessageLogWindow.cc
@@ -428,7 +428,7 @@ void addLatestMessagesToStore(
     }
 }
 
-void addMessages(Glib::RefPtr<Gtk::ListStore> const& store, tr_log_messages& messages, tr_log_messages&& new_messages)
+void addMessages(Glib::RefPtr<Gtk::ListStore> const& store, tr_log_messages& messages, tr_log_messages new_messages)
 {
     auto const n_messages = std::size(new_messages);
     messages.insert(messages.end(), std::make_move_iterator(new_messages.begin()), std::make_move_iterator(new_messages.end()));

--- a/gtk/MessageLogWindow.cc
+++ b/gtk/MessageLogWindow.cc
@@ -118,7 +118,11 @@ private:
 namespace
 {
 
-tr_log_messages log_messages;
+[[nodiscard]] auto& log_messages()
+{
+    static auto msgs = tr_log_messages{};
+    return msgs;
+}
 
 } // namespace
 
@@ -282,7 +286,7 @@ void MessageLogWindow::Impl::onSaveRequest()
 void MessageLogWindow::Impl::onClearRequest()
 {
     store_->clear();
-    log_messages.clear();
+    log_messages().clear();
 }
 
 void MessageLogWindow::Impl::onPauseToggled(Gio::SimpleAction& action)
@@ -443,7 +447,7 @@ bool MessageLogWindow::Impl::onRefresh()
 
     if (!isPaused_)
     {
-        addMessages(store_, log_messages, tr_logGetQueue());
+        addMessages(store_, log_messages(), tr_logGetQueue());
 
         if (pinned_to_new)
         {
@@ -523,7 +527,7 @@ MessageLogWindow::Impl::Impl(
     **/
 
     // cheaper to populate *before* it has listeners
-    addLatestMessagesToStore(store_, log_messages, std::size(log_messages));
+    addLatestMessagesToStore(store_, log_messages(), std::size(log_messages()));
     onRefresh();
 
     sort_->set_sort_column(message_log_cols.sequence, TR_GTK_SORT_TYPE(ASCENDING));

--- a/gtk/MessageLogWindow.cc
+++ b/gtk/MessageLogWindow.cc
@@ -118,8 +118,7 @@ private:
 namespace
 {
 
-tr_log_message* myTail = nullptr;
-tr_log_message* myHead = nullptr;
+tr_log_messages log_messages;
 
 } // namespace
 
@@ -283,8 +282,7 @@ void MessageLogWindow::Impl::onSaveRequest()
 void MessageLogWindow::Impl::onClearRequest()
 {
     store_->clear();
-    tr_logFreeQueue(myHead);
-    myHead = myTail = nullptr;
+    log_messages.clear();
 }
 
 void MessageLogWindow::Impl::onPauseToggled(Gio::SimpleAction& action)
@@ -392,15 +390,19 @@ MessageLogWindow::Impl::~Impl()
 namespace
 {
 
-tr_log_message* addMessages(Glib::RefPtr<Gtk::ListStore> const& store, tr_log_message* head)
+void addLatestMessagesToStore(
+    Glib::RefPtr<Gtk::ListStore> const& store,
+    tr_log_messages const& messages,
+    size_t const n_messages)
 {
     static unsigned int sequence = 0;
-    auto const default_name = Glib::get_application_name();
 
-    while (head != nullptr && head->next != nullptr)
+    auto const default_name = Glib::get_application_name();
+    auto const total = std::size(messages);
+
+    for (auto i = total - std::min(total, n_messages); i < total; ++i)
     {
-        auto const& message = *head;
-        head = head->next;
+        auto const& message = messages[i];
 
         char const* name = !std::empty(message.name) ? message.name.c_str() : default_name.c_str();
 
@@ -424,8 +426,13 @@ tr_log_message* addMessages(Glib::RefPtr<Gtk::ListStore> const& store, tr_log_me
             gtr_warning(gstr);
         }
     }
+}
 
-    return head; /* tail */
+void addMessages(Glib::RefPtr<Gtk::ListStore> const& store, tr_log_messages& messages, tr_log_messages&& new_messages)
+{
+    auto const n_messages = std::size(new_messages);
+    messages.insert(messages.end(), std::make_move_iterator(new_messages.begin()), std::make_move_iterator(new_messages.end()));
+    addLatestMessagesToStore(store, messages, n_messages);
 }
 
 } // namespace
@@ -436,23 +443,7 @@ bool MessageLogWindow::Impl::onRefresh()
 
     if (!isPaused_)
     {
-        if (auto* msgs = tr_logGetQueue(); msgs != nullptr)
-        {
-            /* add the new messages and append them to the end of
-             * our persistent list */
-            tr_log_message* tail = addMessages(store_, msgs);
-
-            if (myTail != nullptr)
-            {
-                myTail->next = msgs;
-            }
-            else
-            {
-                myHead = msgs;
-            }
-
-            myTail = tail;
-        }
+        addMessages(store_, log_messages, tr_logGetQueue());
 
         if (pinned_to_new)
         {
@@ -531,8 +522,9 @@ MessageLogWindow::Impl::Impl(
     ***  messages
     **/
 
-    addMessages(store_, myHead);
-    onRefresh(); /* much faster to populate *before* it has listeners */
+    // cheaper to populate *before* it has listeners
+    addLatestMessagesToStore(store_, log_messages, std::size(log_messages));
+    onRefresh();
 
     sort_->set_sort_column(message_log_cols.sequence, TR_GTK_SORT_TYPE(ASCENDING));
     filter_->set_visible_func(sigc::mem_fun(*this, &Impl::isRowVisible));

--- a/libtransmission/completion.h
+++ b/libtransmission/completion.h
@@ -20,6 +20,8 @@
 #include "libtransmission/bitfield.h"
 #include "libtransmission/types.h"
 
+struct tr_torrent;
+
 /**
  * @brief knows which blocks and pieces we have
  */

--- a/libtransmission/log.cc
+++ b/libtransmission/log.cc
@@ -37,6 +37,8 @@ using namespace std::literals;
 
 namespace
 {
+inline constexpr auto MaxQueueLength = 10000U;
+
 template<typename T>
 inline constexpr bool HasTmGmtoffV = requires(T t) { t.tm_gmtoff; };
 
@@ -127,7 +129,7 @@ void logAddImpl(
         log_state.queue_tail_ = &newmsg->next;
         ++log_state.queue_length_;
 
-        if (log_state.queue_length_ > TrLogMaxQueueLength)
+        if (log_state.queue_length_ > MaxQueueLength)
         {
             tr_log_message* old = log_state.queue_;
             log_state.queue_ = old->next;

--- a/libtransmission/log.cc
+++ b/libtransmission/log.cc
@@ -7,6 +7,7 @@
 #include <cerrno>
 #include <chrono>
 #include <cstddef> // size_t
+#include <deque>
 #include <iterator> // back_insert_iterator, empty
 #include <mutex>
 #include <optional>
@@ -54,11 +55,7 @@ public:
 
     bool queue_enabled_ = false;
 
-    tr_log_message* queue_ = nullptr;
-
-    tr_log_message** queue_tail_ = &queue_;
-
-    size_t queue_length_ = 0;
+    tr_log_messages queue_;
 
     std::recursive_mutex message_mutex_;
 };
@@ -117,26 +114,17 @@ void logAddImpl(
 
     if (log_state.queue_enabled_)
     {
-        auto* const newmsg = new tr_log_message{};
-        newmsg->level = level;
-        newmsg->when = std::chrono::system_clock::now();
-        newmsg->message = std::move(msg);
-        newmsg->file = file;
-        newmsg->line = line;
-        newmsg->name = name;
+        auto& newmsg = log_state.queue_.emplace_back();
+        newmsg.level = level;
+        newmsg.when = std::chrono::system_clock::now();
+        newmsg.message = std::move(msg);
+        newmsg.file = file;
+        newmsg.line = line;
+        newmsg.name = name;
 
-        *log_state.queue_tail_ = newmsg;
-        log_state.queue_tail_ = &newmsg->next;
-        ++log_state.queue_length_;
-
-        if (log_state.queue_length_ > MaxQueueLength)
+        if (std::size(log_state.queue_) > MaxQueueLength)
         {
-            tr_log_message* old = log_state.queue_;
-            log_state.queue_ = old->next;
-            old->next = nullptr;
-            tr_logFreeQueue(old);
-            --log_state.queue_length_;
-            TR_ASSERT(log_state.queue_length_ == TrLogMaxQueueLength);
+            log_state.queue_.pop_front();
         }
     }
     else
@@ -178,26 +166,16 @@ void tr_logSetQueueEnabled(bool is_enabled)
     log_state.queue_enabled_ = is_enabled;
 }
 
-tr_log_message* tr_logGetQueue()
+tr_log_messages tr_logGetQueue()
 {
     auto const lock = log_state.unique_lock();
 
-    auto* const ret = log_state.queue_;
-    log_state.queue_ = nullptr;
-    log_state.queue_tail_ = &log_state.queue_;
-    log_state.queue_length_ = 0;
-
-    return ret;
+    return std::exchange(log_state.queue_, {});
 }
 
-void tr_logFreeQueue(tr_log_message* freeme)
+void tr_logClearQueue()
 {
-    while (freeme != nullptr)
-    {
-        auto* const next = freeme->next;
-        delete freeme;
-        freeme = next;
-    }
+    (void)tr_logGetQueue();
 }
 
 // ---

--- a/libtransmission/log.h
+++ b/libtransmission/log.h
@@ -7,7 +7,7 @@
 
 #include <chrono>
 #include <cstddef> // size_t
-#include <ctime>
+#include <deque>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -34,18 +34,17 @@ struct tr_log_message
 
     // the message
     std::string message;
-
-    // linked list of messages
-    struct tr_log_message* next;
 };
+
+using tr_log_messages = std::deque<tr_log_message>;
 
 // ---
 
 void tr_logSetQueueEnabled(bool is_enabled);
 
-[[nodiscard]] tr_log_message* tr_logGetQueue();
+void tr_logClearQueue();
 
-void tr_logFreeQueue(tr_log_message* freeme);
+[[nodiscard]] tr_log_messages tr_logGetQueue();
 
 // ---
 

--- a/libtransmission/log.h
+++ b/libtransmission/log.h
@@ -20,11 +20,11 @@ std::optional<tr_log_level> tr_logGetLevelFromKey(std::string_view key);
 
 struct tr_log_message
 {
-    tr_log_level level;
+    tr_log_level level = TR_LOG_INFO;
 
     // location in the source code
     std::string_view file;
-    long line;
+    long line = 0;
 
     // when the message was generated
     std::chrono::system_clock::time_point when;

--- a/libtransmission/log.h
+++ b/libtransmission/log.h
@@ -41,8 +41,6 @@ struct tr_log_message
 
 // ---
 
-inline constexpr auto TrLogMaxQueueLength = 10000U;
-
 void tr_logSetQueueEnabled(bool is_enabled);
 
 [[nodiscard]] tr_log_message* tr_logGetQueue();

--- a/libtransmission/log.h
+++ b/libtransmission/log.h
@@ -12,7 +12,7 @@
 #include <string>
 #include <string_view>
 
-#include <libtransmission/types.h>
+#include "libtransmission/types.h"
 
 // ---
 

--- a/libtransmission/log.h
+++ b/libtransmission/log.h
@@ -12,38 +12,11 @@
 #include <string>
 #include <string_view>
 
+#include <libtransmission/types.h>
+
 // ---
-
-enum tr_log_level : uint8_t
-{
-    // No logging at all
-    TR_LOG_OFF,
-
-    // Errors that prevent Transmission from running
-    TR_LOG_CRITICAL,
-
-    // Errors that could prevent a single torrent from running, e.g. missing
-    // files or a private torrent's tracker responding "unregistered torrent"
-    TR_LOG_ERROR,
-
-    // Smaller errors that don't stop the overall system,
-    // e.g. unable to preallocate a file, or unable to connect to a tracker
-    // when other trackers are available
-    TR_LOG_WARN,
-
-    // User-visible info, e.g. "torrent completed" or "running script"
-    TR_LOG_INFO,
-
-    // Debug messages
-    TR_LOG_DEBUG,
-
-    // High-volume debug messages, e.g. tracing peer protocol messages
-    TR_LOG_TRACE
-};
 
 std::optional<tr_log_level> tr_logGetLevelFromKey(std::string_view key);
-
-// ---
 
 struct tr_log_message
 {

--- a/libtransmission/session-settings.h
+++ b/libtransmission/session-settings.h
@@ -19,7 +19,6 @@
 #include <small/vector.hpp>
 
 #include "libtransmission/constants.h"
-#include "libtransmission/log.h"
 #include "libtransmission/quark.h"
 #include "libtransmission/serializer.h"
 #include "libtransmission/types.h"

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -45,7 +45,6 @@
 #include "libtransmission/interned-string.h"
 #include "libtransmission/ip-cache.h"
 #include "libtransmission/local-data.h"
-#include "libtransmission/log.h" // for tr_log_level
 #include "libtransmission/net.h" // for tr_port, tr_tos_t
 #include "libtransmission/open-files.h"
 #include "libtransmission/platform.h"

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -24,6 +24,12 @@
 #include "libtransmission/types.h"
 #include "libtransmission/values.h"
 
+struct tr_ctor;
+struct tr_session;
+struct tr_torrent;
+struct tr_torrent_metainfo;
+struct tr_variant;
+
 // --- Startup & Shutdown
 
 /**

--- a/libtransmission/types.h
+++ b/libtransmission/types.h
@@ -227,6 +227,33 @@ enum tr_idlelimit : uint8_t
     TR_IDLELIMIT_UNLIMITED = 2
 };
 
+enum tr_log_level : uint8_t
+{
+    // No logging at all
+    TR_LOG_OFF,
+
+    // Errors that prevent Transmission from running
+    TR_LOG_CRITICAL,
+
+    // Errors that could prevent a single torrent from running, e.g. missing
+    // files or a private torrent's tracker responding "unregistered torrent"
+    TR_LOG_ERROR,
+
+    // Smaller errors that don't stop the overall system,
+    // e.g. unable to preallocate a file, or unable to connect to a tracker
+    // when other trackers are available
+    TR_LOG_WARN,
+
+    // User-visible info, e.g. "torrent completed" or "running script"
+    TR_LOG_INFO,
+
+    // Debug messages
+    TR_LOG_DEBUG,
+
+    // High-volume debug messages, e.g. tracing peer protocol messages
+    TR_LOG_TRACE
+};
+
 enum tr_peer_from : uint8_t
 {
     TR_PEER_FROM_INCOMING = 0, /* connections made to the listening port */

--- a/libtransmission/types.h
+++ b/libtransmission/types.h
@@ -18,12 +18,7 @@
 
 #include "libtransmission/values.h"
 
-struct tr_ctor;
 struct tr_error;
-struct tr_session;
-struct tr_torrent;
-struct tr_torrent_metainfo;
-struct tr_variant;
 
 // https://www.bittorrent.org/beps/bep_0007.html
 // "The client SHOULD include a key parameter in its announces. The key

--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -18,7 +18,6 @@
 
 #include <libtransmission/transmission.h>
 
-#include <libtransmission/log.h>
 #include <libtransmission/string-utils.h>
 #include <libtransmission/torrent-metainfo.h>
 #include <libtransmission/values.h>

--- a/macosx/MessageWindowController.mm
+++ b/macosx/MessageWindowController.mm
@@ -21,6 +21,9 @@ typedef NS_ENUM(NSUInteger, LevelButtonLevel) {
 
 static NSTimeInterval const kUpdateSeconds = 0.75;
 
+// Maximum number of messages retained in the message window.
+static NSUInteger const kMaxQueueLength = 10000U;
+
 @interface MessageWindowController ()<NSWindowRestoration, NSMenuItemValidation>
 
 @property(nonatomic) IBOutlet NSTableView* fMessageTable;
@@ -268,11 +271,11 @@ static NSTimeInterval const kUpdateSeconds = 0.75;
         }
     }
 
-    if (self.fMessages.count > TrLogMaxQueueLength)
+    if (self.fMessages.count > kMaxQueueLength)
     {
         NSUInteger const oldCount = self.fDisplayedMessages.count;
 
-        NSIndexSet* removeIndexes = [NSIndexSet indexSetWithIndexesInRange:NSMakeRange(0, self.fMessages.count - TrLogMaxQueueLength)];
+        NSIndexSet* removeIndexes = [NSIndexSet indexSetWithIndexesInRange:NSMakeRange(0, self.fMessages.count - kMaxQueueLength)];
         NSArray* itemsToRemove = [self.fMessages objectsAtIndexes:removeIndexes];
 
         [self.fMessages removeObjectsAtIndexes:removeIndexes];

--- a/macosx/MessageWindowController.mm
+++ b/macosx/MessageWindowController.mm
@@ -4,6 +4,8 @@
 
 #include <libtransmission/transmission.h>
 #include <libtransmission/log.h>
+#include <libtransmission/file.h>
+#include <libtransmission/string-utils.h>
 
 #import "MessageWindowController.h"
 #import "Controller.h"
@@ -228,8 +230,8 @@ static NSUInteger const kMaxQueueLength = 10000U;
 
 - (void)updateLog:(NSTimer*)timer
 {
-    tr_log_message* messages;
-    if ((messages = tr_logGetQueue()) == NULL)
+    auto const messages = tr_logGetQueue();
+    if (messages.empty())
     {
         return;
     }
@@ -246,25 +248,25 @@ static NSUInteger const kMaxQueueLength = 10000U;
 
     BOOL changed = NO;
 
-    for (tr_log_message* currentMessage = messages; currentMessage != NULL; currentMessage = currentMessage->next)
+    for (auto const& currentMessage : messages)
     {
-        NSString* name = !std::empty(currentMessage->name) ? @(currentMessage->name.c_str()) : NSProcessInfo.processInfo.processName;
+        NSString* name = !std::empty(currentMessage.name) ? @(currentMessage.name.c_str()) : NSProcessInfo.processInfo.processName;
 
-        auto const file_string = std::string{ currentMessage->file };
-        NSString* file = [(@(file_string.c_str())).lastPathComponent stringByAppendingFormat:@":%ld", currentMessage->line];
+        auto const basename = tr_sys_path_basename(currentMessage.file);
+        NSString* file = [tr_strv_to_utf8_nsstring(basename) stringByAppendingFormat:@":%ld", currentMessage.line];
 
-        auto const secs_since_1970 = std::chrono::system_clock::to_time_t(currentMessage->when);
+        auto const secs_since_1970 = std::chrono::system_clock::to_time_t(currentMessage.when);
         NSDictionary* message = @{
-            @"Message" : [NSString convertedStringFromCString:currentMessage->message.c_str()],
+            @"Message" : [NSString convertedStringFromCString:currentMessage.message.c_str()],
             @"Date" : [NSDate dateWithTimeIntervalSince1970:secs_since_1970],
             @"Index" : @(currentIndex++), //more accurate when sorting by date
-            @"Level" : @(currentMessage->level),
+            @"Level" : @(currentMessage.level),
             @"Name" : name,
             @"File" : file
         };
         [self.fMessages addObject:message];
 
-        if (currentMessage->level <= maxLevel && [self shouldIncludeMessageForFilter:filterString message:message])
+        if (currentMessage.level <= maxLevel && [self shouldIncludeMessageForFilter:filterString message:message])
         {
             [self.fDisplayedMessages addObject:message];
             changed = YES;
@@ -294,8 +296,6 @@ static NSUInteger const kMaxQueueLength = 10000U;
     }
 
     [self.fLock unlock];
-
-    tr_logFreeQueue(messages);
 }
 
 - (NSInteger)numberOfRowsInTableView:(NSTableView*)tableView

--- a/tests/libtransmission/dht-test.cc
+++ b/tests/libtransmission/dht-test.cc
@@ -38,7 +38,6 @@
 
 #include <libtransmission/crypto-utils.h> // tr_rand_obj
 #include <libtransmission/file.h>
-#include <libtransmission/log.h>
 #include <libtransmission/net.h>
 #include <libtransmission/quark.h>
 #include <libtransmission/session-thread.h> // for tr_evthread_init();

--- a/tests/libtransmission/serializer-tests.cc
+++ b/tests/libtransmission/serializer-tests.cc
@@ -227,23 +227,21 @@ TEST_F(SerializerTest, u8StringWarnsOnInvalidUtf8)
     auto const old_level = tr_logGetLevel();
     tr_logSetLevel(TR_LOG_WARN);
     tr_logSetQueueEnabled(true);
-    tr_logFreeQueue(tr_logGetQueue());
+    tr_logClearQueue();
 
     auto actual = std::u8string{};
     EXPECT_TRUE(Converters::deserialize(var, &actual));
 
-    auto* const msgs = tr_logGetQueue();
     auto warned = false;
-    for (auto* msg = msgs; msg != nullptr; msg = msg->next)
+    for (auto const& msg : tr_logGetQueue())
     {
-        if (msg->level == TR_LOG_WARN && msg->message.find("contains invalid UTF-8") != std::string::npos)
+        if (msg.level == TR_LOG_WARN && msg.message.find("contains invalid UTF-8") != std::string::npos)
         {
             warned = true;
             break;
         }
     }
 
-    tr_logFreeQueue(msgs);
     tr_logSetQueueEnabled(false);
     tr_logSetLevel(old_level);
 

--- a/tests/libtransmission/settings-test.cc
+++ b/tests/libtransmission/settings-test.cc
@@ -12,7 +12,6 @@
 
 #include <libtransmission/transmission.h>
 
-#include <libtransmission/log.h>
 #include <libtransmission/net.h>
 #include <libtransmission/open-files.h>
 #include <libtransmission/peer-io.h>

--- a/tests/libtransmission/test-fixtures.h
+++ b/tests/libtransmission/test-fixtures.h
@@ -355,7 +355,7 @@ private:
     {
         static auto constexpr DeadlineSecs = 0.1;
         tr_sessionClose(session, DeadlineSecs);
-        tr_logFreeQueue(tr_logGetQueue());
+        tr_logClearQueue();
     }
 
 protected:

--- a/tests/libtransmission/torrents-test.cc
+++ b/tests/libtransmission/torrents-test.cc
@@ -27,7 +27,7 @@ using namespace std::literals;
 
 TEST_F(TorrentsTest, invalidArgsAreLogged)
 {
-    tr_logFreeQueue(tr_logGetQueue());
+    tr_logClearQueue();
     tr_logSetLevel(TR_LOG_WARN);
     tr_logSetQueueEnabled(true);
 
@@ -180,16 +180,11 @@ TEST_F(TorrentsTest, invalidArgsAreLogged)
     EXPECT_FALSE(tr_torrentHasMetadata(nullptr));
     ++expected_log_size;
 
-    auto actual_log_size = size_t{};
-    tr_log_message* const msgs = tr_logGetQueue();
-    for (auto* walk = msgs; walk != nullptr; walk = walk->next)
-    {
-        ++actual_log_size;
-    }
+    auto const msgs = tr_logGetQueue();
+    auto const actual_log_size = msgs.size();
     EXPECT_EQ(actual_log_size, expected_log_size);
 
     // cleanup
-    tr_logFreeQueue(msgs);
     tr_logSetQueueEnabled(false);
 }
 


### PR DESCRIPTION
I have a batch of refactors that I worked on about a month ago and am trying to get pieces of them into single-topic PRs. This one is a small cleanup to logging that removes the hand-rolled linked list code for batching up log messages and replaces it with a `std::dequeue`.