### PR TITLE
feat: search bar to find a file by filename inside .torrent file (#2403)

### DIFF
--- a/qt/OptionsDialog.cc
+++ b/qt/OptionsDialog.cc
@@ -342,6 +342,6 @@ void OptionsDialog::onDestinationChanged()
     }
 }
 
-void OptionsDialog::onSearchedStringChanged(const QString& newText) {
-    OptionsDialog::reload(newText, true);
+void OptionsDialog::onSearchedStringChanged(const QString& new_searched_string) {
+    OptionsDialog::reload(new_searched_string, true);
 }

--- a/qt/OptionsDialog.cc
+++ b/qt/OptionsDialog.cc
@@ -52,7 +52,7 @@ OptionsDialog::OptionsDialog(Session& session, Prefs const& prefs, AddData addme
         ui_.sourceButton->setTitle(tr("Open Torrent"));
         ui_.sourceButton->setNameFilter(tr("Torrent Files (*.torrent);;All Files (*.*)"));
         ui_.sourceButton->setPath(add_.filename);
-        ui_.searchLineEdit->setPlaceholderText(QStringLiteral("Search..."));
+        ui_.searchLineEdit->setPlaceholderText(tr("Search..."));
         connect(ui_.searchLineEdit, &QLineEdit::textEdited, this, &OptionsDialog::onSearchedStringChanged);
         connect(ui_.sourceButton, &PathButton::pathChanged, this, &OptionsDialog::onSourceChanged);
     }
@@ -127,47 +127,49 @@ void OptionsDialog::clearInfo()
 
 void OptionsDialog::reload(const QString& searched_string, bool reload_only_to_search)
 {
-    clearInfo();
-
-    auto metainfo = tr_torrent_metainfo{};
-    auto ok = bool{};
-
-    switch (add_.type)
-    {
-    case AddData::MAGNET:
-        ok = metainfo.parseMagnet(add_.magnet.toStdString());
-        break;
-
-    case AddData::FILENAME:
-        ok = metainfo.parse_torrent_file(add_.filename.toStdString());
-        break;
-
-    case AddData::METAINFO:
-        ok = metainfo.parse_benc(add_.metainfo.toStdString());
-        break;
-
-    default:
-        break;
-    }
-
-    metainfo_.reset();
-    ui_.filesView->clear();
-    files_.clear();
     if (!reload_only_to_search)
     {
+        clearInfo();
+
+        auto metainfo = tr_torrent_metainfo{};
+        bool ok = false;
+
+        switch (add_.type)
+        {
+        case AddData::MAGNET:
+            ok = metainfo.parseMagnet(add_.magnet.toStdString());
+            break;
+
+        case AddData::FILENAME:
+            ok = metainfo.parse_torrent_file(add_.filename.toStdString());
+            break;
+
+        case AddData::METAINFO:
+            ok = metainfo.parse_benc(add_.metainfo.toStdString());
+            break;
+
+        default:
+            break;
+        }
+
+        metainfo_.reset();
+
+        if (ok)
+        {
+            metainfo_ = metainfo;
+        }
+
+        bool const have_files_to_show = metainfo_ && !std::empty(*metainfo_);
+        ui_.filesView->setVisible(have_files_to_show);
+        layout()->setSizeConstraint(have_files_to_show ? QLayout::SetDefaultConstraint : QLayout::SetFixedSize);
+
         priorities_.clear();
         wanted_.clear();
     }
 
-    if (ok)
-    {
-        metainfo_ = metainfo;
-    }
+    ui_.filesView->clear();
+    files_.clear();
 
-    bool const have_files_to_show = metainfo_ && !std::empty(*metainfo_);
-
-    ui_.filesView->setVisible(have_files_to_show);
-    layout()->setSizeConstraint(have_files_to_show ? QLayout::SetDefaultConstraint : QLayout::SetFixedSize);
 
     if (metainfo_)
     {

--- a/qt/OptionsDialog.cc
+++ b/qt/OptionsDialog.cc
@@ -52,6 +52,8 @@ OptionsDialog::OptionsDialog(Session& session, Prefs const& prefs, AddData addme
         ui_.sourceButton->setTitle(tr("Open Torrent"));
         ui_.sourceButton->setNameFilter(tr("Torrent Files (*.torrent);;All Files (*.*)"));
         ui_.sourceButton->setPath(add_.filename);
+        ui_.searchLineEdit->setPlaceholderText(QStringLiteral("Search..."));
+        connect(ui_.searchLineEdit, &QLineEdit::textEdited, this, &OptionsDialog::onSearchedStringChanged);
         connect(ui_.sourceButton, &PathButton::pathChanged, this, &OptionsDialog::onSourceChanged);
     }
     else
@@ -123,7 +125,7 @@ void OptionsDialog::clearInfo()
     files_.clear();
 }
 
-void OptionsDialog::reload()
+void OptionsDialog::reload(const QString& searched_string, bool reload_only_to_search)
 {
     clearInfo();
 
@@ -151,8 +153,11 @@ void OptionsDialog::reload()
     metainfo_.reset();
     ui_.filesView->clear();
     files_.clear();
-    priorities_.clear();
-    wanted_.clear();
+    if (!reload_only_to_search)
+    {
+        priorities_.clear();
+        wanted_.clear();
+    }
 
     if (ok)
     {
@@ -167,8 +172,10 @@ void OptionsDialog::reload()
     if (metainfo_)
     {
         auto const n_files = metainfo_->file_count();
-        priorities_.assign(n_files, TR_PRI_NORMAL);
-        wanted_.assign(n_files, true);
+        if (!reload_only_to_search) {
+            priorities_.assign(n_files, TR_PRI_NORMAL);
+            wanted_.assign(n_files, true);
+        }
 
         for (tr_file_index_t i = 0; i < n_files; ++i)
         {
@@ -179,7 +186,10 @@ void OptionsDialog::reload()
             f.size = metainfo_->file_size(i);
             f.have = 0;
             f.filename = QString::fromStdString(metainfo_->file_subpath(i));
-            files_.push_back(f);
+            if (searched_string.isEmpty() || (!searched_string.isEmpty() && f.filename.contains(searched_string, Qt::CaseInsensitive)))
+            {
+                files_.push_back(f);
+            }
         }
     }
 
@@ -330,4 +340,8 @@ void OptionsDialog::onDestinationChanged()
     {
         ui_.freeSpaceLabel->setPath(ui_.destinationEdit->text());
     }
+}
+
+void OptionsDialog::onSearchedStringChanged(const QString& newText) {
+    OptionsDialog::reload(newText, true);
 }

--- a/qt/OptionsDialog.h
+++ b/qt/OptionsDialog.h
@@ -52,9 +52,10 @@ private slots:
     void onDestinationChanged();
 
     void onSessionUpdated();
+    void onSearchedStringChanged(const QString &newText);
 
 private:
-    void reload();
+    void reload(const QString& searched_string = QString(), bool reload_only_to_search = false);
     void updateWidgetsLocality();
     void clearInfo();
 

--- a/qt/OptionsDialog.ui
+++ b/qt/OptionsDialog.ui
@@ -11,6 +11,28 @@
    </rect>
   </property>
   <layout class="QGridLayout" name="dialogLayout">
+   <item row="1" column="1">
+    <widget class="QStackedWidget" name="destinationStack">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <widget class="PathButton" name="destinationButton"/>
+     <widget class="QLineEdit" name="destinationEdit"/>
+    </widget>
+   </item>
+   <item row="7" column="0" colspan="2">
+    <widget class="QDialogButtonBox" name="dialogButtons">
+     <property name="orientation">
+      <enum>Qt::Orientation::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Open</set>
+     </property>
+    </widget>
+   </item>
    <item row="0" column="0">
     <widget class="QLabel" name="sourceLabel">
      <property name="text">
@@ -18,6 +40,56 @@
      </property>
      <property name="buddy">
       <cstring>sourceButton</cstring>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="0" colspan="2">
+    <widget class="QCheckBox" name="startCheck">
+     <property name="text">
+      <string>S&amp;tart when added</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="destinationLabel">
+     <property name="text">
+      <string>&amp;Destination folder:</string>
+     </property>
+     <property name="buddy">
+      <cstring>destinationButton</cstring>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="FreeSpaceLabel" name="freeSpaceLabel">
+     <property name="text">
+      <string notr="true">...</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="0" colspan="2">
+    <widget class="QCheckBox" name="trashCheck">
+     <property name="text">
+      <string>Mo&amp;ve .torrent file to the trash</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1">
+    <widget class="QComboBox" name="priorityCombo"/>
+   </item>
+   <item row="3" column="0" colspan="2">
+    <widget class="FileTreeView" name="filesView"/>
+   </item>
+   <item row="4" column="0">
+    <widget class="QLabel" name="priorityLabel">
+     <property name="text">
+      <string>&amp;Priority:</string>
+     </property>
+     <property name="buddy">
+      <cstring>priorityCombo</cstring>
      </property>
     </widget>
    </item>
@@ -33,75 +105,13 @@
      <widget class="QLineEdit" name="sourceEdit"/>
     </widget>
    </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="destinationLabel">
-     <property name="text">
-      <string>&amp;Destination folder:</string>
+   <item row="2" column="0">
+    <widget class="QLineEdit" name="searchLineEdit">
+     <property name="placeholderText">
+      <string>Search...</string>
      </property>
-     <property name="buddy">
-      <cstring>destinationButton</cstring>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1">
-    <widget class="QStackedWidget" name="destinationStack">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <widget class="PathButton" name="destinationButton"/>
-     <widget class="QLineEdit" name="destinationEdit"/>
-    </widget>
-   </item>
-   <item row="2" column="1">
-    <widget class="FreeSpaceLabel" name="freeSpaceLabel">
-     <property name="text">
-      <string notr="true">...</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="0" colspan="2">
-    <widget class="FileTreeView" name="filesView"/>
-   </item>
-   <item row="4" column="0">
-    <widget class="QLabel" name="priorityLabel">
-     <property name="text">
-      <string>&amp;Priority:</string>
-     </property>
-     <property name="buddy">
-      <cstring>priorityCombo</cstring>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="1">
-    <widget class="QComboBox" name="priorityCombo"/>
-   </item>
-   <item row="5" column="0" colspan="2">
-    <widget class="QCheckBox" name="startCheck">
-     <property name="text">
-      <string>S&amp;tart when added</string>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="0" colspan="2">
-    <widget class="QCheckBox" name="trashCheck">
-     <property name="text">
-      <string>Mo&amp;ve .torrent file to the trash</string>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="0" colspan="2">
-    <widget class="QDialogButtonBox" name="dialogButtons">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Open</set>
+     <property name="clearButtonEnabled">
+      <bool>true</bool>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
Adds an inline search box to look up files in a .torrent file. Displays only files whose filenames contain the string entered into the search box. Not case sensitive. #2403 

I didn't work much on the UI aspect, so input into how to make it look better (or how it should look) would be appreciated.
[Screencast from 2026-06-25 19-46-34.webm](https://github.com/user-attachments/assets/d64a0e69-5b6d-4546-bd02-3478232237bc)
