### PR TITLE
Skip occluded macOS main window updates

### DIFF
--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -2398,15 +2398,20 @@ static void removeKeRangerRansomware()
 
     PowerManager.shared.shouldPreventSleep = anyActive && [self.fDefaults boolForKey:@"SleepPrevent"];
 
+    BOOL const mainWindowVisible = self.fWindow.visible && (self.fWindow.occlusionState & NSWindowOcclusionStateVisible) != 0;
+
     if (!NSApp.hidden)
     {
-        if (self.fWindow.visible)
+        // No need to run any main window updates if there are no visible pixels, saves some CPU time.
+        if (mainWindowVisible)
         {
             [self sortTorrentsAndIncludeQueueOrder:NO];
 
             [self.fStatusBar updateWithDownload:dlRate upload:ulRate];
 
             self.fClearCompletedButton.hidden = !anyCompleted;
+
+            [self.fTableView reloadVisibleRows];
         }
 
         //update non-constant parts of info window
@@ -2414,8 +2419,6 @@ static void removeKeRangerRansomware()
         {
             [self.fInfoController updateInfoStats];
         }
-
-        [self.fTableView reloadVisibleRows];
     }
 
     //badge dock


### PR DESCRIPTION
With tens of torrents, all paused, I observed 2-3% of one CPU core spent updating the main window, mostly progress bar drawing, even when the window had no visible pixels.

With this patch I see around 0.5%, with barely any of that time spent in UI.

Notes: Improved macOS performance when the main window is occluded.