### PR TITLE
fix: add checks for `socket_`

### DIFF
--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -246,8 +246,8 @@ bool tr_peerIo::reconnect()
         return false;
     }
 
-    auto const was_read_enabled = socket_ ? socket_->is_read_enabled() : true;
-    auto const was_write_enabled = socket_ ? socket_->is_write_enabled() : true;
+    auto const was_read_enabled = socket_ ? socket_->is_read_enabled() : false;
+    auto const was_write_enabled = socket_ ? socket_->is_write_enabled() : false;
 
     close();
 

--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -458,6 +458,11 @@ void tr_peerIo::read_cb()
 
 void tr_peerIo::set_enabled(tr_direction dir, bool is_enabled)
 {
+    if (!socket_)
+    {
+        // socket was closed by tr_peerIo::close()
+        return;
+    }
     if (dir == tr_direction::Up)
     {
         socket_->set_write_enabled(is_enabled);

--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -246,8 +246,8 @@ bool tr_peerIo::reconnect()
         return false;
     }
 
-    auto const was_read_enabled = socket_->is_read_enabled();
-    auto const was_write_enabled = socket_->is_write_enabled();
+    auto const was_read_enabled = socket_ ? socket_->is_read_enabled() : true;
+    auto const was_write_enabled = socket_ ? socket_->is_write_enabled() : true;
 
     close();
 
@@ -306,6 +306,11 @@ size_t tr_peerIo::try_write(size_t max)
     static auto constexpr Dir = tr_direction::Up;
 
     if (max == 0U)
+    {
+        return {};
+    }
+
+    if (!socket_)
     {
         return {};
     }
@@ -413,6 +418,11 @@ size_t tr_peerIo::try_read(size_t max)
         return {};
     }
 
+    if (!socket_)
+    {
+        return {};
+    }
+
     // Do not read more than the bandwidth allows.
     // If there is no bandwidth left available, disable reads.
     max = bandwidth().clamp(Dir, max);
@@ -460,9 +470,9 @@ void tr_peerIo::set_enabled(tr_direction dir, bool is_enabled)
 {
     if (!socket_)
     {
-        // socket was closed by tr_peerIo::close()
         return;
     }
+
     if (dir == tr_direction::Up)
     {
         socket_->set_write_enabled(is_enabled);

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -94,7 +94,7 @@ public:
 
     [[nodiscard]] auto is_utp() const noexcept
     {
-        return socket_->is_utp();
+        return socket_ ? socket_->is_utp() : false;
     }
 
     void clear();


### PR DESCRIPTION
Fixes #8904.
Supercedes #8909.
Regression from #8060.

Claude was spot on with its analysis, so I just paste it here after proofreading.

---

## Root Cause

The bug is a **use-after-close** in `tr_bandwidth::allocate`. The critical sequence:

### Step 1 — `allocate_bandwidth` populates `refs`
```cpp
// bandwidth.cc:230
allocate_bandwidth(..., refs);  // adds shared_ptr\<tr_peerIo\> for ALL live peers
```
A peer in handshake state (or established) with a valid `socket_` is added to `refs` **and** later to `peer_arrays` (raw pointers).

### Step 2 — `flush_outgoing_protocol_msgs` triggers `close()`
```cpp
// bandwidth.cc:234
io->flush_outgoing_protocol_msgs();
```
This calls `flush(Up, byte_count)` → `try_write(byte_count)` → `socket_->try_write(...)`. If the write returns a **non-retryable error** (e.g. `ECONNREFUSED`, `ETIMEDOUT`), `try_write` calls:
```cpp
// peer-io.cc:336
call_error_callback(error);
```
For a **handshake peer**, `got_error_` → `tr_handshake::on_error` → attempts `io->reconnect()`:
```cpp
// peer-io.cc:252
close();  // ← socket_.reset() — socket_ is now nullptr
// ...
auto s = tr_peer_socket_tcp::create(...);
if (!s)
    return false;  // TCP fallback also fails → socket_ stays null
```
`reconnect()` returns `false`, then `fail()` → `handshake->done(false)` → `fire_done` → `on_handshake_done` → `info-\>destroy_handshake()` destroys the `tr_handshake`. After `call_error_callback` returns, **`socket_` is null** but `tr_peerIo` is still alive (held by `refs`).

### Step 3 — Peer with null `socket_` is placed into `peer_arrays`
```cpp
// bandwidth.cc:247
low.push_back(io.get());  // raw pointer, socket_ == nullptr
```

### Step 4 — `phase_one` dereferences null `socket_`
```cpp
// bandwidth.cc:200
auto const bytes_used = peers[i]->flush(dir, Increment);  // Increment = 3000
```
→ `try_write(3000)` → buffer still has data (it wasn't drained on error) → `max \> 0` → `bandwidth().clamp(Dir, max)` returns **0** (bandwidth exhausted by earlier peers) → hits the guard:
```cpp
// peer-io.cc:317–319
if (max == 0U) {
    set_enabled(Dir, false);  // ← calls socket_-\>set_write_enabled() with socket_ == nullptr
```
→ `set_enabled` at **peer-io.cc:463** unconditionally dereferences `socket_`:
```cpp
socket_->set_write_enabled(is_enabled);  // ← CRASH: socket_ is nullptr
```

---

I bit of supplement from me.

Before #8060, we didn't need any special handling for `socket.close()`. `socket.close()` calls `close()` on the file descriptor and sets the variable to `TR_BAD_SOCKET`, but the `tr_peer_socket` object stays. So when `tr_peerIo` calls `try_read()` or `try_write()` again, `read()` or `write()` will be called with `TR_BAD_SOCKET` and returns an error that is handled just like any other socket errors.