### PR TITLE
ci: support visual studio 2026

### DIFF
--- a/.github/actions/prepare-deps-win32/action.yml
+++ b/.github/actions/prepare-deps-win32/action.yml
@@ -23,8 +23,6 @@ runs:
         & "C:\Program Files\OpenSSL\unins000.exe" /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP- | Out-Host
         (Join-Path $Env:ProgramFiles NASM) | Out-File $Env:GITHUB_PATH -Append
         (Join-Path (Get-Item -Path "${Env:ProgramFiles(x86)}\WiX Toolset v3.*")[0].FullName bin) | Out-File $Env:GITHUB_PATH -Append
-
-        Install-Module -Name Pscx -RequiredVersion 4.0.0-beta4 -AllowPrerelease -Force
     - name: Get Cache Key
       id: cache-key
       shell: pwsh

--- a/.github/actions/setup-vs-env-win32/action.yml
+++ b/.github/actions/setup-vs-env-win32/action.yml
@@ -9,24 +9,30 @@ runs:
     - name: Detect vcvarsall
       shell: pwsh
       run: |
+        $Arch = '${{ inputs.arch }}'
+        if (@('x86', 'x64', 'arm64') -notcontains $Arch) {
+          throw "Unsupported architecture for vcvarsall: $Arch"
+        }
+
+        $RequiredComponent = if ($Arch -eq 'arm64') {
+          'Microsoft.VisualStudio.Component.VC.Tools.ARM64'
+        } else {
+          'Microsoft.VisualStudio.Component.VC.Tools.x86.x64'
+        }
+
         $VsWherePath = Join-Path ${Env:ProgramFiles(x86)} 'Microsoft Visual Studio' Installer vswhere.exe
         if (-not (Test-Path $VsWherePath)) {
           throw "vswhere.exe was not found at expected path: $VsWherePath"
         }
 
-        $VsInstallPath = & $VsWherePath -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+        $VsInstallPath = & $VsWherePath -latest -products * -requires $RequiredComponent -property installationPath
         if (-not $VsInstallPath) {
-          throw 'Unable to determine Visual Studio installation path from vswhere.'
+          throw "No Visual Studio instance with component '$RequiredComponent' was found by vswhere."
         }
 
         $VcVarsAll = Join-Path $VsInstallPath 'VC\Auxiliary\Build\vcvarsall.bat'
         if (-not (Test-Path $VcVarsAll)) {
           throw "vcvarsall.bat was not found at expected path: $VcVarsAll"
-        }
-
-        $Arch = '${{ inputs.arch }}'
-        if (@('x86', 'x64', 'arm64') -notcontains $Arch) {
-          throw "Unsupported architecture for vcvarsall: $Arch"
         }
 
         "VCVARSALL=$VcVarsAll" | Out-File $Env:GITHUB_ENV -Append

--- a/.github/actions/setup-vs-env-win32/action.yml
+++ b/.github/actions/setup-vs-env-win32/action.yml
@@ -1,0 +1,33 @@
+name: Setup Win32 Visual Studio environment
+inputs:
+  arch:
+    description: Architecture (x86, x64, arm64)
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Detect vcvarsall
+      shell: pwsh
+      run: |
+        $VsWherePath = Join-Path ${Env:ProgramFiles(x86)} 'Microsoft Visual Studio' Installer vswhere.exe
+        if (-not (Test-Path $VsWherePath)) {
+          throw "vswhere.exe was not found at expected path: $VsWherePath"
+        }
+
+        $VsInstallPath = & $VsWherePath -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+        if (-not $VsInstallPath) {
+          throw 'Unable to determine Visual Studio installation path from vswhere.'
+        }
+
+        $VcVarsAll = Join-Path $VsInstallPath 'VC\Auxiliary\Build\vcvarsall.bat'
+        if (-not (Test-Path $VcVarsAll)) {
+          throw "vcvarsall.bat was not found at expected path: $VcVarsAll"
+        }
+
+        $Arch = '${{ inputs.arch }}'
+        if (@('x86', 'x64', 'arm64') -notcontains $Arch) {
+          throw "Unsupported architecture for vcvarsall: $Arch"
+        }
+
+        "VCVARSALL=$VcVarsAll" | Out-File $Env:GITHUB_ENV -Append
+        "VC_ARCH=$Arch" | Out-File $Env:GITHUB_ENV -Append

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -424,44 +424,33 @@ jobs:
         with:
           arch: x64
           type: CoreDeps
-      - name: Detect Visual Studio Version
-        run: |
-          $VsWherePath = Join-Path ${Env:ProgramFiles(x86)} 'Microsoft Visual Studio' Installer vswhere.exe
-          if (-not (Test-Path $VsWherePath)) {
-            throw "vswhere.exe was not found at expected path: $VsWherePath"
-          }
-
-          $VsVersion = & $VsWherePath -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property catalog_productLineVersion
-          if (-not $VsVersion) {
-            throw 'Unable to determine Visual Studio version from vswhere.'
-          }
-
-          "VISUAL_STUDIO_VERSION=$VsVersion" | Out-File $Env:GITHUB_ENV -Append
+      - name: Setup Visual Studio Environment
+        uses: ./src/.github/actions/setup-vs-env-win32
+        with:
+          arch: x64
       - name: Configure
         run: |
