### PR TITLE
Fix compact progress text color in Qt client

### DIFF
--- a/qt/TorrentDelegateMin.cc
+++ b/qt/TorrentDelegateMin.cc
@@ -4,10 +4,12 @@
 // License text can be found in the licenses/ folder.
 
 #include <algorithm>
+#include <cmath>
 #include <utility>
 
 #include <QApplication>
 #include <QBrush>
+#include <QColor>
 #include <QFont>
 #include <QFontMetrics>
 #include <QIcon>
@@ -38,6 +40,32 @@ namespace
 constexpr auto GuiPad = 6;
 constexpr auto BarWidth = 50;
 constexpr auto BarHeight = 16;
+
+double contrastRatio(QColor const& lhs, QColor const& rhs)
+{
+    auto const luminance = [](QColor const& color)
+    {
+        auto const channel_luminance = [](int channel)
+        {
+            auto const value = static_cast<double>(channel) / 255.0;
+            return value <= 0.03928 ? value / 12.92 : std::pow((value + 0.055) / 1.055, 2.4);
+        };
+
+        return (0.2126 * channel_luminance(color.red())) + (0.7152 * channel_luminance(color.green())) +
+            (0.0722 * channel_luminance(color.blue()));
+    };
+
+    auto const lhs_luminance = luminance(lhs);
+    auto const rhs_luminance = luminance(rhs);
+    return (std::max(lhs_luminance, rhs_luminance) + 0.05) / (std::min(lhs_luminance, rhs_luminance) + 0.05);
+}
+
+QColor readableTextColor(QColor const& background)
+{
+    auto const black = QColor{ Qt::black };
+    auto const white = QColor{ Qt::white };
+    return contrastRatio(black, background) >= contrastRatio(white, background) ? black : white;
+}
 
 class ItemLayout
 {
@@ -260,12 +288,17 @@ void TorrentDelegateMin::drawTorrent(QPainter* painter, QStyleOptionViewItem con
         progress_bar_style_.palette.setColor(QPalette::Window, SilverBack);
     }
 
-    progress_bar_style_.palette.setColor(QPalette::WindowText, Qt::black);
     progress_bar_style_.state = progress_bar_state;
     progress_bar_style_.text = QStringLiteral("%1%").arg(static_cast<int>(tr_truncd(100.0 * tor.percentDone(), 0)));
     progress_bar_style_.textVisible = true;
     progress_bar_style_.textAlignment = Qt::AlignCenter;
     setProgressBarPercentDone(option, tor);
+    auto const progress = std::clamp(progress_bar_style_.progress, progress_bar_style_.minimum, progress_bar_style_.maximum);
+    auto const midpoint = progress_bar_style_.minimum + ((progress_bar_style_.maximum - progress_bar_style_.minimum) / 2);
+    auto const text_background_role = progress >= midpoint ? QPalette::Highlight : QPalette::Window;
+    progress_bar_style_.palette.setColor(
+        QPalette::WindowText,
+        readableTextColor(progress_bar_style_.palette.color(text_background_role)));
     StyleHelper::drawProgressBar(*painter, progress_bar_style_);
 
     painter->restore();

--- a/qt/TorrentDelegateMin.cc
+++ b/qt/TorrentDelegateMin.cc
@@ -260,6 +260,7 @@ void TorrentDelegateMin::drawTorrent(QPainter* painter, QStyleOptionViewItem con
         progress_bar_style_.palette.setColor(QPalette::Window, SilverBack);
     }
 
+    progress_bar_style_.palette.setColor(QPalette::WindowText, Qt::black);
     progress_bar_style_.state = progress_bar_state;
     progress_bar_style_.text = QStringLiteral("%1%").arg(static_cast<int>(tr_truncd(100.0 * tor.percentDone(), 0)));
     progress_bar_style_.textVisible = true;


### PR DESCRIPTION
## Summary
- keep compact-view progress percentage text readable when a torrent row is selected
- choose the progress text color from black/white based on contrast with the color behind the centered text
- avoid hard-coding black as the only possible progress text color

## Local investigation
- Installed and tested `transmission-4.1.2-x64.msi` on Windows light theme: compact-view selected row kept the progress percentage readable
- Installed and tested `transmission-4.1.2-qt5-x64.msi` on Windows light theme: compact-view selected row also appeared readable locally
- Code path: `StyleHelper::drawProgressBar()` paints progress text with `QPalette::WindowText`, while `TorrentDelegateMin` uses custom progress bar colors. This makes the issue likely theme-dependent when the current `WindowText` color has poor contrast with the custom progress bar background.

## Testing
- `git diff --check`
- Not run: local source build, because this machine is missing vcpkg-provided curl/Qt development dependencies

Related to #7983