### PR TITLE
refactor: remove u8string-related serializers

### DIFF
--- a/libtransmission/serializer.cc
+++ b/libtransmission/serializer.cc
@@ -492,29 +492,6 @@ tr_variant from_verify_added_mode(tr_verify_added_mode const& val)
 
 // ---
 
-bool to_u8string(tr_variant const& src, std::u8string* tgt)
-{
-    if (auto const val = src.value_if<std::string_view>())
-    {
-        if (tr_strv_find_invalid_utf8(*val) != std::string_view::npos)
-        {
-            tr_logAddWarn(fmt::format(fmt::runtime(_("String '{string}' contains invalid UTF-8")), fmt::arg("string", *val)));
-        }
-
-        *tgt = tr_strv_to_u8string(tr_strv_replace_invalid(*val));
-        return true;
-    }
-
-    return false;
-}
-
-tr_variant from_u8string(std::u8string const& val)
-{
-    return std::string{ reinterpret_cast<char const*>(std::data(val)), std::size(val) };
-}
-
-// ---
-
 bool to_pex(tr_variant const& src, tr_pex* tgt)
 {
     auto* const map = src.get_if<tr_variant::Map>();
@@ -593,7 +570,6 @@ void Converters::ensure_default_converters()
             Converters::add(to_preferred_transport, from_preferred_transport);
             Converters::add(to_sched_day, from_sched_day);
             Converters::add(to_string, from_string);
-            Converters::add(to_u8string, from_u8string);
             Converters::add(to_verify_added_mode, from_verify_added_mode);
         });
 }

--- a/libtransmission/serializer.cc
+++ b/libtransmission/serializer.cc
@@ -8,7 +8,6 @@
 #include <chrono>
 #include <cstddef> // size_t
 #include <cstdint> // int64_t, uint32_t, uint64_t
-#include <filesystem>
 #include <limits>
 #include <mutex>
 #include <optional>
@@ -516,24 +515,6 @@ tr_variant from_u8string(std::u8string const& val)
 
 // ---
 
