### PR TITLE
perf: file name cell icon caching added.

### DIFF
--- a/macosx/BaseFileNameCellView.mm
+++ b/macosx/BaseFileNameCellView.mm
@@ -3,6 +3,7 @@
 // License text can be found in the licenses/ folder.
 
 #include <libtransmission/transmission.h>
+#import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
 
 #import "BaseFileNameCellView.h"
 #import "FileListNode.h"
@@ -24,7 +25,28 @@ static CGFloat const kPaddingBetweenNameAndFolderStatus = 4.0;
 @property(nonatomic, strong) NSArray<NSLayoutConstraint*>* dynamicConstraints;
 @end
 
+static NSCache<UTType*, NSImage*>* iconCache;
+
 @implementation BaseFileNameCellView
+
++ (void)initialize
+{
+    iconCache = [[NSCache alloc] init];
+}
+
++ (NSImage*)cachedIconForUTType:(UTType*)uttype
+{
+    __auto_type cachedIcon = [iconCache objectForKey:uttype];
+
+    if (cachedIcon == nil)
+    {
+        __auto_type icon = [NSWorkspace.sharedWorkspace iconForContentType:uttype];
+        [iconCache setObject:icon forKey:uttype];
+        return icon;
+    }
+
+    return cachedIcon;
+}
 
 - (instancetype)initWithFrame:(NSRect)frameRect
 {
@@ -73,6 +95,10 @@ static CGFloat const kPaddingBetweenNameAndFolderStatus = 4.0;
 {
 }
 
+- (void)updateImageIfNeeded
+{
+}
+
 - (void)setNode:(FileListNode*)node
 {
     _node = node;
@@ -89,7 +115,7 @@ static CGFloat const kPaddingBetweenNameAndFolderStatus = 4.0;
     FileListNode* node = self.node;
 
     // Update icon
-    self.iconView.image = node.icon;
+    [self updateImageIfNeeded];
 
     // Update name
     self.nameField.stringValue = node.name;
@@ -166,6 +192,19 @@ static CGFloat const kPaddingBetweenNameAndFolderStatus = 4.0;
 
 @implementation FileNameCellView
 
+- (void)updateImageIfNeeded
+{
+    if (self.node.name == nil)
+    {
+        return;
+    }
+
+    __auto_type uttype = [UTType typeWithFilenameExtension:self.node.name.pathExtension];
+    __auto_type image = [self.class cachedIconForUTType:uttype];
+
+    self.iconView.image = image;
+}
+
 - (void)setupConstraints
 {
     NSImageView* iconView = self.iconView;
@@ -196,6 +235,15 @@ static CGFloat const kPaddingBetweenNameAndFolderStatus = 4.0;
 @end
 
 @implementation FolderNameCellView
+
+- (instancetype)initWithFrame:(NSRect)frameRect
+{
+    if (self = [super initWithFrame:frameRect])
+    {
+        self.iconView.image = [self.class cachedIconForUTType:UTTypeFolder];
+    }
+    return self;
+}
 
 - (void)setupConstraints
 {


### PR DESCRIPTION
In previous https://github.com/transmission/transmission/pull/8497 PR file name cell was slightly optimized.

This PR continues optimization by adding icon caching.

I checked with this snippet.

```objective-c++
#import <mach/mach_time.h>

// Inside -(void)updateDisplay {
static uint64_t totalNanoseconds = 0;
static uint64_t callCount = 0;

uint64_t start = mach_absolute_time();

// --- body of updateDisplay... ---

uint64_t end = mach_absolute_time();

mach_timebase_info_data_t info;
mach_timebase_info(&info);
uint64_t elapsedNano = (end - start) * info.numer / info.denom;

totalNanoseconds += elapsedNano;
callCount++;

// Average time every 500 calls (scrolling).
if (callCount % 500 == 0) {
    NSLog(@"[PERF_TEST] Calls: %llu | Avg time per cell: %.3f ms", 
          callCount, (double)totalNanoseconds / callCount / 1000000.0);
}
// }
// [self updateColors];
// ...
// } // end of -(void)updateDisplay
```

### Results

#### Before cells separation

| Total Rendered Cells | Before Optimization (main) | After Optimization (This PR) | Speedup / Improvement |
|---|---|---|---|
| 1,000 cells | 0.534 ms | 0.409 ms | -23.4% time spent |
| 1,500 cells | 0.539 ms | 0.357 ms | -33.8% time spent |
| 2,000 cells | 0.540 ms | 0.377 ms | -30.2% time spent |
| 2,500 cells | 0.543 ms | 0.389 ms | -28.4% time spent |
| 3,000 cells | 0.533 ms | 0.397 ms | -25.5% time spent |
| Average | 0.538 ms | 0.386 ms | ~1.39x Faster |

#### After cells separation with icon caching

| Total Rendered Cells | Before Optimization (main) | After Optimization (This PR) | Speedup / Improvement |
|---|---|---|---|
| 1,000 cells | 0.409 ms | 0.138 ms | -66.3% time spent |
| 1,500 cells | 0.357 ms | 0.134 ms | -62.5% time spent |
| 2,000 cells | 0.377 ms | 0.131 ms | -65.3% time spent |
| 2,500 cells | 0.389 ms | 0.129 ms | -66.8% time spent |
| 3,000 cells | 0.397 ms | 0.128 ms | -67.8% time spent |
| Average | 0.386 ms | 0.132 ms | ~2.9x Faster |

### Video 

#### Before Optimization

https://github.com/user-attachments/assets/8d425ffb-f043-4402-923d-fd27f7947ca7

#### After Optimization

https://github.com/user-attachments/assets/118224dc-eacb-4402-ad95-54f1da35c59f