-          Import-VisualStudioVars -VisualStudioVersion $Env:VISUAL_STUDIO_VERSION -Architecture x64
-          cmake `
-            -S src `
-            -B obj `
-            -G Ninja `
-            -DCMAKE_BUILD_TYPE=Debug `
-            -DCMAKE_PREFIX_PATH="${Env:DEPS_PREFIX}" `
-            -DENABLE_TESTS=${{ needs.what-to-make.outputs.make-tests == 'true' && 'ON' || 'OFF' }} `
-            -DRUN_CLANG_TIDY=ON `
-            -DUSE_SYSTEM_DEFAULT=OFF
+          $CmakeArgs = @(
+            '-S src'
+            '-B obj'
+            '-G Ninja'
+            '-DCMAKE_BUILD_TYPE=Debug'
+            "-DCMAKE_PREFIX_PATH=$Env:DEPS_PREFIX"
+            "-DENABLE_TESTS=${{ needs.what-to-make.outputs.make-tests == 'true' && 'ON' || 'OFF' }}"
+            '-DRUN_CLANG_TIDY=ON'
+            '-DUSE_SYSTEM_DEFAULT=OFF'
+          )
+          cmd /c "\"$Env:VCVARSALL\" $Env:VC_ARCH >nul && cmake $($CmakeArgs -join ' ')"
       - name: Make (Core)
         run: |
-          Import-VisualStudioVars -VisualStudioVersion $Env:VISUAL_STUDIO_VERSION -Architecture x64
-          cmake --build obj --config Debug --target transmission 2>&1 | tee makelog
+          cmd /c "\"$Env:VCVARSALL\" $Env:VC_ARCH >nul && cmake --build obj --config Debug --target transmission" 2>&1 | tee makelog
       - name: Make (App)
         run: |
-          Import-VisualStudioVars -VisualStudioVersion $Env:VISUAL_STUDIO_VERSION -Architecture x64
-          cmake --build obj --config Debug --target transmission-app 2>&1 | tee -a makelog
+          cmd /c "\"$Env:VCVARSALL\" $Env:VC_ARCH >nul && cmake --build obj --config Debug --target transmission-app" 2>&1 | tee -a makelog
       - name: Make (Tests)
         if: needs.what-to-make.outputs.make-tests == 'true'
         run: |
-          Import-VisualStudioVars -VisualStudioVersion $Env:VISUAL_STUDIO_VERSION -Architecture x64
-          cmake --build obj --config Debug --target libtransmission-test 2>&1 | tee -a makelog
+          cmd /c "\"$Env:VCVARSALL\" $Env:VC_ARCH >nul && cmake --build obj --config Debug --target libtransmission-test" 2>&1 | tee -a makelog
       - name: Test for warnings
         run: |
           if (Select-String -Path makelog -Pattern 'warning:') { exit 1 }
@@ -697,31 +686,35 @@ jobs:
         with:
           arch: ${{ matrix.arch }}
           type: Deps
+      - name: Setup Visual Studio Environment
+        uses: ./.github/actions/setup-vs-env-win32
+        with:
+          arch: ${{ matrix.arch }}
       - name: Configure
         run: |
-          Import-VisualStudioVars -VisualStudioVersion 2022 -Architecture ${{ matrix.arch }}
-          cmake `
-            -S . `
-            -B obj `
-            -G Ninja `
-            -DCMAKE_BUILD_TYPE=RelWithDebInfo `
-            -DCMAKE_INSTALL_PREFIX=pfx `
-            -DCMAKE_PREFIX_PATH="${Env:DEPS_PREFIX}" `
-            -DENABLE_CLI=${{ (needs.what-to-make.outputs.make-cli == 'true') && 'ON' || 'OFF' }} `
-            -DENABLE_DAEMON=${{ (needs.what-to-make.outputs.make-daemon == 'true' || needs.what-to-make.outputs.make-dist == 'true') && 'ON' || 'OFF' }} `
-            -DENABLE_GTK=OFF `
-            -DENABLE_MAC=OFF `
-            -DENABLE_QT=${{ (needs.what-to-make.outputs.make-dist == 'true' || needs.what-to-make.outputs.make-qt == 'true') && 'ON' || 'OFF' }} `
-            -DENABLE_TESTS=${{ (needs.what-to-make.outputs.make-tests == 'true') && 'ON' || 'OFF' }} `
-            -DENABLE_UTILS=ON `
-            -DREBUILD_WEB=${{ (needs.what-to-make.outputs.make-web == 'true') && 'ON' || 'OFF' }} `
-            -DENABLE_WERROR=ON `
-            -DRUN_CLANG_TIDY=OFF `
-            -DUSE_SYSTEM_DEFAULT=OFF
+          $CmakeArgs = @(
+            '-S .'
+            '-B obj'
+            '-G Ninja'
+            '-DCMAKE_BUILD_TYPE=RelWithDebInfo'
+            '-DCMAKE_INSTALL_PREFIX=pfx'
+            "-DCMAKE_PREFIX_PATH=$Env:DEPS_PREFIX"
+            "-DENABLE_CLI=${{ (needs.what-to-make.outputs.make-cli == 'true') && 'ON' || 'OFF' }}"
+            "-DENABLE_DAEMON=${{ (needs.what-to-make.outputs.make-daemon == 'true' || needs.what-to-make.outputs.make-dist == 'true') && 'ON' || 'OFF' }}"
+            '-DENABLE_GTK=OFF'
+            '-DENABLE_MAC=OFF'
+            "-DENABLE_QT=${{ (needs.what-to-make.outputs.make-dist == 'true' || needs.what-to-make.outputs.make-qt == 'true') && 'ON' || 'OFF' }}"
+            "-DENABLE_TESTS=${{ (needs.what-to-make.outputs.make-tests == 'true') && 'ON' || 'OFF' }}"
+            '-DENABLE_UTILS=ON'
+            "-DREBUILD_WEB=${{ (needs.what-to-make.outputs.make-web == 'true') && 'ON' || 'OFF' }}"
+            '-DENABLE_WERROR=ON'
+            '-DRUN_CLANG_TIDY=OFF'
+            '-DUSE_SYSTEM_DEFAULT=OFF'
+          )
+          cmd /c "\"$Env:VCVARSALL\" $Env:VC_ARCH >nul && cmake $($CmakeArgs -join ' ')"
       - name: Make
         run: |
-          Import-VisualStudioVars -VisualStudioVersion 2022 -Architecture ${{ matrix.arch }}
-          cmake --build obj --config RelWithDebInfo
+          cmd /c "\"$Env:VCVARSALL\" $Env:VC_ARCH >nul && cmake --build obj --config RelWithDebInfo"
       - name: Test
         if: ${{ needs.what-to-make.outputs.make-tests == 'true' }}
         uses: ./.github/actions/run-tests
@@ -734,8 +727,7 @@ jobs:
       - name: Package
         if: ${{ needs.what-to-make.outputs.make-dist == 'true' || (needs.what-to-make.outputs.make-daemon == 'true' && needs.what-to-make.outputs.make-qt == 'true') }}
         run: |
-          Import-VisualStudioVars -VisualStudioVersion 2022 -Architecture ${{ matrix.arch }}
-          cmake --build obj --config RelWithDebInfo --target pack-msi
+          cmd /c "\"$Env:VCVARSALL\" $Env:VC_ARCH >nul && cmake --build obj --config RelWithDebInfo --target pack-msi"
       - uses: actions/upload-artifact@v6
         with:
           name: binaries-${{ github.job }}-${{ matrix.arch }}

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -440,17 +440,17 @@ jobs:
             '-DRUN_CLANG_TIDY=ON'
             '-DUSE_SYSTEM_DEFAULT=OFF'
           )
-          cmd /c "\"$Env:VCVARSALL\" $Env:VC_ARCH >nul && cmake $($CmakeArgs -join ' ')"
+          cmd /c "`"$Env:VCVARSALL`" $Env:VC_ARCH >nul && cmake $($CmakeArgs -join ' ')"
       - name: Make (Core)
         run: |