-bool to_fs_path(tr_variant const& src, std::filesystem::path* tgt)
-{
-    if (auto u8str = std::u8string{}; to_u8string(src, &u8str))
-    {
-        *tgt = std::filesystem::path{ u8str };
-        return true;
-    }
-
-    return false;
-}
-
-tr_variant from_fs_path(std::filesystem::path const& path)
-{
-    return from_u8string(path.u8string());
-}
-
-// ---
-
 bool to_pex(tr_variant const& src, tr_pex* tgt)
 {
     auto* const map = src.get_if<tr_variant::Map>();
@@ -597,7 +578,6 @@ void Converters::ensure_default_converters()
             Converters::add(to_diffserv_t, from_diffserv_t);
             Converters::add(to_double, from_double);
             Converters::add(to_encryption_mode, from_encryption_mode);
-            Converters::add(to_fs_path, from_fs_path);
             Converters::add(to_int<int64_t>, from_int<int64_t>);
             Converters::add(to_int<size_t>, from_int<size_t>);
             Converters::add(to_int<time_t>, from_int<time_t>);

--- a/libtransmission/string-utils.cc
+++ b/libtransmission/string-utils.cc
@@ -159,10 +159,3 @@ std::string_view::size_type tr_strv_find_invalid_utf8(std::string_view const sv)
 {
     return utf8::find_invalid(sv);
 }
-
-std::u8string tr_strv_to_u8string(std::string_view const sv)
-{
-    auto u8str = tr_strv_to_utf8_string(sv);
-    auto const view = std::views::transform(u8str, [](char c) -> char8_t { return c; });
-    return { view.begin(), view.end() };
-}

--- a/libtransmission/string-utils.h
+++ b/libtransmission/string-utils.h
@@ -113,8 +113,6 @@ template <typename... Args> constexpr bool tr_strv_sep(std::string_view* sv, std
 #endif
 #endif
 
-[[nodiscard]] std::u8string tr_strv_to_u8string(std::string_view sv);
-
 [[nodiscard]] std::string tr_strv_replace_invalid(std::string_view sv, uint32_t replacement = 0xFFFD /*�*/);
 
 [[nodiscard]] std::string_view::size_type tr_strv_find_invalid_utf8(std::string_view sv);

--- a/tests/libtransmission/serializer-tests.cc
+++ b/tests/libtransmission/serializer-tests.cc
@@ -31,11 +31,6 @@ using tr::serializer::Converters;
 namespace
 {
 
-[[nodiscard]] std::string toString(std::u8string const& value)
-{
-    return { reinterpret_cast<char const*>(std::data(value)), std::size(value) };
-}
-
 struct Rect
 {
     int x = 0;
@@ -169,18 +164,6 @@ TEST_F(SerializerTest, usesTimeT)
     EXPECT_EQ(actual, Expected);
 }
 
-TEST_F(SerializerTest, usesU8String)
-{
-    auto const expected = std::u8string{ u8"hello" };
-    auto const var = Converters::serialize(expected);
-    EXPECT_TRUE(var.holds_alternative<std::string_view>());
-    EXPECT_EQ(var.value_if<std::string_view>().value_or(""sv), "hello"sv);
-
-    auto actual = std::u8string{};
-    EXPECT_TRUE(Converters::deserialize(var, &actual));
-    EXPECT_EQ(toString(actual), toString(expected));
-}
-
 TEST_F(SerializerTest, usesTrPex)
 {
     static auto constexpr CompactIp = std::array{ '\x7F', '\0', '\0', '\1', '\x73', '\x1A' }; // 127.0.0.1:6771
@@ -204,35 +187,6 @@ TEST_F(SerializerTest, usesTrPex)
     EXPECT_TRUE(Converters::deserialize(var, &actual));
     EXPECT_EQ(actual.socket_address, expected_sockaddr);
     EXPECT_EQ(actual.flags, expected_flags);
-}
-
-TEST_F(SerializerTest, u8StringWarnsOnInvalidUtf8)
-{
-    auto const bad = std::string{ static_cast<char>(0xC3), static_cast<char>(0x28) };
-    auto const var = tr_variant{ std::string_view{ bad } };
-
-    auto const old_level = tr_logGetLevel();
-    tr_logSetLevel(TR_LOG_WARN);
-    tr_logSetQueueEnabled(true);
-    tr_logClearQueue();
-
-    auto actual = std::u8string{};
-    EXPECT_TRUE(Converters::deserialize(var, &actual));
-
-    auto warned = false;
-    for (auto const& msg : tr_logGetQueue())
-    {
-        if (msg.level == TR_LOG_WARN && msg.message.find("contains invalid UTF-8") != std::string::npos)
-        {
-            warned = true;
-            break;
-        }
-    }
-
-    tr_logSetQueueEnabled(false);
-    tr_logSetLevel(old_level);
-
-    EXPECT_TRUE(warned);
 }
 
 TEST_F(SerializerTest, usesCustomTypes)

--- a/tests/libtransmission/serializer-tests.cc
+++ b/tests/libtransmission/serializer-tests.cc
@@ -6,7 +6,6 @@
 #include <cmath>
 #include <climits>
 #include <cstdint>
-#include <filesystem>
 #include <list>
 #include <mutex>
 #include <limits>
@@ -180,18 +179,6 @@ TEST_F(SerializerTest, usesU8String)
     auto actual = std::u8string{};
     EXPECT_TRUE(Converters::deserialize(var, &actual));
     EXPECT_EQ(toString(actual), toString(expected));
-}
-
-TEST_F(SerializerTest, usesFsPath)
-{
-    auto const expected = std::filesystem::path{ std::u8string{ u8"foo/βar" } };
-    auto const var = Converters::serialize(expected);
-    EXPECT_TRUE(var.holds_alternative<std::string_view>());
-    EXPECT_EQ(var.value_if<std::string_view>().value_or(""sv), "foo/βar"sv);
-
-    auto actual = std::filesystem::path{};
-    EXPECT_TRUE(Converters::deserialize(var, &actual));
-    EXPECT_EQ(toString(actual.u8string()), toString(expected.u8string()));
 }
 
 TEST_F(SerializerTest, usesTrPex)


### PR DESCRIPTION
Part of https://github.com/transmission/transmission/issues/8263#issuecomment-4647211570.

Remove fspath and u8string serializer, as well as `char` -> `char8_t` string converter.