### PR TITLE
fix: keep tr_peerMsgs alive within io callbacks

### DIFF
--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -2186,7 +2186,7 @@ bool tr_peerMsgsImpl::is_valid_request(peer_request const& req) const
 
 size_t tr_peerMsgsImpl::max_available_reqs() const
 {
-    if (tor_.is_done() || !tor_.has_metainfo() || client_is_choked() || !client_is_interested())
+    if (tor_.is_done() || !tor_.has_metainfo() || !tor_.client_can_download() || client_is_choked() || !client_is_interested())
     {
         return 0;
     }

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -1809,7 +1809,7 @@ tr_error_code_t tr_peerMsgsImpl::client_got_block(std::span<uint8_t const> block
 
 void tr_peerMsgsImpl::did_write(tr_peerIo* /*io*/, size_t bytes_written, bool was_piece_data, void* vmsgs)
 {
-    auto* const msgs = static_cast<tr_peerMsgsImpl*>(vmsgs);
+    auto const msgs = static_cast<tr_peerMsgsImpl*>(vmsgs)->shared_from_this();
 
     if (was_piece_data)
     {
@@ -1900,7 +1900,9 @@ ReadResult tr_peerMsgsImpl::can_read_impl(tr_peerIo* io)
 
 ReadState tr_peerMsgsImpl::can_read(tr_peerIo* io, void* vmsgs, size_t* piece)
 {
-    auto* const msgs = static_cast<tr_peerMsgsImpl*>(vmsgs);
+    // Some errors (e.g. disk IO error) can immediately remove this peer from the peer mgr,
+    // which will destroy this object if we don't keep it alive
+    auto const msgs = static_cast<tr_peerMsgsImpl*>(vmsgs)->shared_from_this();
 
     auto ret = ReadState::Now;
     *piece = 0U;

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -1226,6 +1226,11 @@ private:
 
     [[nodiscard]] constexpr bool is_piece_transfer_allowed(tr_direction direction) const noexcept
     {
+        if (!is_running())
+        {
+            return false;
+        }
+
         if (uses_speed_limit(direction) && speed_limit(direction).is_zero())
         {
             return false;


### PR DESCRIPTION
Fixes #6317.
Fixes #8908.
Supersedes #8715.

Notes: Fixed use-after-free in peer code.

Ran this patch through fsanitize build downloading 8 torrents in parallel with no crashes.