### PR TITLE
fix: apply honor-session-limits change to both directions

### DIFF
--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -269,8 +269,9 @@ void tr_torrentUseSessionLimits(tr_torrent* const tor, bool const enabled)
 {
     tr_return_if_fail(tr_isTorrent(tor));
 
-    if (tor->bandwidth().honor_parent_limits(tr_direction::Up, enabled) ||
-        tor->bandwidth().honor_parent_limits(tr_direction::Down, enabled))
+    auto const changed_up = tor->bandwidth().honor_parent_limits(tr_direction::Up, enabled);
+    auto const changed_down = tor->bandwidth().honor_parent_limits(tr_direction::Down, enabled);
+    if (changed_up || changed_down)
     {
         tor->set_dirty();
     }

--- a/tests/libtransmission/torrent-test.cc
+++ b/tests/libtransmission/torrent-test.cc
@@ -7,6 +7,8 @@
 #include <cstddef>
 #include <ranges>
 
+#include <libtransmission/transmission.h>
+
 #include <libtransmission/torrent.h>
 
 #include "test-fixtures.h"
@@ -73,6 +75,28 @@ TEST_F(TorrentTest, queueMoveDown)
     {
         EXPECT_EQ(ExpectedQueuePosition[i], torrents[i]->queue_position()) << i;
     }
+}
+
+TEST_F(TorrentTest, useSessionLimitsAffectsBothDirections)
+{
+    auto* const tor = torrentInitFromFile(TorFilenames[0]);
+    ASSERT_NE(nullptr, tor);
+
+    // Torrents honor the session (parent) limits in both directions by default.
+    EXPECT_TRUE(tor->bandwidth().are_parent_limits_honored(tr_direction::Up));
+    EXPECT_TRUE(tor->bandwidth().are_parent_limits_honored(tr_direction::Down));
+
+    // Disabling must clear the flag for BOTH directions. Regression test for a
+    // short-circuit `||` that skipped the Down call once the Up call changed,
+    // leaving downloads still bound by the session limit.
+    tr_torrentUseSessionLimits(tor, false);
+    EXPECT_FALSE(tor->bandwidth().are_parent_limits_honored(tr_direction::Up));
+    EXPECT_FALSE(tor->bandwidth().are_parent_limits_honored(tr_direction::Down));
+
+    // Re-enabling restores both directions.
+    tr_torrentUseSessionLimits(tor, true);
+    EXPECT_TRUE(tor->bandwidth().are_parent_limits_honored(tr_direction::Up));
+    EXPECT_TRUE(tor->bandwidth().are_parent_limits_honored(tr_direction::Down));
 }
 
 TEST_F(TorrentTest, queueMoveTop)


### PR DESCRIPTION
### Summary
  `tr_torrentUseSessionLimits()` only updated the **upload** direction's `honor_parent_limits_`
  flag, leaving **download** still bound by the global/session speed limit. A torrent set to *not*
  honor session limits still had its download throttled by the global cap (uploads were correctly
  exempted).

  ### Root cause
  ```cpp
  if (tor->bandwidth().honor_parent_limits(tr_direction::Up, enabled) ||
      tor->bandwidth().honor_parent_limits(tr_direction::Down, enabled))
  {
      tor->set_dirty();
  }
  ```
  honor_parent_limits() has a side effect (it sets the flag) and returns whether the value
  changed. In a short-circuit ||, when the Up call returns true (changed), the Down call
  is never evaluated — so the download direction's flag is never updated. Toggling from the
  default (honored) flips Up (returns true, short-circuits) and silently leaves Down
  honored. This also matches the RPC docs describing the field as "true if session upload
  limits are honored".

  ### Fix

  Evaluate both calls before combining, so both directions are always updated.

  ### Verification

  - Added regression test TorrentTest.useSessionLimitsAffectsBothDirections: fails on main
  (Down stays honored), passes with the fix.
  - End-to-end against transmission-daemon with a 50 KB/s global download limit and a
  well-seeded torrent