### PR TITLE
Refactor: Optimize FileListNode memory footprint using Class Cluster

### DIFF
--- a/macosx/FileListNode.h
+++ b/macosx/FileListNode.h
@@ -20,8 +20,8 @@
 
 @property(nonatomic, readonly) NSIndexSet* indexes;
 
-- (instancetype)initWithFolderName:(NSString*)name path:(NSString*)path torrent:(Torrent*)torrent;
-- (instancetype)initWithFileName:(NSString*)name
++ (instancetype)createWithFolderName:(NSString*)name path:(NSString*)path torrent:(Torrent*)torrent;
++ (instancetype)createWithFileName:(NSString*)name
                             path:(NSString*)path
                             size:(uint64_t)size
                            index:(NSUInteger)index
@@ -30,8 +30,12 @@
 - (void)insertChild:(FileListNode*)child;
 - (void)insertIndex:(NSUInteger)index withSize:(uint64_t)size;
 
-@property(nonatomic, readonly) NSString* description;
-
 - (BOOL)updateFromOldName:(NSString*)oldName toNewName:(NSString*)newName inPath:(NSString*)path;
 
+@end
+
+@interface OnlyFileListNode : FileListNode
+@end
+
+@interface OnlyFolderListNode : FileListNode
 @end

--- a/macosx/FileListNode.h
+++ b/macosx/FileListNode.h
@@ -22,20 +22,14 @@
 
 + (instancetype)createWithFolderName:(NSString*)name path:(NSString*)path torrent:(Torrent*)torrent;
 + (instancetype)createWithFileName:(NSString*)name
-                            path:(NSString*)path
-                            size:(uint64_t)size
-                           index:(NSUInteger)index
-                         torrent:(Torrent*)torrent;
+                              path:(NSString*)path
+                              size:(uint64_t)size
+                             index:(NSUInteger)index
+                           torrent:(Torrent*)torrent;
 
 - (void)insertChild:(FileListNode*)child;
 - (void)insertIndex:(NSUInteger)index withSize:(uint64_t)size;
 
 - (BOOL)updateFromOldName:(NSString*)oldName toNewName:(NSString*)newName inPath:(NSString*)path;
 
-@end
-
-@interface OnlyFileListNode : FileListNode
-@end
-
-@interface OnlyFolderListNode : FileListNode
 @end

--- a/macosx/FileListNode.mm
+++ b/macosx/FileListNode.mm
@@ -10,17 +10,25 @@
 
 #import "FileListNode.h"
 
-@interface FileListNode () {
-    @protected
-    uint64_t _size;
-    @protected
-    NSImage *_iconInternal;
-}
-- (instancetype)initWithName:(NSString*)name path:(NSString*)path torrent:(Torrent*)torrent size:(uint64_t)size;
-- (NSImage *)createIcon;
+@interface OnlyFileListNode : FileListNode
 @end
 
-@interface OnlyFileListNode () {
+@interface OnlyFolderListNode : FileListNode
+@end
+
+@interface FileListNode ()
+{
+  @protected
+    uint64_t _size;
+  @protected
+    NSImage* _iconInternal;
+}
+- (instancetype)initWithName:(NSString*)name path:(NSString*)path torrent:(Torrent*)torrent size:(uint64_t)size;
+- (NSImage*)createIcon;
+@end
+
+@interface OnlyFileListNode ()
+{
     NSIndexSet* _indexesInternal;
 }
 - (instancetype)initWithFileName:(NSString*)name
@@ -30,7 +38,8 @@
                          torrent:(Torrent*)torrent;
 @end
 
-@interface OnlyFolderListNode () {
+@interface OnlyFolderListNode ()
+{
     NSMutableIndexSet* _indexesInternal;
     NSMutableArray* _childrenInternal;
 }
@@ -39,7 +48,7 @@
 
 @implementation FileListNode
 
-- (NSMutableArray<FileListNode *> *)children
+- (NSMutableArray<FileListNode*>*)children
 {
     return nil;
 }
@@ -151,10 +160,10 @@
 }
 
 + (instancetype)createWithFileName:(NSString*)name
-                            path:(NSString*)path
-                            size:(uint64_t)size
-                           index:(NSUInteger)index
-                         torrent:(Torrent*)torrent
+                              path:(NSString*)path
+                              size:(uint64_t)size
+                             index:(NSUInteger)index
+                           torrent:(Torrent*)torrent
 {
     return [[OnlyFileListNode alloc] initWithFileName:name path:path size:size index:index torrent:torrent];
 }
@@ -230,7 +239,7 @@
     return _indexesInternal;
 }
 
-- (NSMutableArray<FileListNode *> *)children
+- (NSMutableArray<FileListNode*>*)children
 {
     return _childrenInternal;
 }

--- a/macosx/FileListNode.mm
+++ b/macosx/FileListNode.mm
@@ -10,54 +10,46 @@
 
 #import "FileListNode.h"
 