-          cmd /c "\"$Env:VCVARSALL\" $Env:VC_ARCH >nul && cmake --build obj --config Debug --target transmission" 2>&1 | tee makelog
+          cmd /c "`"$Env:VCVARSALL`" $Env:VC_ARCH >nul && cmake --build obj --config Debug --target transmission" 2>&1 | tee makelog
       - name: Make (App)
         run: |
-          cmd /c "\"$Env:VCVARSALL\" $Env:VC_ARCH >nul && cmake --build obj --config Debug --target transmission-app" 2>&1 | tee -a makelog
+          cmd /c "`"$Env:VCVARSALL`" $Env:VC_ARCH >nul && cmake --build obj --config Debug --target transmission-app" 2>&1 | tee -a makelog
       - name: Make (Tests)
         if: needs.what-to-make.outputs.make-tests == 'true'
         run: |
-          cmd /c "\"$Env:VCVARSALL\" $Env:VC_ARCH >nul && cmake --build obj --config Debug --target libtransmission-test" 2>&1 | tee -a makelog
+          cmd /c "`"$Env:VCVARSALL`" $Env:VC_ARCH >nul && cmake --build obj --config Debug --target libtransmission-test" 2>&1 | tee -a makelog
       - name: Test for warnings
         run: |
           if (Select-String -Path makelog -Pattern 'warning:') { exit 1 }
@@ -711,10 +711,10 @@ jobs:
             '-DRUN_CLANG_TIDY=OFF'
             '-DUSE_SYSTEM_DEFAULT=OFF'
           )
-          cmd /c "\"$Env:VCVARSALL\" $Env:VC_ARCH >nul && cmake $($CmakeArgs -join ' ')"
+          cmd /c "`"$Env:VCVARSALL`" $Env:VC_ARCH >nul && cmake $($CmakeArgs -join ' ')"
       - name: Make
         run: |
-          cmd /c "\"$Env:VCVARSALL\" $Env:VC_ARCH >nul && cmake --build obj --config RelWithDebInfo"
+          cmd /c "`"$Env:VCVARSALL`" $Env:VC_ARCH >nul && cmake --build obj --config RelWithDebInfo"
       - name: Test
         if: ${{ needs.what-to-make.outputs.make-tests == 'true' }}
         uses: ./.github/actions/run-tests
@@ -727,7 +727,7 @@ jobs:
       - name: Package
         if: ${{ needs.what-to-make.outputs.make-dist == 'true' || (needs.what-to-make.outputs.make-daemon == 'true' && needs.what-to-make.outputs.make-qt == 'true') }}
         run: |
-          cmd /c "\"$Env:VCVARSALL\" $Env:VC_ARCH >nul && cmake --build obj --config RelWithDebInfo --target pack-msi"
+          cmd /c "`"$Env:VCVARSALL`" $Env:VC_ARCH >nul && cmake --build obj --config RelWithDebInfo --target pack-msi"
       - uses: actions/upload-artifact@v6
         with:
           name: binaries-${{ github.job }}-${{ matrix.arch }}

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -74,7 +74,7 @@ jobs:
           get_changes tests      CMakeLists.txt cmake third-party libtransmission utils tests
           get_changes utils      CMakeLists.txt cmake third-party libtransmission utils
           get_changes web        CMakeLists.txt cmake web
-          get_changes ci-actions .github/workflows/actions.yml .github/actions
+          get_changes ci-actions .github/workflows/actions.yml .github/actions release
           cat "$GITHUB_OUTPUT"
 
   code-style:

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -424,9 +424,22 @@ jobs:
         with:
           arch: x64
           type: CoreDeps
