### PR TITLE
chore: 4.1.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,7 +95,7 @@ set(TR_NAME ${PROJECT_NAME})
 # these should be the only five lines you need to change
 set(TR_VERSION_MAJOR "4")
 set(TR_VERSION_MINOR "1")
-set(TR_VERSION_PATCH "2")
+set(TR_VERSION_PATCH "3")
 set(TR_VERSION_BETA_NUMBER "") # empty string for not beta
 set(TR_VERSION_DEV FALSE)
 

--- a/news/news-4.1.3.md
+++ b/news/news-4.1.3.md
@@ -1,0 +1,17 @@
+# Transmission 4.1.3
+
+This is Transmission 4.1.3, a bugfix release. It fixes a potential
+CRSF security issue for users who enable remote access to Transmission.
+Users are encouraged to upgrade to this version.
+
+## What's New in 4.1.3
+
+### All Platforms
+
+* Fixed a CORS bug that leaked the anti-CSRF nonce. ([#8938](https://github.com/transmission/transmission/pull/8938))
+* Fixed a use-after-free bug in peer code. ([#8921](https://github.com/transmission/transmission/pull/8921))
+* Fixed build error when compiling with [fmt](https://github.com/fmtlib/fmt) 12.2.0. ([#8942](https://github.com/transmission/transmission/pull/8942))
+
+### Everything Else
+
+* Fixed a `4.1.2` build error in tests. ([#8881](https://github.com/transmission/transmission/pull/8881))


### PR DESCRIPTION
bump to 4.1.3 and add release notes.

https://github.com/transmission/transmission/blob/chore/4.1.3/news/news-4.1.3.md