-@interface FileListNode ()
-
-@property(nonatomic, readonly) NSMutableIndexSet* indexesInternal;
-@property(nonatomic) NSImage* iconInternal;
-
+@interface FileListNode () {
+    @protected
+    uint64_t _size;
+    @protected
+    NSImage *_iconInternal;
+}
+- (instancetype)initWithName:(NSString*)name path:(NSString*)path torrent:(Torrent*)torrent size:(uint64_t)size;
+- (NSImage *)createIcon;
 @end
 
-@implementation FileListNode
-
-- (instancetype)initWithFolderName:(NSString*)name path:(NSString*)path torrent:(Torrent*)torrent
-{
-    if ((self = [self initWithFolder:YES name:name path:path torrent:torrent]))
-    {
-        _children = [[NSMutableArray alloc] init];
-        _size = 0;
-    }
-
-    return self;
+@interface OnlyFileListNode () {
+    NSIndexSet* _indexesInternal;
 }
-
 - (instancetype)initWithFileName:(NSString*)name
                             path:(NSString*)path
                             size:(uint64_t)size
                            index:(NSUInteger)index
-                         torrent:(Torrent*)torrent
-{
-    if ((self = [self initWithFolder:NO name:name path:path torrent:torrent]))
-    {
-        _size = size;
-        [_indexesInternal addIndex:index];
-    }
+                         torrent:(Torrent*)torrent;
+@end
 
-    return self;
+@interface OnlyFolderListNode () {
+    NSMutableIndexSet* _indexesInternal;
+    NSMutableArray* _childrenInternal;
+}
+- (instancetype)initWithFolderName:(NSString*)name path:(NSString*)path torrent:(Torrent*)torrent;
+@end
+
+@implementation FileListNode
+
+- (NSMutableArray<FileListNode *> *)children
+{
+    return nil;
 }
 
 - (void)insertChild:(FileListNode*)child
 {
-    NSAssert(_isFolder, @"method can only be invoked on folders");
-
-    [_children addObject:child];
 }
 
 - (void)insertIndex:(NSUInteger)index withSize:(uint64_t)size
 {
-    NSAssert(_isFolder, @"method can only be invoked on folders");
-
-    [self.indexesInternal addIndex:index];
-    _size += size;
 }
 
 - (id)copyWithZone:(NSZone*)zone
@@ -68,29 +60,32 @@
 
 - (NSString*)description
 {
-    if (!_isFolder)
-    {
-        return [NSString stringWithFormat:@"%@ (%ld)", _name, _indexesInternal.firstIndex];
-    }
-    else
-    {
-        return [NSString stringWithFormat:@"%@ (folder: %@)", _name, _indexesInternal];
-    }
+    return @"";
+}
+
+- (BOOL)isFolder
+{
+    return NO;
+}
+
+- (NSImage*)createIcon
+{
+    NSAssert(NO, @"Implement in subclasses");
+    return nil;
 }
 
 - (NSImage*)icon
 {
     if (!_iconInternal)
     {
-        _iconInternal = [NSWorkspace.sharedWorkspace
-            iconForFileType:_isFolder ? NSFileTypeForHFSTypeCode(kGenericFolderIcon) : _name.pathExtension];
+        _iconInternal = [self createIcon];
     }
     return _iconInternal;
 }
 
 - (NSIndexSet*)indexes
 {
-    return _indexesInternal;
+    return nil;
 }
 
 - (BOOL)updateFromOldName:(NSString*)oldName toNewName:(NSString*)newName inPath:(NSString*)path
@@ -135,20 +130,125 @@
 
 #pragma mark - Private
 
-- (instancetype)initWithFolder:(BOOL)isFolder name:(NSString*)name path:(NSString*)path torrent:(Torrent*)torrent
+- (instancetype)initWithName:(NSString*)name path:(NSString*)path torrent:(Torrent*)torrent size:(uint64_t)size
 {
     if ((self = [super init]))
     {
-        _isFolder = isFolder;
         _name = [name copy];
         _path = [path copy];
-
-        _indexesInternal = [[NSMutableIndexSet alloc] init];
-
         _torrent = torrent;
+        _size = size;
     }
 
     return self;
+}
+
+#pragma mark - Class Cluster
+
++ (instancetype)createWithFolderName:(NSString*)name path:(NSString*)path torrent:(Torrent*)torrent
+{
+    return [[OnlyFolderListNode alloc] initWithFolderName:name path:path torrent:torrent];
+}
+
++ (instancetype)createWithFileName:(NSString*)name
+                            path:(NSString*)path
+                            size:(uint64_t)size
+                           index:(NSUInteger)index
+                         torrent:(Torrent*)torrent
+{
+    return [[OnlyFileListNode alloc] initWithFileName:name path:path size:size index:index torrent:torrent];
+}
+
+@end
+
+@implementation OnlyFileListNode
+
+- (instancetype)initWithFileName:(NSString*)name
+                            path:(NSString*)path
+                            size:(uint64_t)size
+                           index:(NSUInteger)index
+                         torrent:(Torrent*)torrent
+{
+    if (self = [super initWithName:name path:path torrent:torrent size:size])
+    {
+        _indexesInternal = [NSIndexSet indexSetWithIndex:index];
+    }
+    return self;
+}
+
+- (NSImage*)createIcon
+{
+    return [NSWorkspace.sharedWorkspace iconForFileType:self.name.pathExtension];
+}
+
+- (NSIndexSet*)indexes
+{
+    return _indexesInternal;
+}
+
+- (void)insertChild:(FileListNode*)child
+{
+    NSAssert(NO, @"method can only be invoked on folders");
+}
+
+- (void)insertIndex:(NSUInteger)index withSize:(uint64_t)size
+{
+    NSAssert(NO, @"method can only be invoked on folders");
+}
+
+- (NSString*)description
+{
+    return [NSString stringWithFormat:@"%@ (%ld)", self.name, _indexesInternal.firstIndex];
+}
+
+@end
+
+@implementation OnlyFolderListNode
+
+- (instancetype)initWithFolderName:(NSString*)name path:(NSString*)path torrent:(Torrent*)torrent
+{
+    if (self = [super initWithName:name path:path torrent:torrent size:0])
+    {
+        _indexesInternal = [[NSMutableIndexSet alloc] init];
+        _childrenInternal = [[NSMutableArray alloc] init];
+    }
+    return self;
+}
+
+- (BOOL)isFolder
+{
+    return YES;
+}
+
+- (NSImage*)createIcon
+{
+    return [NSWorkspace.sharedWorkspace iconForFileType:NSFileTypeForHFSTypeCode(kGenericFolderIcon)];
+}
+
+- (NSIndexSet*)indexes
+{
+    return _indexesInternal;
+}
+
+- (NSMutableArray<FileListNode *> *)children
+{
+    return _childrenInternal;
+}
+
+- (void)insertChild:(FileListNode*)child
+{
+    [_childrenInternal addObject:child];
+}
+
+- (void)insertIndex:(NSUInteger)index withSize:(uint64_t)size
+{
+    [_indexesInternal addIndex:index];
+    _size += size;
+}
+
+- (NSString*)description
+{
+    return [NSString stringWithFormat:@"%@ (folder: %@)", self.name, _indexesInternal];
 }
 
 @end

--- a/macosx/Torrent.mm
+++ b/macosx/Torrent.mm
@@ -1969,7 +1969,7 @@ static tr_torrent_rename_done_func makeRenameDoneCallback(NSDictionary* contextI
 
             if (!tempNode)
             {
-                tempNode = [[FileListNode alloc] initWithFolderName:pathComponents[0] path:@"" torrent:self];
+                tempNode = [FileListNode createWithFolderName:pathComponents[0] path:@"" torrent:self];
             }
 
             [self insertPathForComponents:pathComponents //
@@ -1988,7 +1988,7 @@ static tr_torrent_rename_done_func makeRenameDoneCallback(NSDictionary* contextI
     }
     else
     {
-        FileListNode* node = [[FileListNode alloc] initWithFileName:self.name path:@"" size:self.size index:0 torrent:self];
+        FileListNode* node = [FileListNode createWithFileName:self.name path:@"" size:self.size index:0 torrent:self];
         self.fileList = @[ node ];
         self.flatFileList = self.fileList;
     }
@@ -2027,11 +2027,11 @@ static tr_torrent_rename_done_func makeRenameDoneCallback(NSDictionary* contextI
         NSString* path = [parent.path stringByAppendingPathComponent:parent.name];
         if (isFolder)
         {
-            node = [[FileListNode alloc] initWithFolderName:name path:path torrent:self];
+            node = [FileListNode createWithFolderName:name path:path torrent:self];
         }
         else
         {
-            node = [[FileListNode alloc] initWithFileName:name path:path size:size index:index torrent:self];
+            node = [FileListNode createWithFileName:name path:path size:size index:index torrent:self];
             [flatFileList addObject:node];
         }
 


### PR DESCRIPTION
This PR reduces memory footprint of FileListNode by splitting it into OnlyFileListNode ( files ) and OnlyFolderListNode.

Results using `class_getInstanceSize`.

| Class | Before Refactor | After Refactor |
|---|---|---|
| File Nodes (OnlyFileListNode) | ~64-72 bytes | 56 bytes |
| Folder Nodes (OnlyFolderListNode) | ~72 bytes | 64 bytes |

Can be further reduced by splitting `FileNameCell` into `OnlyFileNameCell` and `OnlyFolderNameCell` (https://github.com/transmission/transmission/pull/8497) ( icon field can become truly readonly cause `NSWorkspace` caches icons ).