+      - name: Detect Visual Studio Version
+        run: |
+          $VsWherePath = Join-Path ${Env:ProgramFiles(x86)} 'Microsoft Visual Studio' Installer vswhere.exe
+          if (-not (Test-Path $VsWherePath)) {
+            throw "vswhere.exe was not found at expected path: $VsWherePath"
+          }
+
+          $VsVersion = & $VsWherePath -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property catalog_productLineVersion
+          if (-not $VsVersion) {
+            throw 'Unable to determine Visual Studio version from vswhere.'
+          }
+
+          "VISUAL_STUDIO_VERSION=$VsVersion" | Out-File $Env:GITHUB_ENV -Append
       - name: Configure
         run: |
-          Import-VisualStudioVars -VisualStudioVersion 2022 -Architecture x64
+          Import-VisualStudioVars -VisualStudioVersion $Env:VISUAL_STUDIO_VERSION -Architecture x64
           cmake `
             -S src `
             -B obj `
@@ -438,16 +451,16 @@ jobs:
             -DUSE_SYSTEM_DEFAULT=OFF
       - name: Make (Core)
         run: |
-          Import-VisualStudioVars -VisualStudioVersion 2022 -Architecture x64
+          Import-VisualStudioVars -VisualStudioVersion $Env:VISUAL_STUDIO_VERSION -Architecture x64
           cmake --build obj --config Debug --target transmission 2>&1 | tee makelog
       - name: Make (App)
         run: |
-          Import-VisualStudioVars -VisualStudioVersion 2022 -Architecture x64
+          Import-VisualStudioVars -VisualStudioVersion $Env:VISUAL_STUDIO_VERSION -Architecture x64
           cmake --build obj --config Debug --target transmission-app 2>&1 | tee -a makelog
       - name: Make (Tests)
         if: needs.what-to-make.outputs.make-tests == 'true'
         run: |
-          Import-VisualStudioVars -VisualStudioVersion 2022 -Architecture x64
+          Import-VisualStudioVars -VisualStudioVersion $Env:VISUAL_STUDIO_VERSION -Architecture x64
           cmake --build obj --config Debug --target libtransmission-test 2>&1 | tee -a makelog
       - name: Test for warnings
         run: |

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -435,7 +435,7 @@ jobs:
             '-B obj'
             '-G Ninja'
             '-DCMAKE_BUILD_TYPE=Debug'
-            "-DCMAKE_PREFIX_PATH=$Env:DEPS_PREFIX"
+            "-DCMAKE_PREFIX_PATH=`"$Env:DEPS_PREFIX`""
             "-DENABLE_TESTS=${{ needs.what-to-make.outputs.make-tests == 'true' && 'ON' || 'OFF' }}"
             '-DRUN_CLANG_TIDY=ON'
             '-DUSE_SYSTEM_DEFAULT=OFF'
@@ -698,7 +698,7 @@ jobs:
             '-G Ninja'
             '-DCMAKE_BUILD_TYPE=RelWithDebInfo'
             '-DCMAKE_INSTALL_PREFIX=pfx'
