### PR TITLE
fix: don't expose RPC session id via CORS

### DIFF
--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -556,17 +556,9 @@ void handle_request(struct evhttp_request* req, void* arg)
         return;
     }
 
-    evhttp_add_header(output_headers, "Access-Control-Allow-Origin", "*");
-
     auto const* const input_headers = evhttp_request_get_input_headers(req);
     if (auto const cmd = evhttp_request_get_command(req); cmd == EVHTTP_REQ_OPTIONS)
     {
-        if (char const* headers = evhttp_find_header(input_headers, "Access-Control-Request-Headers"); headers != nullptr)
-        {
-            evhttp_add_header(output_headers, "Access-Control-Allow-Headers", headers);
-        }
-
-        evhttp_add_header(output_headers, "Access-Control-Allow-Methods", "GET, POST, OPTIONS");
         send_simple_response(req, HTTP_OK);
         return;
     }
@@ -640,10 +632,6 @@ void handle_request(struct evhttp_request* req, void* arg)
             session_id);
         evhttp_add_header(output_headers, TR_RPC_SESSION_ID_HEADER, session_id.c_str());
         evhttp_add_header(output_headers, TR_RPC_RPC_VERSION_HEADER, std::data(TrRpcVersionSemver));
-        evhttp_add_header(
-            output_headers,
-            "Access-Control-Expose-Headers",
-            TR_RPC_SESSION_ID_HEADER ", " TR_RPC_RPC_VERSION_HEADER);
         send_simple_response(req, 409, body.c_str());
     }
 #endif
@@ -1033,6 +1021,14 @@ void tr_rpc_server::load(Settings&& settings)
         if (this->is_password_enabled())
         {
             tr_logAddInfo(_("Password required"));
+        }
+        else if (!this->is_whitelist_enabled())
+        {
+            tr_logAddWarn(
+                "The RPC server has no password and its IP whitelist is disabled. "
+                "Anyone who can reach it has full control. "
+                "Consider enabling 'rpc_whitelist_enabled' or "
+                "setting 'rpc_authentication_required' and 'rpc_password'.");
         }
     }
 


### PR DESCRIPTION
The RPC server sent `Access-Control-Allow-Origin: *`, reflected the preflight CORS headers, and advertised X-Transmission-Session-Id via Access-Control-Expose-Headers on the 409 handshake. Any page a user visited could read the session-id nonce that guards against CSRF.

This PR removes the CORS code &  returns no CORS headers at all. It's not clear to me that CORS has a valid use case for the RPC server, so maybe it was a mistake to land #1885 / d11ccf113c21c78f3e30259f8fd72527f6a89f0e:

- Native & mobile apps (eg transmission-qt and transmission-remote, and 3rd party apps transdrone, transmission-remote-gui) aren't browser-based
- The bundled web UI (and 3rd party replacements like kettu, transmission-web-control) are served by the daemon, so are all same-origin
- Server-side frontends (eg Flood and Combustion) proxy the daemon, so the browser never hits the daemon

So the safest & simplest fix is to remove the feature. This is not a breaking [semver](https://semver.org/) change since this was never a documented API feature.

This PR also adds, as a safety precaution, a log warning if an RPC server is started with both the whitelist _and_ user authentication disabled.

Reported by Jan Kahmen (turingpoint).

Notes: Fixed a CORS bug that leaked the anti-CSRF nonce.