### PR TITLE
fix: add missing reference type alias to tr_strbuf

### DIFF
--- a/libtransmission/tr-strbuf.h
+++ b/libtransmission/tr-strbuf.h
@@ -26,6 +26,7 @@ private:
 
 public:
     using value_type = Char;
+    using reference = Char&;
     using const_reference = Char const&;
 
     tr_strbuf()


### PR DESCRIPTION
Newer fmt versions (>= PR #4679) have container_buffer::grow access storage via operator[] instead of .data(), relying on the container's reference type alias to pick the correct pointer type. Without it, tr_strbuf falls back to const_reference, producing a const char* where char* is required.