-            "-DCMAKE_PREFIX_PATH=$Env:DEPS_PREFIX"
+            "-DCMAKE_PREFIX_PATH=`"$Env:DEPS_PREFIX`""
             "-DENABLE_CLI=${{ (needs.what-to-make.outputs.make-cli == 'true') && 'ON' || 'OFF' }}"
             "-DENABLE_DAEMON=${{ (needs.what-to-make.outputs.make-daemon == 'true' || needs.what-to-make.outputs.make-dist == 'true') && 'ON' || 'OFF' }}"
             '-DENABLE_GTK=OFF'

--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -88,10 +88,13 @@ struct StopsCompare
         return tr_compare_3way(one.announce_url, two.announce_url);
     }
 
+    // Suppress STL-instantiation noise from MSVC xutility noexcept(bool(...)).
+    // NOLINTBEGIN(readability-redundant-casting)
     [[nodiscard]] constexpr auto operator()(tr_announce_request const& one, tr_announce_request const& two) const noexcept
     {
         return compare(one, two) < 0;
     }
+    // NOLINTEND(readability-redundant-casting)
 };
 
 } // namespace
@@ -1581,11 +1584,14 @@ void scrapeAndAnnounceMore(tr_announcer_impl* announcer)
      * available, use compareAnnounceTiers to prioritize. */
     if (announce_me.size() > MaxAnnouncesPerUpkeep)
     {
+        // Suppress STL-instantiation noise from MSVC xutility noexcept(bool(...)).
+        // NOLINTBEGIN(readability-redundant-casting)
         std::partial_sort(
             std::begin(announce_me),
             std::begin(announce_me) + MaxAnnouncesPerUpkeep,
             std::end(announce_me),
             [](auto const* a, auto const* b) { return compareAnnounceTiers(a, b) < 0; });
+        // NOLINTEND(readability-redundant-casting)
         announce_me.resize(MaxAnnouncesPerUpkeep);
     }
 

--- a/libtransmission/ip-cache.cc
+++ b/libtransmission/ip-cache.cc
@@ -78,7 +78,7 @@ namespace global_source_ip_helpers
 
     auto const [dst_ss, dst_sslen] = tr_socket_address::to_sockaddr(dst_addr, dst_port);
     auto const [bind_ss, bind_sslen] = tr_socket_address::to_sockaddr(bind_addr, {});
-    if (auto const sock = socket(dst_ss.ss_family, SOCK_DGRAM, 0); sock != TR_BAD_SOCKET)
+    if (auto const sock = socket(dst_ss.ss_family, SOCK_DGRAM, 0); is_valid_socket(sock))
     {
         if (bind(sock, reinterpret_cast<sockaddr const*>(&bind_ss), bind_sslen) == 0)
         {

--- a/libtransmission/net.cc
+++ b/libtransmission/net.cc
@@ -113,7 +113,7 @@ int tr_make_listen_socket_ipv6only(tr_socket_t const sock)
 
 void tr_netSetDiffServ([[maybe_unused]] tr_socket_t s, [[maybe_unused]] int tos, tr_address_type type)
 {
-    if (s == TR_BAD_SOCKET)
+    if (!is_valid_socket(s))
     {
         return;
     }
@@ -151,7 +151,7 @@ tr_socket_t tr_netBindTCPImpl(tr_address const& addr, tr_port port, bool suppres
     TR_ASSERT(addr.is_valid());
 
     auto const fd = socket(tr_ip_protocol_to_af(addr.type), SOCK_STREAM, 0);
-    if (fd == TR_BAD_SOCKET)
+    if (!is_valid_socket(fd))
     {
         *err_out = sockerrno;
         return TR_BAD_SOCKET;
@@ -247,7 +247,7 @@ std::optional<std::pair<tr_socket_address, tr_socket_t>> tr_netAccept(tr_session
     auto sock = sockaddr_storage{};
     socklen_t len = sizeof(struct sockaddr_storage);
     auto const sockfd = accept(listening_sockfd, reinterpret_cast<sockaddr*>(&sock), &len);
-    if (sockfd == TR_BAD_SOCKET)
+    if (!is_valid_socket(sockfd))
     {
         return {};
     }

--- a/libtransmission/net.h
+++ b/libtransmission/net.h
@@ -61,6 +61,11 @@ using tr_socket_t = int;
 #define set_sockerrno(save) (sockerrno) = (save)
 #endif
 
+[[nodiscard]] constexpr bool is_valid_socket(tr_socket_t s) noexcept
+{
+    return s != static_cast<tr_socket_t>(TR_BAD_SOCKET);
+}
+
 #include "libtransmission/tr-assert.h"
 #include "libtransmission/types.h"
 #include "libtransmission/utils.h" // for tr_compare_3way()

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -2298,10 +2298,13 @@ struct ComparePeerInfo
     }
 
     template<typename T>
+    // Suppress STL-instantiation noise from MSVC xutility noexcept(bool(...)).
+    // NOLINTBEGIN(readability-redundant-casting)
     [[nodiscard]] bool operator()(T const& a, T const& b) const noexcept
     {
         return compare(*a, *b) < 0;
     }
+    // NOLINTEND(readability-redundant-casting)
 
     time_t const now_ = tr_time();
 };

--- a/libtransmission/peer-socket-tcp.cc
+++ b/libtransmission/peer-socket-tcp.cc
@@ -11,6 +11,8 @@
 #include <netinet/tcp.h> // TCP_CONGESTION
 #endif
 
+#include <utility> // std::cmp_equal
+
 #include <event2/event.h>
 
 #include <fmt/format.h>
@@ -29,7 +31,7 @@ namespace
 tr_socket_t create_socket(int const domain)
 {
     auto const sockfd = socket(domain, SOCK_STREAM, 0);
-    if (sockfd == TR_BAD_SOCKET)
+    if (!is_valid_socket(sockfd))
     {
         if (sockerrno != EAFNOSUPPORT)
         {
@@ -84,7 +86,7 @@ tr_socket_t open_peer_socket(tr_session const& session, tr_socket_address const&
     }
 
     auto const s = create_socket(tr_ip_protocol_to_af(addr.type));
-    if (s == TR_BAD_SOCKET)
+    if (!is_valid_socket(s))
     {
         return TR_BAD_SOCKET;
     }
@@ -163,7 +165,7 @@ public:
         : tr_peer_socket_tcp{ socket_address }
         , sock_{ sock }
     {
-        TR_ASSERT(sock_ != TR_BAD_SOCKET);
+        TR_ASSERT(is_valid_socket(sock_));
 
         session.setSocketDiffServ(sock, address().type);
 
@@ -322,7 +324,7 @@ private:
         auto* const s = static_cast<tr_peer_socket_tcp_impl*>(vs);
         tr_logAddTraceSock(s, "libevent says this peer socket is ready for reading");
 
-        TR_ASSERT(s->sock_ == fd);
+        TR_ASSERT(std::cmp_equal(s->sock_, fd));
 
         s->is_read_enabled_ = false;
         s->read_cb();
@@ -333,7 +335,7 @@ private:
         auto* const s = static_cast<tr_peer_socket_tcp_impl*>(vs);
         tr_logAddTraceSock(s, "libevent says this peer socket is ready for writing");
 
-        TR_ASSERT(s->sock_ == fd);
+        TR_ASSERT(std::cmp_equal(s->sock_, fd));
 
         s->is_write_enabled_ = false;
         s->write_cb();
@@ -359,7 +361,7 @@ std::unique_ptr<tr_peer_socket_tcp> tr_peer_socket_tcp::create(
     tr_socket_address const& socket_address,
     bool const client_is_seed)
 {
-    if (auto const sock = open_peer_socket(session, socket_address, client_is_seed); sock != TR_BAD_SOCKET)
+    if (auto const sock = open_peer_socket(session, socket_address, client_is_seed); is_valid_socket(sock))
     {
         return create(session, socket_address, sock);
     }

--- a/libtransmission/peer-socket-utp.cc
+++ b/libtransmission/peer-socket-utp.cc
@@ -55,13 +55,13 @@ int default_udp_bufsize(int const optname)
 {
     int ret = -1;
 
-    if (auto const fd = socket(PF_INET, SOCK_DGRAM, 0); fd != TR_BAD_SOCKET)
+    if (auto const fd = socket(PF_INET, SOCK_DGRAM, 0); is_valid_socket(fd))
     {
         get_bufsize(fd, optname, ret);
         tr_net_close_socket(fd);
     }
 
-    if (auto const fd = socket(PF_INET6, SOCK_DGRAM, 0); fd != TR_BAD_SOCKET)
+    if (auto const fd = socket(PF_INET6, SOCK_DGRAM, 0); is_valid_socket(fd))
     {
         get_bufsize(fd, optname, ret);
         tr_net_close_socket(fd);

--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -759,7 +759,7 @@ int tr_evhttp_bind_socket(struct evhttp* httpd, char const* address, ev_uint16_t
     }
 
     auto const fd = socket(result->ai_family, result->ai_socktype, result->ai_protocol);
-    if (fd == INVALID_SOCKET)
+    if (!is_valid_socket(fd))
     {
         freeaddrinfo(result);
         return evhttp_bind_socket(httpd, address, port);

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -421,7 +421,7 @@ tr_session::BoundSocket::BoundSocket(
           &BoundSocket::onCanRead,
           this) }
 {
-    if (socket_ == TR_BAD_SOCKET)
+    if (!is_valid_socket(socket_))
     {
         return;
     }
@@ -437,7 +437,7 @@ tr_session::BoundSocket::~BoundSocket()
 {
     ev_.reset();
 
-    if (socket_ != TR_BAD_SOCKET)
+    if (is_valid_socket(socket_))
     {
         tr_net_close_socket(socket_);
         socket_ = TR_BAD_SOCKET;

--- a/libtransmission/subprocess-win32.cc
+++ b/libtransmission/subprocess-win32.cc
@@ -73,10 +73,13 @@ public:
         return diff;
     }
 
+    // Suppress STL-instantiation noise from MSVC xutility noexcept(bool(...)).
+    // NOLINTBEGIN(readability-redundant-casting)
     [[nodiscard]] auto operator()(std::wstring_view a, std::wstring_view b) const noexcept // <
     {
         return compare(a, b) < 0;
     }
+    // NOLINTEND(readability-redundant-casting)
 };
 
 using SortedWideEnv = std::map<std::wstring, std::wstring, WStrICompare>;

--- a/libtransmission/tr-assert.cc
+++ b/libtransmission/tr-assert.cc
@@ -10,7 +10,7 @@
 
 #include "libtransmission/tr-assert.h"
 
-[[noreturn]] bool tr_assert_report(std::string_view file, long line, std::string_view message)
+[[noreturn]] void tr_assert_report(std::string_view file, long line, std::string_view message)
 {
     std::cerr << "assertion failed: " << message << " (" << file << ':' << line << ")\n";
     abort();

--- a/libtransmission/tr-assert.h
+++ b/libtransmission/tr-assert.h
@@ -9,10 +9,10 @@
 
 #include <string_view>
 
-[[noreturn]] bool tr_assert_report(std::string_view file, long line, std::string_view message);
+[[noreturn]] void tr_assert_report(std::string_view file, long line, std::string_view message);
 
-#define TR_ASSERT(x) ((void)((x) || tr_assert_report(__FILE__, __LINE__, #x)))
-#define TR_ASSERT_MSG(x, message) ((void)((x) || tr_assert_report(__FILE__, __LINE__, message)))
+#define TR_ASSERT(x) ((x) ? (void)0 : tr_assert_report(__FILE__, __LINE__, #x))
+#define TR_ASSERT_MSG(x, message) ((x) ? (void)0 : tr_assert_report(__FILE__, __LINE__, message))
 
 #define TR_ENABLE_ASSERTS
 

--- a/libtransmission/tr-dht.cc
+++ b/libtransmission/tr-dht.cc
@@ -235,7 +235,7 @@ private:
 
     [[nodiscard]] SwarmStatus swarm_status(int family, int* const setme_node_count = nullptr) const
     {
-        if (udp_socket(family) == TR_BAD_SOCKET)
+        if (!is_valid_socket(udp_socket(family)))
         {
             if (setme_node_count != nullptr)
             {

--- a/libtransmission/tr-lpd.cc
+++ b/libtransmission/tr-lpd.cc
@@ -250,7 +250,7 @@ public:
 
         for (auto const sock : mcast_sockets_)
         {
-            if (sock != TR_BAD_SOCKET)
+            if (is_valid_socket(sock))
             {
                 tr_net_close_socket(sock);
             }
@@ -314,7 +314,7 @@ private:
         // setup datagram socket
         sock = socket(tr_ip_protocol_to_af(ip_protocol), SOCK_DGRAM, 0);
 
-        if (sock == TR_BAD_SOCKET)
+        if (!is_valid_socket(sock))
         {
             return false;
         }
@@ -634,7 +634,7 @@ private:
             return false;
         }
 
-        if (mcast_sockets_[ip_protocol] == TR_BAD_SOCKET)
+        if (!is_valid_socket(mcast_sockets_[ip_protocol]))
         {
             return true;
         }

--- a/libtransmission/tr-udp.cc
+++ b/libtransmission/tr-udp.cc
@@ -172,7 +172,7 @@ tr_session::tr_udp_core::tr_udp_core(tr_session& session, tr_port udp_port)
     {
         // no IPv4; do nothing
     }
-    else if (tr_socket_t const sock = socket(PF_INET, SOCK_DGRAM, 0); sock != TR_BAD_SOCKET)
+    else if (tr_socket_t const sock = socket(PF_INET, SOCK_DGRAM, 0); is_valid_socket(sock))
     {
         (void)evutil_make_listen_socket_reuseable(static_cast<evutil_socket_t>(sock));
 
@@ -224,7 +224,7 @@ tr_session::tr_udp_core::tr_udp_core(tr_session& session, tr_port udp_port)
     {
         // no IPv6; do nothing
     }
-    else if (tr_socket_t const sock = socket(PF_INET6, SOCK_DGRAM, 0); sock != TR_BAD_SOCKET)
+    else if (tr_socket_t const sock = socket(PF_INET6, SOCK_DGRAM, 0); is_valid_socket(sock))
     {
         (void)evutil_make_listen_socket_reuseable(static_cast<evutil_socket_t>(sock));
         (void)tr_make_listen_socket_ipv6only(static_cast<evutil_socket_t>(sock));
@@ -273,7 +273,7 @@ tr_session::tr_udp_core::tr_udp_core(tr_session& session, tr_port udp_port)
         }
     }
 
-    if (udp4_socket_ == TR_BAD_SOCKET && udp6_socket_ == TR_BAD_SOCKET)
+    if (!is_valid_socket(udp4_socket_) && !is_valid_socket(udp6_socket_))
     {
         tr_logAddError(_("Couldn't create any UDP sockets."));
     }
@@ -283,7 +283,7 @@ tr_session::tr_udp_core::~tr_udp_core()
 {
     udp6_event_.reset();
 
-    if (udp6_socket_ != TR_BAD_SOCKET)
+    if (is_valid_socket(udp6_socket_))
     {
         tr_net_close_socket(udp6_socket_);
         udp6_socket_ = TR_BAD_SOCKET;
@@ -291,7 +291,7 @@ tr_session::tr_udp_core::~tr_udp_core()
 
     udp4_event_.reset();
 
-    if (udp4_socket_ != TR_BAD_SOCKET)
+    if (is_valid_socket(udp4_socket_))
     {
         tr_net_close_socket(udp4_socket_);
         udp4_socket_ = TR_BAD_SOCKET;
@@ -305,7 +305,7 @@ void tr_session::tr_udp_core::sendto(void const* buf, size_t buflen, struct sock
     {
         errno = EAFNOSUPPORT;
     }
-    else if (auto const sock = to->sa_family == AF_INET ? udp4_socket_ : udp6_socket_; sock == TR_BAD_SOCKET)
+    else if (auto const sock = to->sa_family == AF_INET ? udp4_socket_ : udp6_socket_; !is_valid_socket(sock))
     {
         // don't warn on bad sockets; the system may not support IPv6
         return;

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -23,6 +23,7 @@
 #include <string_view>
 #include <system_error>
 #include <type_traits>
+#include <utility> // std::cmp_equal
 #include <vector>
 
 #ifdef _WIN32
@@ -167,7 +168,7 @@ std::optional<std::vector<std::string>> win32MakeUtf8Argv()
         LocalFree(reinterpret_cast<HLOCAL>(wargv));
     }
 
-    if (static_cast<int>(std::size(argv)) == argc)
+    if (std::cmp_equal(std::size(argv), argc))
     {
         return argv;
     }

--- a/libtransmission/watchdir-win32.cc
+++ b/libtransmission/watchdir-win32.cc
@@ -112,12 +112,12 @@ public:
             bufferevent_free(event_);
         }
 
-        if (notify_pipe_[0] != TR_BAD_SOCKET)
+        if (is_valid_socket(notify_pipe_[0]))
         {
             tr_net_close_socket(notify_pipe_[0]);
         }
 
-        if (notify_pipe_[1] != TR_BAD_SOCKET)
+        if (is_valid_socket(notify_pipe_[1]))
         {
             tr_net_close_socket(notify_pipe_[1]);
         }
@@ -284,17 +284,6 @@ private:
                 break;
             }
 
-            if (nread == static_cast<size_t>(-1))
-            {
-                auto const error_code = errno;
-                tr_logAddError(
-                    fmt::format(
-                        _("Couldn't read event: {error} ({error_code})"),
-                        fmt::arg("error", tr_strerror(error_code)),
-                        fmt::arg("error_code", error_code)));
-                break;
-            }
-
             if (nread != header_size)
             {
                 tr_logAddError(
@@ -320,17 +309,6 @@ private:
 
             // consume entire name into buffer
             nread = bufferevent_read(event, &buffer[header_size], nleft);
-            if (nread == static_cast<size_t>(-1))
-            {
-                auto const error_code = errno;
-                tr_logAddError(
-                    fmt::format(
-                        _("Couldn't read filename: {error} ({error_code})"),
-                        fmt::arg("error", tr_strerror(error_code)),
-                        fmt::arg("error_code", error_code)));
-                break;
-            }
-
             if (nread != nleft)
             {
                 tr_logAddError(

--- a/release/windows/toolchain.ps1
+++ b/release/windows/toolchain.ps1
@@ -20,13 +20,19 @@ if (-not (Test-Path $VsWherePath)) {
     throw 'vswhere was not found. Expected it under "Program Files (x86)\\Microsoft Visual Studio\\Installer".'
 }
 
-$VsInstance = & $VsWherePath -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -format json | ConvertFrom-Json
+$RequiredComponent = if ($BuildArch -eq 'arm64') {
+    'Microsoft.VisualStudio.Component.VC.Tools.ARM64'
+} else {
+    'Microsoft.VisualStudio.Component.VC.Tools.x86.x64'
+}
+
+$VsInstance = & $VsWherePath -latest -products * -requires $RequiredComponent -format json | ConvertFrom-Json
 if ($VsInstance -is [Array]) {
     $VsInstance = $VsInstance[0]
 }
 
 if (-not $VsInstance -or -not $VsInstance.installationPath) {
-    throw 'No Visual Studio instance with C++ x86/x64 tools was found by vswhere.'
+    throw "No Visual Studio instance with component '$RequiredComponent' was found by vswhere."
 }
 
 $global:VsInstallPrefix = $VsInstance.installationPath

--- a/release/windows/toolchain.ps1
+++ b/release/windows/toolchain.ps1
@@ -12,15 +12,30 @@ $global:LinkerFlags = @(
     '/PDBALTPATH:%_PDB%'
 )
 
-foreach ($VsType in @('Enterprise', 'Professional', 'Community', 'BuildTools')) {
-    $global:VsInstallPrefix = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio' 2022 $VsType
-    if (Test-Path $global:VsInstallPrefix) {
-        break
-    }
-    $global:VsInstallPrefix = Join-Path ${env:ProgramFiles} 'Microsoft Visual Studio' 2022 $VsType
-    if (Test-Path $global:VsInstallPrefix) {
-        break
-    }
+$VsWherePath = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio' Installer vswhere.exe
+if (-not (Test-Path $VsWherePath)) {
+    $VsWherePath = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio' Installer vswhere
 }
-$global:VsVersion = ((& (Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio' Installer vswhere) -Property catalog_productSemanticVersion -Path $VsInstallPrefix) -Split '[+]')[0]
+if (-not (Test-Path $VsWherePath)) {
+    throw 'vswhere was not found. Expected it under "Program Files (x86)\\Microsoft Visual Studio\\Installer".'
+}
+
+$VsInstance = & $VsWherePath -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -format json | ConvertFrom-Json
+if ($VsInstance -is [Array]) {
+    $VsInstance = $VsInstance[0]
+}
+
+if (-not $VsInstance -or -not $VsInstance.installationPath) {
+    throw 'No Visual Studio instance with C++ x86/x64 tools was found by vswhere.'
+}
+
+$global:VsInstallPrefix = $VsInstance.installationPath
+$global:VsVersion = ($VsInstance.catalog.productSemanticVersion -split '[+]')[0]
+if (-not $global:VsVersion) {
+    throw 'Unable to determine Visual Studio semantic version from vswhere output.'
+}
+
 $global:VcVarsScript = Join-Path $VsInstallPrefix VC Auxiliary Build vcvarsall.bat
+if (-not (Test-Path $global:VcVarsScript)) {
+    throw "vcvarsall.bat was not found at expected path: $global:VcVarsScript"
+}


### PR DESCRIPTION
GitHub's added Visual Studio 2026 to their windows-2025 runners, which is breaking our clang-tidy job:

- It's finding a new set of clang-warnings that need to be fixed
- In the `release/` scripts, Pscx's `Import-VisualStudioVars` fails on this version of VS
- The paths to visual studio need to be updated, eg we have places that hardcode VS 2022 in the paths

This PR uses `vswhere` to find Visual Studio's paths, has a small bespoke helper to replace `Import-VisualStudioVars`, and fixes the clang-tidy warnings.

---

Potential fix for this CI failure in `clang-tidy-libtransmission-win32`:

```
nasm v3.1.0 [Approved]
nasm package files install completed. Performing other installation steps.
Installing 64-bit nasm...
nasm has been installed.
 The install of nasm was successful.
  Software installed as 'EXE', install location is likely default.
