### PR TITLE
fix: free bad peers buf timely

### DIFF
--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -2185,6 +2185,7 @@ void close_bad_peers(tr_swarm* s, time_t const now_sec, bad_peers_t& bad_peers_b
         tr_logAddTraceSwarm(peer->swarm, fmt::format("removing bad peer {}", peer->display_name()));
         close_peer(peer);
     }
+    bad_peers_buf.clear();
 }
 
 void enforceSwarmPeerLimit(tr_swarm* swarm, size_t max)


### PR DESCRIPTION
Regression from #7837.

Fixes `TR_ASSERT(current_size == std::size(peers))` failure at `libtransmission/peer-mgr.cc:2222`.