### PR TITLE
refactor: use GCD block instead of performSelector.

### DIFF
--- a/macosx/AddMagnetWindowController.mm
+++ b/macosx/AddMagnetWindowController.mm
@@ -129,7 +129,9 @@ typedef NS_ENUM(NSUInteger, PopupPriority) {
         {
             if (!self.fDestination)
             {
-                [self performSelectorOnMainThread:@selector(cancelAdd:) withObject:nil waitUntilDone:NO];
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    [self cancelAdd:nil];
+                });
             }
         }
     }];
@@ -159,7 +161,9 @@ typedef NS_ENUM(NSUInteger, PopupPriority) {
 
             if (returnCode == NSAlertSecondButtonReturn)
             {
-                [self performSelectorOnMainThread:@selector(confirmAdd) withObject:nil waitUntilDone:NO];
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    [self confirmAdd];
+                });
             }
         }];
     }

--- a/macosx/AddWindowController.mm
+++ b/macosx/AddWindowController.mm
@@ -205,7 +205,9 @@ typedef NS_ENUM(NSUInteger, PopupPriority) {
         {
             if (!self.fDestination)
             {
-                [self performSelectorOnMainThread:@selector(cancelAdd:) withObject:nil waitUntilDone:NO];
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    [self cancelAdd:nil];
+                });
             }
         }
     }];
@@ -235,7 +237,9 @@ typedef NS_ENUM(NSUInteger, PopupPriority) {
 
             if (returnCode == NSAlertSecondButtonReturn)
             {
-                [self performSelectorOnMainThread:@selector(confirmAdd) withObject:nil waitUntilDone:NO];
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    [self confirmAdd];
+                });
             }
         }];
     }

--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -594,8 +594,9 @@ static void removeKeRangerRansomware()
             [controller = self](bool const active, bool const by_user)
             {
                 NSDictionary* const dict = @{ @"Active" : @(active), @"ByUser" : @(by_user) };
-                [controller performSelectorOnMainThread:@selector(altSpeedToggledCallbackIsLimited:) withObject:dict
-                                          waitUntilDone:NO];
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    [controller altSpeedToggledCallbackIsLimited:dict];
+                });
             });
         BOOL const usesSpeedLimitSched = [_fDefaults boolForKey:@"SpeedLimitAuto"];
         if (usesSpeedLimitSched)
@@ -1195,7 +1196,9 @@ static void removeKeRangerRansomware()
     if ([urlString rangeOfString:@"magnet:" options:(NSAnchoredSearch | NSCaseInsensitiveSearch)].location != NSNotFound)
     {
         // originalRequest was a redirect to a magnet
-        [self performSelectorOnMainThread:@selector(openMagnet:) withObject:urlString waitUntilDone:NO];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self openMagnet:urlString];
+        });
         return;
     }
 
@@ -1488,7 +1491,9 @@ static void removeKeRangerRansomware()
 - (void)open:(NSArray*)files
 {
     NSDictionary* dict = @{ @"Filenames" : files, @"AddType" : @(AddTypeManual) };
-    [self performSelectorOnMainThread:@selector(openFilesWithDict:) withObject:dict waitUntilDone:NO];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self openFilesWithDict:dict];
+    });
 }
 
 - (void)openShowSheet:(id)sender
@@ -1514,7 +1519,9 @@ static void removeKeRangerRansomware()
                 @"Filenames" : filenames,
                 @"AddType" : sender == self.fOpenIgnoreDownloadFolder ? @(AddTypeShowOptions) : @(AddTypeManual)
             };
-            [self performSelectorOnMainThread:@selector(openFilesWithDict:) withObject:dictionary waitUntilDone:NO];
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [self openFilesWithDict:dictionary];
+            });
         }
     }];
 }
@@ -2191,7 +2198,9 @@ static void removeKeRangerRansomware()
             }
 
             [torrents removeObjectAtIndex:0];
-            [self performSelectorOnMainThread:@selector(copyTorrentFileForTorrents:) withObject:torrents waitUntilDone:NO];
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [self copyTorrentFileForTorrents:torrents];
+            });
         }];
     }
     else

--- a/macosx/CreatorWindowController.mm
+++ b/macosx/CreatorWindowController.mm
@@ -333,7 +333,9 @@ static NSMutableSet* creatorWindowControllerSet;
 
             if (returnCode == NSAlertFirstButtonReturn)
             {
-                [self performSelectorOnMainThread:@selector(createReal) withObject:nil waitUntilDone:NO];
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    [self createReal];
+                });
             }
         }];
     }

--- a/macosx/PortChecker.h
+++ b/macosx/PortChecker.h
@@ -19,12 +19,12 @@ typedef NS_ENUM(NSUInteger, PortStatus) { //
 
 @property(nonatomic, readonly) PortStatus status;
 
-- (instancetype)initForPort:(NSInteger)portNumber delay:(BOOL)delay withDelegate:(NSObject<PortCheckerDelegate>*)delegate;
+- (instancetype)initForPort:(NSInteger)portNumber delay:(BOOL)delay withDelegate:(id<PortCheckerDelegate>)delegate;
 - (void)cancelProbe;
 
 @end
 
-@protocol PortCheckerDelegate<NSObject>
+@protocol PortCheckerDelegate
 
 - (void)portCheckerDidFinishProbing:(PortChecker*)portChecker;
 

--- a/macosx/PortChecker.mm
+++ b/macosx/PortChecker.mm
@@ -8,7 +8,7 @@ static NSTimeInterval const kCheckFireInterval = 3.0;
 
 @interface PortChecker ()
 
-@property(nonatomic, weak) NSObject<PortCheckerDelegate>* fDelegate;
+@property(nonatomic, weak) id<PortCheckerDelegate> fDelegate;
 @property(nonatomic) PortStatus fStatus;
 
 @property(nonatomic) NSURLSession* fSession;
@@ -20,7 +20,7 @@ static NSTimeInterval const kCheckFireInterval = 3.0;
 
 @implementation PortChecker
 
-- (instancetype)initForPort:(NSInteger)portNumber delay:(BOOL)delay withDelegate:(NSObject<PortCheckerDelegate>*)delegate
+- (instancetype)initForPort:(NSInteger)portNumber delay:(BOOL)delay withDelegate:(id<PortCheckerDelegate>)delegate
 {
     if ((self = [super init]))
     {
@@ -108,8 +108,10 @@ static NSTimeInterval const kCheckFireInterval = 3.0;
 {
     self.fStatus = status;
 
-    NSObject<PortCheckerDelegate>* delegate = self.fDelegate;
-    [delegate performSelectorOnMainThread:@selector(portCheckerDidFinishProbing:) withObject:self waitUntilDone:NO];
+    __auto_type delegate = self.fDelegate;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [delegate portCheckerDidFinishProbing:self]; 
+    });
 }
 
 @end

--- a/macosx/PortChecker.mm
+++ b/macosx/PortChecker.mm
@@ -110,7 +110,7 @@ static NSTimeInterval const kCheckFireInterval = 3.0;
 
     __auto_type delegate = self.fDelegate;
     dispatch_async(dispatch_get_main_queue(), ^{
-        [delegate portCheckerDidFinishProbing:self]; 
+        [delegate portCheckerDidFinishProbing:self];
     });
 }
 


### PR DESCRIPTION
Modernized main thread dispatching.

### Benefits
- **Compile-time safety**: Removed unsafe string-based selector execution.
- **Better UI responsiveness on macOS**: GCD main queue integrates better with RunLoop modes than the old legacy method during UI tracking events.

Notes: Improved UI code to use less CPU.