### PR TITLE
ci(netbsd): add other pkgsrc mirrors as fallback

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1587,7 +1587,9 @@ jobs:
             set -ex
             uname -a
             export PATH="/usr/pkg/bin:/usr/pkg/sbin${PATH:+:${PATH}}"
-            export PKG_PATH="https://cdn.NetBSD.org/pub/pkgsrc/packages/NetBSD/`uname -p`/`uname -r`/All"
+            PKG_PATH="https://cdn.NetBSD.org/pub/pkgsrc/packages/NetBSD/`uname -p`/`uname -r`/All"
+            PKG_PATH="${PKG_PATH};https://ftp.NetBSD.org/pub/pkgsrc/packages/NetBSD/`uname -p`/`uname -r`/All"
+            export PKG_PATH
             /usr/sbin/pkg_add -u \
               curl \
               cmake \


### PR DESCRIPTION
Hopefully mitigate the main NetBSD CDN acting up, like on this run:

https://github.com/transmission/transmission/actions/runs/27808006388/job/82292035029?pr=8920

```
pkg_add: Can't process [https://cdn.NetBSD.org:443/pub/pkgsrc/packages/NetBSD/x86_64/10.1/All/curl*:](https://cdn.netbsd.org/pub/pkgsrc/packages/NetBSD/x86_64/10.1/All/curl*:) Service Unavailable
  pkg_add: no pkg found for 'curl', sorry.
  pkg_add: Can't process [https://cdn.NetBSD.org:443/pub/pkgsrc/packages/NetBSD/x86_64/10.1/All/cmake*:](https://cdn.netbsd.org/pub/pkgsrc/packages/NetBSD/x86_64/10.1/All/cmake*:) Service Unavailable
  pkg_add: no pkg found for 'cmake', sorry.
  pkg_add: Can't process [https://cdn.NetBSD.org:443/pub/pkgsrc/packages/NetBSD/x86_64/10.1/All/fast*:](https://cdn.netbsd.org/pub/pkgsrc/packages/NetBSD/x86_64/10.1/All/fast*:) Service Unavailable
  pkg_add: no pkg found for 'fast_float', sorry.
  pkg_add: Can't process [https://cdn.NetBSD.org:443/pub/pkgsrc/packages/NetBSD/x86_64/10.1/All/fmtlib*:](https://cdn.netbsd.org/pub/pkgsrc/packages/NetBSD/x86_64/10.1/All/fmtlib*:) Service Unavailable
  pkg_add: no pkg found for 'fmtlib', sorry.
  pkg_add: Can't process [https://cdn.NetBSD.org:443/pub/pkgsrc/packages/NetBSD/x86_64/10.1/All/gettext-tools*:](https://cdn.netbsd.org/pub/pkgsrc/packages/NetBSD/x86_64/10.1/All/gettext-tools*:) Service Unavailable
  pkg_add: no pkg found for 'gettext-tools', sorry.
  pkg_add: Can't process [https://cdn.NetBSD.org:443/pub/pkgsrc/packages/NetBSD/x86_64/10.1/All/gtkmm4*:](https://cdn.netbsd.org/pub/pkgsrc/packages/NetBSD/x86_64/10.1/All/gtkmm4*:) Service Unavailable
  pkg_add: no pkg found for 'gtkmm4', sorry.
  pkg_add: Can't process [https://cdn.NetBSD.org:443/pub/pkgsrc/packages/NetBSD/x86_64/10.1/All/libdeflate*:](https://cdn.netbsd.org/pub/pkgsrc/packages/NetBSD/x86_64/10.1/All/libdeflate*:) Service Unavailable
  pkg_add: no pkg found for 'libdeflate', sorry.
  pkg_add: Can't process [https://cdn.NetBSD.org:443/pub/pkgsrc/packages/NetBSD/x86_64/10.1/All/libevent*:](https://cdn.netbsd.org/pub/pkgsrc/packages/NetBSD/x86_64/10.1/All/libevent*:) Service Unavailable
  pkg_add: no pkg found for 'libevent', sorry.
  pkg_add: Can't process [https://cdn.NetBSD.org:443/pub/pkgsrc/packages/NetBSD/x86_64/10.1/All/libpsl*:](https://cdn.netbsd.org/pub/pkgsrc/packages/NetBSD/x86_64/10.1/All/libpsl*:) Service Unavailable
  pkg_add: no pkg found for 'libpsl', sorry.
  pkg_add: Can't process [https://cdn.NetBSD.org:443/pub/pkgsrc/packages/NetBSD/x86_64/10.1/All/miniupnpc*:](https://cdn.netbsd.org/pub/pkgsrc/packages/NetBSD/x86_64/10.1/All/miniupnpc*:) Service Unavailable
  pkg_add: no pkg found for 'miniupnpc', sorry.
```

Mirror URL taken from https://www.netbsd.org/mirrors/.