### PR TITLE
refactor: replace `char*` with `std::string_view`

### DIFF
--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -864,16 +864,16 @@ auto tier_announce_event_pull(tr_tier* tier)
     return e;
 }
 
-bool isUnregistered(char const* errmsg)
+bool isUnregistered(std::string_view errmsg)
 {
-    auto const lower = tr_strlower(errmsg != nullptr ? errmsg : "");
+    auto const lower = tr_strlower(errmsg);
 
-    auto constexpr Keys = std::array<std::string_view, 2>{ "unregistered torrent"sv, "torrent not registered"sv };
+    auto constexpr Keys = std::array{ "unregistered torrent"sv, "torrent not registered"sv };
 
     return std::ranges::any_of(Keys, [&lower](auto const& key) { return tr_strv_contains(lower, key); });
 }
 
-void on_announce_error(tr_tier* tier, char const* err, tr_announce_event e, time_t interval = {})
+void on_announce_error(tr_tier* tier, std::string_view err, tr_announce_event e, time_t interval = {})
 {
     using namespace announce_helpers;
 
@@ -1015,11 +1015,11 @@ void tr_announcer_impl::onAnnounceDone(
             response.downloads.value_or(-1),
             response.interval,
             response.min_interval,
-            (!std::empty(response.tracker_id) ? response.tracker_id.c_str() : "none"),
+            !std::empty(response.tracker_id) ? response.tracker_id : "none"sv,
             std::size(response.pex),
             std::size(response.pex6),
-            (!std::empty(response.errmsg) ? response.errmsg.c_str() : "none"),
-            (!std::empty(response.warning) ? response.warning.c_str() : "none")));
+            !std::empty(response.errmsg) ? response.errmsg : "none"sv,
+            !std::empty(response.warning) ? response.warning : "none"sv));
 
     // https://github.com/arvidn/libtorrent/issues/5084#issuecomment-688516452
     if (response.min_interval != 0)
@@ -1064,7 +1064,7 @@ void tr_announcer_impl::onAnnounceDone(
 
         on_announce_error(
             tier,
-            response.errmsg.c_str(),
+            response.errmsg,
             event,
             response.interval > time_t{} ? response.interval : response.min_interval);
     }
@@ -1249,7 +1249,7 @@ namespace on_scrape_done_helpers
     return std::ranges::any_of(too_long_errors, [&errmsg](auto const& substr) { return tr_strv_contains(errmsg, substr); });
 }
 
-void on_scrape_error(tr_session const* /*session*/, tr_tier* tier, char const* errmsg)
+void on_scrape_error(tr_session const* /*session*/, tr_tier* tier, std::string_view errmsg)
 {
     if (auto* const current_tracker = tier->currentTracker(); current_tracker != nullptr)
     {
@@ -1265,7 +1265,7 @@ void on_scrape_error(tr_session const* /*session*/, tr_tier* tier, char const* e
     }
 
     // set the error message
-    tier->last_scrape_str = errmsg != nullptr ? errmsg : "";
+    tier->last_scrape_str = errmsg;
     tier->lastScrapeSucceeded = false;
 
     // switch to the next tracker
@@ -1372,7 +1372,7 @@ void tr_announcer_impl::onScrapeDone(tr_scrape_response const& response)
         }
         else if (!std::empty(response.errmsg))
         {
-            on_scrape_error(session, tier, response.errmsg.c_str());
+            on_scrape_error(session, tier, response.errmsg);
         }
         else
         {


### PR DESCRIPTION
Minor refactor to replace some instances of `char*` in tracker code to `std::string_view`.