### PR TITLE
macOS: scope shared instances to static

### DIFF
--- a/macosx/AboutWindowController.mm
+++ b/macosx/AboutWindowController.mm
@@ -20,7 +20,7 @@
 
 @implementation AboutWindowController
 
-AboutWindowController* fAboutBoxInstance = nil;
+static AboutWindowController* fAboutBoxInstance = nil;
 
 + (AboutWindowController*)aboutController
 {

--- a/macosx/BlocklistDownloader.mm
+++ b/macosx/BlocklistDownloader.mm
@@ -18,7 +18,7 @@
 
 @implementation BlocklistDownloader
 
-BlocklistDownloader* fBLDownloader = nil;
+static BlocklistDownloader* fBLDownloader = nil;
 
 + (BlocklistDownloader*)downloader
 {

--- a/macosx/BlocklistDownloaderViewController.mm
+++ b/macosx/BlocklistDownloaderViewController.mm
@@ -20,7 +20,7 @@
 
 @implementation BlocklistDownloaderViewController
 
-BlocklistDownloaderViewController* fBLViewController = nil;
+static BlocklistDownloaderViewController* fBLViewController = nil;
 + (void)downloadWithPrefsController:(PrefsController*)prefsController
 {
     if (!fBLViewController)

--- a/macosx/BonjourController.mm
+++ b/macosx/BonjourController.mm
@@ -14,7 +14,7 @@ static NSUInteger const kBonjourServiceNameMaxLength = 63;
 
 @implementation BonjourController
 
-BonjourController* fDefaultController = nil;
+static BonjourController* fDefaultController = nil;
 
 + (BonjourController*)defaultController
 {

--- a/macosx/GroupsController.mm
+++ b/macosx/GroupsController.mm
@@ -19,14 +19,14 @@ static CGFloat const kIconWidthSmall = 12.0;
 
 @implementation GroupsController
 
-GroupsController* fGroupsInstance = nil;
-
 + (GroupsController*)groups
 {
-    if (!fGroupsInstance)
-    {
+    static GroupsController* fGroupsInstance = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
         fGroupsInstance = [[GroupsController alloc] init];
-    }
+    });
+
     return fGroupsInstance;
 }
 


### PR DESCRIPTION
Apply static modifier to encapsulate shared instances in compilation unit.