### PR TITLE
fix: FTBFS with fmt 12.2.0 (#8942)

### DIFF
--- a/libtransmission/tr-strbuf.h
+++ b/libtransmission/tr-strbuf.h
@@ -102,6 +102,16 @@ public:
         return buffer_[pos];
     }
 
+    [[nodiscard]] constexpr Char& operator[](size_t pos) noexcept
+    {
+        return buffer_[pos];
+    }
+
+    [[nodiscard]] constexpr Char operator[](size_t pos) const noexcept
+    {
+        return buffer_[pos];
+    }
+
     [[nodiscard]] constexpr auto size() const noexcept
     {
         return buffer_.size();


### PR DESCRIPTION
## Summary
- Cherry-pick of 4d0be3a6e4d83b0c4a471a92ee1393d434e7a16e from the `4.1.x` branch onto `main`.
- Adds non-const/const `operator[]` overloads to `tr_strbuf_base`, fixing a build failure with fmt 12.2.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)