### PR TITLE
fix: FTBFS with fmt 12.2.0

### DIFF
--- a/libtransmission/tr-strbuf.h
+++ b/libtransmission/tr-strbuf.h
@@ -102,6 +102,16 @@ public:
         return buffer_[pos];
     }
 
+    [[nodiscard]] constexpr Char& operator[](size_t pos) noexcept
+    {
+        return buffer_[pos];
+    }
+
+    [[nodiscard]] constexpr Char operator[](size_t pos) const noexcept
+    {
+        return buffer_[pos];
+    }
+
     [[nodiscard]] constexpr auto size() const noexcept
     {
         return buffer_.size();


### PR DESCRIPTION
fmt [12.2.0](https://github.com/fmtlib/fmt/releases/tag/12.2.0) was released last week and is rolling out on the GitHub Action runners and we're seeing a FTBFS in `tr-strbuf.h` with it, eg in [this CI log](https://productionresultssa7.blob.core.windows.net/actions-results/5c613b0d-4dc2-4232-80e3-2aa7c46f1c50/workflow-job-run-8dda075e-8ec9-5e0a-bf10-2fb7c789259c/logs/job/job-logs.txt?rsct=text%2Fplain&se=2026-06-24T16%3A18%3A37Z&sig=SGRa1FtoOkAxcnnfG01CWXwHDKpRYVJ21QtR9%2FoDmyM%3D&ske=2026-06-24T19%3A31%3A33Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2026-06-24T15%3A31%3A33Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2025-11-05&sp=r&spr=https&sr=b&st=2026-06-24T16%3A08%3A32Z&sv=2025-11-05).

Notes: Fixed build error when using [fmt](https://github.com/fmtlib/fmt) 12.2.0.