wixtoolset v3.14.1.20250415 already installed.
 Use --force to reinstall, specify a version to install, or try upgrade.

Chocolatey installed 2/3 packages. 
 See the log for details (C:\ProgramData\chocolatey\logs\chocolatey.log).

Warnings:
 - wixtoolset - wixtoolset v3.14.1.20250415 already installed.
 Use --force to reinstall, specify a version to install, or try upgrade.
Run $RepoRoot = if (Test-Path (Join-Path . 'src/release/windows/main.ps1')) { Join-Path . 'src' } else { (Get-Item .).FullName }
  $RepoRoot = if (Test-Path (Join-Path . 'src/release/windows/main.ps1')) { Join-Path . 'src' } else { (Get-Item .).FullName }
  try {
      $DepsHash = & (Join-Path $RepoRoot release windows main.ps1) -Mode DepsHash -BuildArch x64 -BuildPart CoreDeps
      "hash=${DepsHash}" | Out-File $Env:GITHUB_OUTPUT -Append
  } catch {
      Write-Error ("{1}{0}{2}{0}{3}" -f [Environment]::NewLine, $_.ToString(), $_.InvocationInfo.PositionMessage, $_.ScriptStackTrace) -ErrorAction Continue
      exit 1
  }
  shell: C:\Program Files\PowerShell\7\pwsh.EXE -command ". '{0}'"
  env:
    GTEST_OUTPUT: xml:./
    DEPS_PREFIX: D:\x64-prefix
Write-Error: Index was outside the bounds of the array.
At D:\a\_temp\5216cc28-a9f3-4c98-b8b3-55f771c4b216.ps1:4 char:17
+ … $DepsHash = & (Join-Path $RepoRoot release windows main.ps1) -Mode De …
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
at <ScriptBlock>, D:\a\transmission\transmission\src\release\windows\toolchain.ps1: line 25
at Invoke-DownloadAndInclude, D:\a\transmission\transmission\src\release\windows\main.ps1: line 115
at Import-Script, D:\a\transmission\transmission\src\release\windows\main.ps1: line 167
at <ScriptBlock>, D:\a\transmission\transmission\src\release\windows\main.ps1: line 259
at <ScriptBlock>, D:\a\_temp\5216cc28-a9f3-4c98-b8b3-55f771c4b216.ps1: line 4
at <ScriptBlock>, <No file>: line 1
Error: Process completed with exit code 1.
```