### PR TITLE
fix: invalid nullptr parameter warning (#8428)

### DIFF
--- a/qt/Application.cc
+++ b/qt/Application.cc
@@ -141,7 +141,6 @@ QString Application::intern(QString const& in)
 
 Application::Application(
     Prefs& prefs,
-    RpcClient& rpc,
     bool minimized,
     QString const& config_dir,
     QStringList const& filenames,
@@ -153,6 +152,9 @@ Application::Application(
     setApplicationName(ConfigName);
     loadTranslations();
     initUnits();
+
+    nam_ = std::make_unique<QNetworkAccessManager>();
+    rpc_ = std::make_unique<RpcClient>(*nam_);
 
     setWindowIcon(makeWindowIcon());
 
@@ -175,7 +177,7 @@ Application::Application(
     QAccessible::installFactory(&accessibleFactory);
 #endif
 
-    session_ = std::make_unique<Session>(config_dir, prefs_, rpc);
+    session_ = std::make_unique<Session>(config_dir, prefs_, *rpc_);
     model_ = std::make_unique<TorrentModel>(prefs_);
     window_ = std::make_unique<MainWindow>(*session_, prefs_, *model_, minimized);
     watch_dir_ = std::make_unique<WatchDir>(*model_);

--- a/qt/Application.cc
+++ b/qt/Application.cc
@@ -15,6 +15,9 @@
 #include <QRect>
 #include <QSystemTrayIcon>
 
+#include <QNetworkAccessManager>
+#include "RpcClient.h"
+
 #ifdef QT_DBUS_LIB
 #include <QDBusConnection>
 #include <QDBusMessage>

--- a/qt/Application.h
+++ b/qt/Application.h
@@ -17,6 +17,9 @@
 #include <QTranslator>
 #include <QWeakPointer>
 
+#include <QNetworkAccessManager>
+#include "RpcClient.h"
+
 #include <libtransmission-app/favicon-cache.h>
 #include <libtransmission/quark.h>
 
@@ -41,7 +44,6 @@ class Application : public QApplication
 public:
     Application(
         Prefs& prefs,
-        RpcClient& rpc,
         bool minimized,
         QString const& config_dir,
         QStringList const& filenames,
@@ -109,6 +111,8 @@ private:
 
     std::unordered_set<QString> interned_strings_;
 
+    std::unique_ptr<QNetworkAccessManager> nam_;
+    std::unique_ptr<RpcClient> rpc_;
     Prefs& prefs_;
     std::unique_ptr<Session> session_;
     std::unique_ptr<TorrentModel> model_;

--- a/qt/Application.h
+++ b/qt/Application.h
@@ -17,9 +17,6 @@
 #include <QTranslator>
 #include <QWeakPointer>
 
-#include <QNetworkAccessManager>
-#include "RpcClient.h"
-
 #include <libtransmission-app/favicon-cache.h>
 #include <libtransmission/quark.h>
 
@@ -36,6 +33,7 @@ class Session;
 class Torrent;
 class TorrentModel;
 class WatchDir;
+class QNetworkAccessManager;
 
 class Application : public QApplication
 {

--- a/qt/main.cc
+++ b/qt/main.cc
@@ -8,7 +8,6 @@
 #include <string_view>
 
 #include <QDir>
-#include <QNetworkAccessManager>
 
 #include <fmt/format.h>
 
@@ -23,7 +22,6 @@
 #include "Application.h"
 #include "InteropHelper.h"
 #include "Prefs.h"
-#include "RpcClient.h"
 #include "VariantHelpers.h"
 
 using namespace std::string_view_literals;
@@ -309,9 +307,7 @@ int tr_main(int argc, char** argv)
 
     // run the app
     auto qt_argc = static_cast<int>(std::size(qt_argv));
-    auto nam = QNetworkAccessManager{};
-    auto rpc = RpcClient{ nam };
-    auto const app = Application{ prefs, rpc, minimized, config_dir, filenames, qt_argc, std::data(qt_argv) };
+    auto const app = Application{ prefs, minimized, config_dir, filenames, qt_argc, std::data(qt_argv) };
     auto const ret = QApplication::exec();
 
     // save prefs before exiting


### PR DESCRIPTION
Fixes the issue #8428. 

The problem was that objects QNetworkAccessManager and RpcClient were initialized before there ever was a QApplication (here via a child class Application) object initialized, then these objects couldn't find a QApplication object and threw the warnings. 

Normally you initialize the QApplication first, and then everything else. That's what I did. And because QNetworkAccessManager and RpcClient are not used by anybody except Application, I just moved them inside the Application class' constructor. 