### PR TITLE
#8913: Fix window height auto-sizing with groups

### DIFF
--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -5304,12 +5304,6 @@ static void removeKeRangerRansomware()
 
         height = (kGroupSeparatorHeight + self.fTableView.intercellSpacing.height) * groups +
             (self.fTableView.rowHeight + self.fTableView.intercellSpacing.height) * (self.fTableView.numberOfRows - groups);
-
-        //account for group padding...
-        if (groups > 1)
-        {
-            height += (groups - 1) * 20;
-        }
     }
     else
     {


### PR DESCRIPTION
There was a "group padding" that was added to the height calculation that wasn't needed (from my testing in both size modes with and without groups).

Notes: Fixed window height auto-sizing with groups.