### PR TITLE
Refactor mac toolbar controller

### DIFF
--- a/Transmission.xcodeproj/project.pbxproj
+++ b/Transmission.xcodeproj/project.pbxproj
@@ -11,12 +11,6 @@
 		0A6169A80FE5C9A200C66CE6 /* bitfield.h in Headers */ = {isa = PBXBuildFile; fileRef = 0A6169A60FE5C9A200C66CE6 /* bitfield.h */; };
 		0A89346B736DBCF81F3A4850 /* torrent-metainfo.cc in Sources */ = {isa = PBXBuildFile; fileRef = 0A89346B736DBCF81F3A4851 /* torrent-metainfo.cc */; };
 		0A89346B736DBCF81F3A4852 /* torrent-metainfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 0A89346B736DBCF81F3A4853 /* torrent-metainfo.h */; };
-		9F0B1F302E4D1A0100A1B2C3 /* env.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F0B1F2A2E4D1A0100A1B2C3 /* env.h */; };
-		9F0B1F312E4D1A0100A1B2C3 /* file-utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F0B1F2C2E4D1A0100A1B2C3 /* file-utils.h */; };
-		9F0B1F322E4D1A0100A1B2C3 /* string-utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F0B1F2E2E4D1A0100A1B2C3 /* string-utils.h */; };
-		9F0B1F332E4D1A0100A1B2C3 /* env.cc in Sources */ = {isa = PBXBuildFile; fileRef = 9F0B1F2B2E4D1A0100A1B2C3 /* env.cc */; };
-		9F0B1F342E4D1A0100A1B2C3 /* file-utils.cc in Sources */ = {isa = PBXBuildFile; fileRef = 9F0B1F2D2E4D1A0100A1B2C3 /* file-utils.cc */; };
-		9F0B1F352E4D1A0100A1B2C3 /* string-utils.cc in Sources */ = {isa = PBXBuildFile; fileRef = 9F0B1F2F2E4D1A0100A1B2C3 /* string-utils.cc */; };
 		1BB44E07B1B52E28291B4E32 /* file-piece-map.cc in Sources */ = {isa = PBXBuildFile; fileRef = 1BB44E07B1B52E28291B4E30 /* file-piece-map.cc */; };
 		1BB44E07B1B52E28291B4E33 /* file-piece-map.h in Headers */ = {isa = PBXBuildFile; fileRef = 1BB44E07B1B52E28291B4E31 /* file-piece-map.h */; };
 		2856E0656A49F2665D69E760 /* benc.h in Headers */ = {isa = PBXBuildFile; fileRef = 2856E0656A49F2665D69E761 /* benc.h */; };
@@ -74,6 +68,12 @@
 		8D11072B0486CEB800E47090 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 089C165CFE840E0CC02AAC07 /* InfoPlist.strings */; };
 		8D11072D0486CEB800E47090 /* main.mm in Sources */ = {isa = PBXBuildFile; fileRef = 29B97316FDCFA39411CA2CEA /* main.mm */; settings = {ATTRIBUTES = (); }; };
 		8D11072F0486CEB800E47090 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */; };
+		9F0B1F302E4D1A0100A1B2C3 /* env.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F0B1F2A2E4D1A0100A1B2C3 /* env.h */; };
+		9F0B1F312E4D1A0100A1B2C3 /* file-utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F0B1F2C2E4D1A0100A1B2C3 /* file-utils.h */; };
+		9F0B1F322E4D1A0100A1B2C3 /* string-utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F0B1F2E2E4D1A0100A1B2C3 /* string-utils.h */; };
+		9F0B1F332E4D1A0100A1B2C3 /* env.cc in Sources */ = {isa = PBXBuildFile; fileRef = 9F0B1F2B2E4D1A0100A1B2C3 /* env.cc */; };
+		9F0B1F342E4D1A0100A1B2C3 /* file-utils.cc in Sources */ = {isa = PBXBuildFile; fileRef = 9F0B1F2D2E4D1A0100A1B2C3 /* file-utils.cc */; };
+		9F0B1F352E4D1A0100A1B2C3 /* string-utils.cc in Sources */ = {isa = PBXBuildFile; fileRef = 9F0B1F2F2E4D1A0100A1B2C3 /* string-utils.cc */; };
 		A200B9200A22798F007BBB1E /* InfoWindowController.mm in Sources */ = {isa = PBXBuildFile; fileRef = A200B83A0A2263BA007BBB1E /* InfoWindowController.mm */; };
 		A201527E0D1C270F0081714F /* torrent-ctor.cc in Sources */ = {isa = PBXBuildFile; fileRef = A20152790D1C26EB0081714F /* torrent-ctor.cc */; };
 		A20162C913DE48BF00E15488 /* receivedata.c in Sources */ = {isa = PBXBuildFile; fileRef = A20162C713DE48BF00E15488 /* receivedata.c */; };
@@ -304,8 +304,6 @@
 		BEFC1E4D0C07861A00B0BB3C /* session.h in Headers */ = {isa = PBXBuildFile; fileRef = BEFC1E140C07861A00B0BB3C /* session.h */; };
 		BEFC1E4E0C07861A00B0BB3C /* inout.h in Headers */ = {isa = PBXBuildFile; fileRef = BEFC1E150C07861A00B0BB3C /* inout.h */; };
 		BEFC1E4F0C07861A00B0BB3C /* inout.cc in Sources */ = {isa = PBXBuildFile; fileRef = BEFC1E160C07861A00B0BB3C /* inout.cc */; };
-		EDC0A1B12E5A100100A1B2C3 /* local-data.h in Headers */ = {isa = PBXBuildFile; fileRef = EDC0A1AF2E5A100100A1B2C3 /* local-data.h */; };
-		EDC0A1B22E5A100100A1B2C3 /* local-data.cc in Sources */ = {isa = PBXBuildFile; fileRef = EDC0A1B02E5A100100A1B2C3 /* local-data.cc */; };
 		BEFC1E520C07861A00B0BB3C /* open-files.h in Headers */ = {isa = PBXBuildFile; fileRef = BEFC1E190C07861A00B0BB3C /* open-files.h */; };
 		BEFC1E530C07861A00B0BB3C /* open-files.cc in Sources */ = {isa = PBXBuildFile; fileRef = BEFC1E1A0C07861A00B0BB3C /* open-files.cc */; };
 		BEFC1E550C07861A00B0BB3C /* completion.h in Headers */ = {isa = PBXBuildFile; fileRef = BEFC1E1C0C07861A00B0BB3C /* completion.h */; };
@@ -440,12 +438,12 @@
 		CAB35C64252F6F5E00552A55 /* mime-types.h in Headers */ = {isa = PBXBuildFile; fileRef = CAB35C62252F6F5E00552A55 /* mime-types.h */; };
 		CCEBA596277340F6DF9F4480 /* session-alt-speeds.cc in Sources */ = {isa = PBXBuildFile; fileRef = CCEBA596277340F6DF9F4481 /* session-alt-speeds.cc */; };
 		CCEBA596277340F6DF9F4482 /* session-alt-speeds.h in Headers */ = {isa = PBXBuildFile; fileRef = CCEBA596277340F6DF9F4483 /* session-alt-speeds.h */; };
-		F0A1B2C32F1A2B3C00445566 /* session-settings.h in Headers */ = {isa = PBXBuildFile; fileRef = F0A1B2C42F1A2B3C00445566 /* session-settings.h */; };
 		E138A9780C04D88F00C5426C /* ProgressGradients.mm in Sources */ = {isa = PBXBuildFile; fileRef = E138A9760C04D88F00C5426C /* ProgressGradients.mm */; };
 		E23B55A5FC3B557F7746D510 /* interned-string.h in Headers */ = {isa = PBXBuildFile; fileRef = E23B55A5FC3B557F7746D511 /* interned-string.h */; settings = {ATTRIBUTES = (Project, ); }; };
 		E975121263DD973CAF4AEBA0 /* timer.h in Headers */ = {isa = PBXBuildFile; fileRef = E975121263DD973CAF4AEBA1 /* timer.h */; };
 		E975121263DD973CAF4AEBA2 /* timer-ev.h in Headers */ = {isa = PBXBuildFile; fileRef = E975121263DD973CAF4AEBA3 /* timer-ev.h */; };
 		E975121263DD973CAF4AEBA4 /* timer-ev.cc in Sources */ = {isa = PBXBuildFile; fileRef = E975121263DD973CAF4AEBA5 /* timer-ev.cc */; };
+		ED1EB19B2FF95CCA004BA280 /* MainToolbarController.mm in Sources */ = {isa = PBXBuildFile; fileRef = ED1EB19A2FF95CCA004BA280 /* MainToolbarController.mm */; };
 		ED20B87C28589274005FA6BE /* common_defs.h in Headers */ = {isa = PBXBuildFile; fileRef = ED20B87B28589274005FA6BE /* common_defs.h */; };
 		ED20B87F285892C5005FA6BE /* crc32_multipliers.h in Headers */ = {isa = PBXBuildFile; fileRef = ED20B87D285892C5005FA6BE /* crc32_multipliers.h */; };
 		ED20B880285892C5005FA6BE /* crc32_tables.h in Headers */ = {isa = PBXBuildFile; fileRef = ED20B87E285892C5005FA6BE /* crc32_tables.h */; };
@@ -478,10 +476,13 @@
 		EDBBE76B2F0FF05500E90EA1 /* peer-socket-tcp.h in Headers */ = {isa = PBXBuildFile; fileRef = EDBBE7652F0FF05500E90EA1 /* peer-socket-tcp.h */; };
 		EDBBE76C2F0FF05500E90EA1 /* peer-socket-utp.h in Headers */ = {isa = PBXBuildFile; fileRef = EDBBE7672F0FF05500E90EA1 /* peer-socket-utp.h */; };
 		EDBDFA9E25AFCCA60093D9C1 /* evutil_time.c in Sources */ = {isa = PBXBuildFile; fileRef = EDBDFA9D25AFCCA60093D9C1 /* evutil_time.c */; };
+		EDC0A1B12E5A100100A1B2C3 /* local-data.h in Headers */ = {isa = PBXBuildFile; fileRef = EDC0A1AF2E5A100100A1B2C3 /* local-data.h */; };
+		EDC0A1B22E5A100100A1B2C3 /* local-data.cc in Sources */ = {isa = PBXBuildFile; fileRef = EDC0A1B02E5A100100A1B2C3 /* local-data.cc */; };
 		EDC37BCD2EE9C2AD001E2612 /* api-compat.cc in Sources */ = {isa = PBXBuildFile; fileRef = EDC37BCC2EE9C2AD001E2612 /* api-compat.cc */; };
 		EDC37BCE2EE9C2AD001E2612 /* api-compat.h in Headers */ = {isa = PBXBuildFile; fileRef = EDC37BCB2EE9C2AD001E2612 /* api-compat.h */; };
 		EDC749F92D98AE3000A12D0F /* PowerManager.mm in Sources */ = {isa = PBXBuildFile; fileRef = EDC749F82D98AE2900A12D0F /* PowerManager.mm */; };
 		EDD735D62D83087400852628 /* UniformTypeIdentifiers.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EDD735D52D83087400852628 /* UniformTypeIdentifiers.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
+		F0A1B2C32F1A2B3C00445566 /* session-settings.h in Headers */ = {isa = PBXBuildFile; fileRef = F0A1B2C42F1A2B3C00445566 /* session-settings.h */; };
 		F11545ACA7C4D7A464F703AB /* block-info.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A044CBD8C049AFCBD4DB411 /* block-info.h */; settings = {ATTRIBUTES = (Project, ); }; };
 		F63480631E1D7274005B9E09 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F63480621E1D7274005B9E09 /* Images.xcassets */; };
 /* End PBXBuildFile section */
@@ -848,6 +849,12 @@
 		888A256631B3DE536FEB8B01 /* tr-strbuf.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; fileEncoding = 4; path = "tr-strbuf.h"; sourceTree = "<group>"; };
 		8D1107310486CEB800E47090 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		8D1107320486CEB800E47090 /* Transmission.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Transmission.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		9F0B1F2A2E4D1A0100A1B2C3 /* env.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; path = env.h; sourceTree = "<group>"; };
+		9F0B1F2B2E4D1A0100A1B2C3 /* env.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = env.cc; sourceTree = "<group>"; };
+		9F0B1F2C2E4D1A0100A1B2C3 /* file-utils.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; path = "file-utils.h"; sourceTree = "<group>"; };
+		9F0B1F2D2E4D1A0100A1B2C3 /* file-utils.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "file-utils.cc"; sourceTree = "<group>"; };
+		9F0B1F2E2E4D1A0100A1B2C3 /* string-utils.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; path = "string-utils.h"; sourceTree = "<group>"; };
+		9F0B1F2F2E4D1A0100A1B2C3 /* string-utils.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "string-utils.cc"; sourceTree = "<group>"; };
 		A200B8390A2263BA007BBB1E /* InfoWindowController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = InfoWindowController.h; sourceTree = "<group>"; };
 		A200B83A0A2263BA007BBB1E /* InfoWindowController.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = InfoWindowController.mm; sourceTree = "<group>"; };
 		A20152790D1C26EB0081714F /* torrent-ctor.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "torrent-ctor.cc"; sourceTree = "<group>"; };
@@ -1137,13 +1144,9 @@
 		BEFC1DF00C07861A00B0BB3C /* version.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; path = version.h; sourceTree = "<group>"; };
 		BEFC1DF10C07861A00B0BB3C /* utils.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; path = utils.h; sourceTree = "<group>"; };
 		BEFC1DF20C07861A00B0BB3C /* utils.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = utils.cc; sourceTree = "<group>"; };
-		9F0B1F2F2E4D1A0100A1B2C3 /* string-utils.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "string-utils.cc"; sourceTree = "<group>"; };
-		9F0B1F2E2E4D1A0100A1B2C3 /* string-utils.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; path = "string-utils.h"; sourceTree = "<group>"; };
 		BEFC1DF30C07861A00B0BB3C /* port-forwarding-upnp.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; path = "port-forwarding-upnp.h"; sourceTree = "<group>"; };
 		BEFC1DF40C07861A00B0BB3C /* port-forwarding-upnp.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "port-forwarding-upnp.cc"; sourceTree = "<group>"; };
 		BEFC1DF50C07861A00B0BB3C /* transmission.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = transmission.h; sourceTree = "<group>"; };
-		EDEB86BE2BDF9E9D00112233 /* constants.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = constants.h; sourceTree = "<group>"; };
-		EDEB86BF2BDF9E9D00112233 /* types.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = types.h; sourceTree = "<group>"; };
 		BEFC1DF60C07861A00B0BB3C /* session.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = session.cc; sourceTree = "<group>"; };
 		BEFC1DF90C07861A00B0BB3C /* torrent.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = torrent.cc; sourceTree = "<group>"; };
 		BEFC1DFC0C07861A00B0BB3C /* port-forwarding.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; path = "port-forwarding.h"; sourceTree = "<group>"; };
@@ -1156,8 +1159,6 @@
 		BEFC1E140C07861A00B0BB3C /* session.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; path = session.h; sourceTree = "<group>"; };
 		BEFC1E150C07861A00B0BB3C /* inout.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; path = inout.h; sourceTree = "<group>"; };
 		BEFC1E160C07861A00B0BB3C /* inout.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = inout.cc; sourceTree = "<group>"; };
-		EDC0A1AF2E5A100100A1B2C3 /* local-data.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; path = local-data.h; sourceTree = "<group>"; };
-		EDC0A1B02E5A100100A1B2C3 /* local-data.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = local-data.cc; sourceTree = "<group>"; };
 		BEFC1E190C07861A00B0BB3C /* open-files.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; path = "open-files.h"; sourceTree = "<group>"; };
 		BEFC1E1A0C07861A00B0BB3C /* open-files.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "open-files.cc"; sourceTree = "<group>"; };
 		BEFC1E1C0C07861A00B0BB3C /* completion.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; path = completion.h; sourceTree = "<group>"; };
@@ -1170,12 +1171,8 @@
 		C1033E061A3279B800EF44D8 /* crypto-utils.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; path = "crypto-utils.h"; sourceTree = "<group>"; };
 		C1077A4A183EB29600634C22 /* error.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = error.cc; sourceTree = "<group>"; };
 		C1077A4B183EB29600634C22 /* error.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; path = error.h; sourceTree = "<group>"; };
-		9F0B1F2B2E4D1A0100A1B2C3 /* env.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = env.cc; sourceTree = "<group>"; };
-		9F0B1F2A2E4D1A0100A1B2C3 /* env.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; path = env.h; sourceTree = "<group>"; };
 		C1077A4C183EB29600634C22 /* file-posix.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "file-posix.cc"; sourceTree = "<group>"; };
 		C1077A4D183EB29600634C22 /* file.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; path = file.h; sourceTree = "<group>"; };
-		9F0B1F2D2E4D1A0100A1B2C3 /* file-utils.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "file-utils.cc"; sourceTree = "<group>"; };
-		9F0B1F2C2E4D1A0100A1B2C3 /* file-utils.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; path = "file-utils.h"; sourceTree = "<group>"; };
 		C10C644B1D9AF328003C1B4C /* session-id.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = "session-id.cc"; sourceTree = "<group>"; };
 		C10C644C1D9AF328003C1B4C /* session-id.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; fileEncoding = 4; path = "session-id.h"; sourceTree = "<group>"; };
 		C11DEA141FCD31C0009E22B9 /* subprocess-posix.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = "subprocess-posix.cc"; sourceTree = "<group>"; };
@@ -1391,7 +1388,7 @@
 		C81E411127F5BABD00652F56 /* CocoaCompatibility.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CocoaCompatibility.h; sourceTree = "<group>"; };
 		C841A27F29197724009F18E8 /* NSKeyedUnarchiverAdditions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NSKeyedUnarchiverAdditions.h; sourceTree = "<group>"; };
 		C841A28029197724009F18E8 /* NSKeyedUnarchiverAdditions.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = NSKeyedUnarchiverAdditions.mm; sourceTree = "<group>"; };
-		C843FC8329C51B9400491854 /* string-utils.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = string-utils.mm; sourceTree = "<group>"; };
+		C843FC8329C51B9400491854 /* string-utils.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = "string-utils.mm"; sourceTree = "<group>"; };
 		C843FC8529C8B40800491854 /* VersionComparator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VersionComparator.h; sourceTree = "<group>"; };
 		C843FC8629C8B40800491854 /* VersionComparator.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = VersionComparator.mm; sourceTree = "<group>"; };
 		C86BCD9828228A9600F45599 /* SparkleProxy.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = SparkleProxy.mm; sourceTree = "<group>"; };
@@ -1410,13 +1407,14 @@
 		CAB35C62252F6F5E00552A55 /* mime-types.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; fileEncoding = 4; path = "mime-types.h"; sourceTree = "<group>"; };
 		CCEBA596277340F6DF9F4481 /* session-alt-speeds.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "session-alt-speeds.cc"; sourceTree = "<group>"; };
 		CCEBA596277340F6DF9F4483 /* session-alt-speeds.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; path = "session-alt-speeds.h"; sourceTree = "<group>"; };
-		F0A1B2C42F1A2B3C00445566 /* session-settings.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; path = "session-settings.h"; sourceTree = "<group>"; };
 		E138A9750C04D88F00C5426C /* ProgressGradients.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ProgressGradients.h; sourceTree = "<group>"; };
 		E138A9760C04D88F00C5426C /* ProgressGradients.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ProgressGradients.mm; sourceTree = "<group>"; };
 		E23B55A5FC3B557F7746D511 /* interned-string.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; path = "interned-string.h"; sourceTree = "<group>"; };
 		E975121263DD973CAF4AEBA1 /* timer.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; fileEncoding = 4; path = timer.h; sourceTree = "<group>"; };
 		E975121263DD973CAF4AEBA3 /* timer-ev.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; fileEncoding = 4; path = "timer-ev.h"; sourceTree = "<group>"; };
 		E975121263DD973CAF4AEBA5 /* timer-ev.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = "timer-ev.cc"; sourceTree = "<group>"; };
+		ED1EB1992FF95CCA004BA280 /* MainToolbarController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MainToolbarController.h; sourceTree = "<group>"; };
+		ED1EB19A2FF95CCA004BA280 /* MainToolbarController.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MainToolbarController.mm; sourceTree = "<group>"; };
 		ED20B87B28589274005FA6BE /* common_defs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = common_defs.h; sourceTree = "<group>"; };
 		ED20B87D285892C5005FA6BE /* crc32_multipliers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = crc32_multipliers.h; path = lib/crc32_multipliers.h; sourceTree = "<group>"; };
 		ED20B87E285892C5005FA6BE /* crc32_tables.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = crc32_tables.h; path = lib/crc32_tables.h; sourceTree = "<group>"; };
@@ -1473,11 +1471,16 @@
 		EDBBE7672F0FF05500E90EA1 /* peer-socket-utp.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "peer-socket-utp.h"; sourceTree = "<group>"; };
 		EDBBE7682F0FF05500E90EA1 /* peer-socket-utp.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "peer-socket-utp.cc"; sourceTree = "<group>"; };
 		EDBDFA9D25AFCCA60093D9C1 /* evutil_time.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = evutil_time.c; sourceTree = "<group>"; };
+		EDC0A1AF2E5A100100A1B2C3 /* local-data.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; path = "local-data.h"; sourceTree = "<group>"; };
+		EDC0A1B02E5A100100A1B2C3 /* local-data.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "local-data.cc"; sourceTree = "<group>"; };
 		EDC37BCB2EE9C2AD001E2612 /* api-compat.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "api-compat.h"; sourceTree = "<group>"; };
 		EDC37BCC2EE9C2AD001E2612 /* api-compat.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "api-compat.cc"; sourceTree = "<group>"; };
 		EDC749F72D98ADE200A12D0F /* PowerManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PowerManager.h; sourceTree = "<group>"; };
 		EDC749F82D98AE2900A12D0F /* PowerManager.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = PowerManager.mm; sourceTree = "<group>"; };
 		EDD735D52D83087400852628 /* UniformTypeIdentifiers.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UniformTypeIdentifiers.framework; path = System/Library/Frameworks/UniformTypeIdentifiers.framework; sourceTree = SDKROOT; };
+		EDEB86BE2BDF9E9D00112233 /* constants.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = constants.h; sourceTree = "<group>"; };
+		EDEB86BF2BDF9E9D00112233 /* types.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = types.h; sourceTree = "<group>"; };
+		F0A1B2C42F1A2B3C00445566 /* session-settings.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; path = "session-settings.h"; sourceTree = "<group>"; };
 		F63480621E1D7274005B9E09 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = Images/Images.xcassets; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -1689,6 +1692,8 @@
 		080E96DDFE201D6D7F000001 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				ED1EB1992FF95CCA004BA280 /* MainToolbarController.h */,
+				ED1EB19A2FF95CCA004BA280 /* MainToolbarController.mm */,
 				29B97316FDCFA39411CA2CEA /* main.mm */,
 				C86BCD9828228A9600F45599 /* SparkleProxy.mm */,
 				4DF0C5AA0899190500DD8943 /* Controller.h */,
@@ -3547,6 +3552,7 @@
 				A21A9D41106EC2E800F1C3C1 /* TrackerCell.mm in Sources */,
 				A263CFC010DD67670038DE27 /* InfoTextField.mm in Sources */,
 				A209EAC61142CF28002B02D1 /* InfoActivityViewController.mm in Sources */,
+				ED1EB19B2FF95CCA004BA280 /* MainToolbarController.mm in Sources */,
 				A209EAC71142CF28002B02D1 /* InfoGeneralViewController.mm in Sources */,
 				A209EB011142D3A5002B02D1 /* InfoTrackersViewController.mm in Sources */,
 				A209EB9D1142E59A002B02D1 /* InfoPeersViewController.mm in Sources */,

--- a/macosx/CMakeLists.txt
+++ b/macosx/CMakeLists.txt
@@ -123,6 +123,8 @@ target_sources(${TR_NAME}-mac
         InfoWindowController.h
         InfoWindowController.mm
         main.mm
+        MainToolbarController.h
+        MainToolbarController.mm
         MessageWindowController.h
         MessageWindowController.mm
         NSApplicationAdditions.h

--- a/macosx/Controller.h
+++ b/macosx/Controller.h
@@ -26,7 +26,7 @@ typedef NS_ENUM(NSUInteger, AddType) { //
 };
 
 @interface Controller
-    : NSObject<NSApplicationDelegate, NSMenuItemValidation, NSPopoverDelegate, NSSharingServiceDelegate, NSSharingServicePickerDelegate, NSSoundDelegate, NSToolbarDelegate, NSToolbarItemValidation, NSWindowDelegate, QLPreviewPanelDataSource, QLPreviewPanelDelegate, VDKQueueDelegate, SUUpdaterDelegate>
+    : NSObject<NSApplicationDelegate, NSMenuItemValidation, NSPopoverDelegate, NSSharingServiceDelegate, NSSharingServicePickerDelegate, NSSoundDelegate, NSWindowDelegate, QLPreviewPanelDataSource, QLPreviewPanelDelegate, VDKQueueDelegate, SUUpdaterDelegate>
 
 - (void)openFiles:(NSArray<NSString*>*)filenames addType:(AddType)type forcePath:(NSString*)path;
 
@@ -156,9 +156,6 @@ typedef NS_ENUM(NSUInteger, AddType) { //
 - (IBAction)toggleFilterBar:(id)sender;
 - (IBAction)toggleToolbarShown:(id)sender;
 - (void)focusFilterField;
-
-- (void)allToolbarClicked:(id)sender;
-- (void)selectedToolbarClicked:(id)sender;
 
 - (void)updateMainWindow;
 

--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -42,11 +42,8 @@
 #import "AddMagnetWindowController.h"
 #import "MessageWindowController.h"
 #import "GlobalOptionsPopoverViewController.h"
-#import "ButtonToolbarItem.h"
-#import "GroupToolbarItem.h"
-#import "ShareToolbarItem.h"
+#import "MainToolbarController.h"
 #import "ShareTorrentFileHelper.h"
-#import "Toolbar.h"
 #import "BlocklistDownloader.h"
 #import "StatusBarController.h"
 #import "FilterBarController.h"
@@ -62,28 +59,6 @@
 #import "VersionComparator.h"
 #import "PowerManager.h"
 #import "Utils.h"
-
-typedef NSString* ToolbarItemIdentifier NS_TYPED_EXTENSIBLE_ENUM;
-
-static ToolbarItemIdentifier const ToolbarItemIdentifierCreate = @"Toolbar Create";
-static ToolbarItemIdentifier const ToolbarItemIdentifierOpenFile = @"Toolbar Open";
-static ToolbarItemIdentifier const ToolbarItemIdentifierOpenWeb = @"Toolbar Open Web";
-static ToolbarItemIdentifier const ToolbarItemIdentifierRemove = @"Toolbar Remove";
-static ToolbarItemIdentifier const ToolbarItemIdentifierInfo = @"Toolbar Info";
-static ToolbarItemIdentifier const ToolbarItemIdentifierPauseAll = @"Toolbar Pause All";
-static ToolbarItemIdentifier const ToolbarItemIdentifierResumeAll = @"Toolbar Resume All";
-static ToolbarItemIdentifier const ToolbarItemIdentifierPauseResumeAll = @"Toolbar Pause / Resume All";
-static ToolbarItemIdentifier const ToolbarItemIdentifierPauseSelected = @"Toolbar Pause Selected";
-static ToolbarItemIdentifier const ToolbarItemIdentifierResumeSelected = @"Toolbar Resume Selected";
-static ToolbarItemIdentifier const ToolbarItemIdentifierPauseResumeSelected = @"Toolbar Pause / Resume Selected";
-static ToolbarItemIdentifier const ToolbarItemIdentifierFilter = @"Toolbar Toggle Filter";
-static ToolbarItemIdentifier const ToolbarItemIdentifierQuickLook = @"Toolbar QuickLook";
-static ToolbarItemIdentifier const ToolbarItemIdentifierShare = @"Toolbar Share";
-
-typedef NS_ENUM(NSUInteger, ToolbarGroupTag) { //
-    ToolbarGroupTagPause = 0,
-    ToolbarGroupTagResume = 1
-};
 
 typedef NSString* SortType NS_TYPED_EXTENSIBLE_ENUM;
 
@@ -371,7 +346,7 @@ static void removeKeRangerRansomware()
     NSLog(@"OSX.KeRanger.A ransomware removal completed, proceeding to normal operation");
 }
 
-@interface Controller ()<UNUserNotificationCenterDelegate, NSURLSessionDataDelegate, NSURLSessionDownloadDelegate, PowerManagerDelegate>
+@interface Controller ()<UNUserNotificationCenterDelegate, NSURLSessionDataDelegate, NSURLSessionDownloadDelegate, PowerManagerDelegate, MainToolbarControllerDelegate>
 
 @property(nonatomic) IBOutlet NSWindow* fWindow;
 @property(nonatomic) NSLayoutConstraint* fMinHeightConstraint;
@@ -416,6 +391,8 @@ static void removeKeRangerRansomware()
 @property(nonatomic) StatusBarController* fStatusBar;
 
 @property(nonatomic) FilterBarController* fFilterBar;
+
+@property(nonatomic) MainToolbarController* fToolbarController;
 
 @property(nonatomic) QLPreviewPanel* fPreviewPanel;
 @property(nonatomic) BOOL fQuitting;
@@ -624,12 +601,8 @@ static void removeKeRangerRansomware()
 {
     [super awakeFromNib];
 
-    Toolbar* toolbar = [[Toolbar alloc] initWithIdentifier:@"TRMainToolbar"];
-    toolbar.delegate = self;
-    toolbar.allowsUserCustomization = YES;
-    toolbar.autosavesConfiguration = YES;
-    toolbar.displayMode = NSToolbarDisplayModeIconOnly;
-    self.fWindow.toolbar = toolbar;
+    self.fToolbarController = [[MainToolbarController alloc] initWithDelegate:self];
+    self.fWindow.toolbar = [self.fToolbarController createToolbar];
 
     self.fWindow.toolbarStyle = NSWindowToolbarStyleUnified;
     self.fWindow.titleVisibility = NSWindowTitleHidden;
@@ -4216,393 +4189,94 @@ static void removeKeRangerRansomware()
     return self.fWindow;
 }
 
-- (ButtonToolbarItem*)standardToolbarButtonWithIdentifier:(NSString*)ident
+- (NSArray<Torrent*>*)mainToolbarAllTorrents
 {
-    return [self toolbarButtonWithIdentifier:ident forToolbarButtonClass:[ButtonToolbarItem class]];
+    return self.fTorrents;
 }
 
-- (__kindof ButtonToolbarItem*)toolbarButtonWithIdentifier:(NSString*)ident forToolbarButtonClass:(Class)klass
+- (NSArray<Torrent*>*)mainToolbarSelectedTorrents
 {
-    ButtonToolbarItem* item = [[klass alloc] initWithItemIdentifier:ident];
-
-    NSButton* button = [[NSButton alloc] init];
-    button.bezelStyle = NSBezelStyleTexturedRounded;
-    button.stringValue = @"";
-
-    item.view = button;
-
-    return item;
+    return self.fTableView.selectedTorrents;
 }
 
-- (NSToolbarItem*)toolbar:(NSToolbar*)toolbar itemForItemIdentifier:(NSString*)ident willBeInsertedIntoToolbar:(BOOL)flag
+- (NSInteger)mainToolbarSelectedTorrentCount
 {
-    if ([ident isEqualToString:ToolbarItemIdentifierCreate])
-    {
-        ButtonToolbarItem* item = [self standardToolbarButtonWithIdentifier:ident];
-
-        item.label = NSLocalizedString(@"Create", "Create toolbar item -> label");
-        item.paletteLabel = NSLocalizedString(@"Create Torrent File", "Create toolbar item -> palette label");
-        item.toolTip = NSLocalizedString(@"Create torrent file", "Create toolbar item -> tooltip");
-        item.image = [NSImage imageWithSystemSymbolName:@"doc.badge.plus" accessibilityDescription:nil];
-        item.target = self;
-        item.action = @selector(createFile:);
-        item.autovalidates = NO;
-
-        return item;
-    }
-    else if ([ident isEqualToString:ToolbarItemIdentifierOpenFile])
-    {
-        ButtonToolbarItem* item = [self standardToolbarButtonWithIdentifier:ident];
-
-        item.label = NSLocalizedString(@"Open", "Open toolbar item -> label");
-        item.paletteLabel = NSLocalizedString(@"Open Torrent Files", "Open toolbar item -> palette label");
-        item.toolTip = NSLocalizedString(@"Open torrent files", "Open toolbar item -> tooltip");
-        item.image = [NSImage imageWithSystemSymbolName:@"folder" accessibilityDescription:nil];
-        item.target = self;
-        item.action = @selector(openShowSheet:);
-        item.autovalidates = NO;
-
-        return item;
-    }
-    else if ([ident isEqualToString:ToolbarItemIdentifierOpenWeb])
-    {
-        ButtonToolbarItem* item = [self standardToolbarButtonWithIdentifier:ident];
-
-        item.label = NSLocalizedString(@"Open Address", "Open address toolbar item -> label");
-        item.paletteLabel = NSLocalizedString(@"Open Torrent Address", "Open address toolbar item -> palette label");
-        item.toolTip = NSLocalizedString(@"Open torrent web address", "Open address toolbar item -> tooltip");
-        item.image = [NSImage imageWithSystemSymbolName:@"globe" accessibilityDescription:nil];
-        item.target = self;
-        item.action = @selector(openURLShowSheet:);
-        item.autovalidates = NO;
-
-        return item;
-    }
-    else if ([ident isEqualToString:ToolbarItemIdentifierRemove])
-    {
-        ButtonToolbarItem* item = [self standardToolbarButtonWithIdentifier:ident];
-
-        item.label = NSLocalizedString(@"Remove", "Remove toolbar item -> label");
-        item.paletteLabel = NSLocalizedString(@"Remove Selected", "Remove toolbar item -> palette label");
-        item.toolTip = NSLocalizedString(@"Remove selected transfers", "Remove toolbar item -> tooltip");
-        item.image = [NSImage imageWithSystemSymbolName:@"nosign" accessibilityDescription:nil];
-        item.target = self;
-        item.action = @selector(removeNoDelete:);
-        item.visibilityPriority = NSToolbarItemVisibilityPriorityHigh;
-
-        return item;
-    }
-    else if ([ident isEqualToString:ToolbarItemIdentifierInfo])
-    {
-        ButtonToolbarItem* item = [self standardToolbarButtonWithIdentifier:ident];
-        ((NSButtonCell*)((NSButton*)item.view).cell).showsStateBy = NSContentsCellMask; //blue when enabled
-
-        item.label = NSLocalizedString(@"Inspector", "Inspector toolbar item -> label");
-        item.paletteLabel = NSLocalizedString(@"Toggle Inspector", "Inspector toolbar item -> palette label");
-        item.toolTip = NSLocalizedString(@"Toggle the torrent inspector", "Inspector toolbar item -> tooltip");
-        item.image = [NSImage imageWithSystemSymbolName:@"info.circle" accessibilityDescription:nil];
-        item.target = self;
-        item.action = @selector(showInfo:);
-
-        return item;
-    }
-    else if ([ident isEqualToString:ToolbarItemIdentifierPauseResumeAll])
-    {
-        GroupToolbarItem* groupItem = [[GroupToolbarItem alloc] initWithItemIdentifier:ident];
-
-        NSToolbarItem* itemPause = [self standardToolbarButtonWithIdentifier:ToolbarItemIdentifierPauseAll];
-        NSToolbarItem* itemResume = [self standardToolbarButtonWithIdentifier:ToolbarItemIdentifierResumeAll];
-
-        NSSegmentedControl* segmentedControl = [[NSSegmentedControl alloc] initWithFrame:NSZeroRect];
-        segmentedControl.segmentStyle = NSSegmentStyleTexturedRounded;
-        segmentedControl.trackingMode = NSSegmentSwitchTrackingMomentary;
-        segmentedControl.segmentCount = 2;
-
-        [segmentedControl setTag:ToolbarGroupTagPause forSegment:ToolbarGroupTagPause];
-        [segmentedControl setImage:[NSImage imageWithSystemSymbolName:@"pause.circle.fill" accessibilityDescription:nil]
-                        forSegment:ToolbarGroupTagPause];
-        [segmentedControl setToolTip:NSLocalizedString(@"Pause all transfers", "All toolbar item -> tooltip")
-                          forSegment:ToolbarGroupTagPause];
-
-        [segmentedControl setTag:ToolbarGroupTagResume forSegment:ToolbarGroupTagResume];
-        [segmentedControl setImage:[NSImage imageWithSystemSymbolName:@"arrow.clockwise.circle.fill" accessibilityDescription:nil]
-                        forSegment:ToolbarGroupTagResume];
-        [segmentedControl setToolTip:NSLocalizedString(@"Resume all transfers", "All toolbar item -> tooltip")
-                          forSegment:ToolbarGroupTagResume];
-        if ([toolbar isKindOfClass:Toolbar.class] && ((Toolbar*)toolbar).isRunningCustomizationPalette)
-        {
-            // On macOS 13.2, the palette autolayout will hang unless the segmentedControl width is longer than the groupItem paletteLabel (matters especially in Russian and French).
-            [segmentedControl setWidth:64 forSegment:ToolbarGroupTagPause];
-            [segmentedControl setWidth:64 forSegment:ToolbarGroupTagResume];
-        }
-
-        groupItem.label = NSLocalizedString(@"Apply All", "All toolbar item -> label");
-        groupItem.paletteLabel = NSLocalizedString(@"Pause / Resume All", "All toolbar item -> palette label");
-        groupItem.visibilityPriority = NSToolbarItemVisibilityPriorityHigh;
-        groupItem.subitems = @[ itemPause, itemResume ];
-        groupItem.view = segmentedControl;
-        groupItem.target = self;
-        groupItem.action = @selector(allToolbarClicked:);
-
-        [groupItem createMenu:@[
-            NSLocalizedString(@"Pause All", "All toolbar item -> label"),
-            NSLocalizedString(@"Resume All", "All toolbar item -> label")
-        ]];
-
-        return groupItem;
-    }
-    else if ([ident isEqualToString:ToolbarItemIdentifierPauseResumeSelected])
-    {
-        GroupToolbarItem* groupItem = [[GroupToolbarItem alloc] initWithItemIdentifier:ident];
-
-        NSToolbarItem* itemPause = [self standardToolbarButtonWithIdentifier:ToolbarItemIdentifierPauseSelected];
-        NSToolbarItem* itemResume = [self standardToolbarButtonWithIdentifier:ToolbarItemIdentifierResumeSelected];
-
-        NSSegmentedControl* segmentedControl = [[NSSegmentedControl alloc] initWithFrame:NSZeroRect];
-        segmentedControl.segmentStyle = NSSegmentStyleTexturedRounded;
-        segmentedControl.trackingMode = NSSegmentSwitchTrackingMomentary;
-        segmentedControl.segmentCount = 2;
-
-        [segmentedControl setTag:ToolbarGroupTagPause forSegment:ToolbarGroupTagPause];
-        [segmentedControl setImage:[NSImage imageWithSystemSymbolName:@"pause" accessibilityDescription:nil]
-                        forSegment:ToolbarGroupTagPause];
-        [segmentedControl setToolTip:NSLocalizedString(@"Pause selected transfers", "Selected toolbar item -> tooltip")
-                          forSegment:ToolbarGroupTagPause];
-
-        [segmentedControl setTag:ToolbarGroupTagResume forSegment:ToolbarGroupTagResume];
-        [segmentedControl setImage:[NSImage imageWithSystemSymbolName:@"arrow.clockwise" accessibilityDescription:nil]
-                        forSegment:ToolbarGroupTagResume];
-        [segmentedControl setToolTip:NSLocalizedString(@"Resume selected transfers", "Selected toolbar item -> tooltip")
-                          forSegment:ToolbarGroupTagResume];
-        if ([toolbar isKindOfClass:Toolbar.class] && ((Toolbar*)toolbar).isRunningCustomizationPalette)
-        {
-            // On macOS 13.2, the palette autolayout will hang unless the segmentedControl width is longer than the groupItem paletteLabel (matters especially in Russian and French).
-            [segmentedControl setWidth:64 forSegment:ToolbarGroupTagPause];
-            [segmentedControl setWidth:64 forSegment:ToolbarGroupTagResume];
-        }
-
-        groupItem.label = NSLocalizedString(@"Apply Selected", "Selected toolbar item -> label");
-        groupItem.paletteLabel = NSLocalizedString(@"Pause / Resume Selected", "Selected toolbar item -> palette label");
-        groupItem.visibilityPriority = NSToolbarItemVisibilityPriorityHigh;
-        groupItem.subitems = @[ itemPause, itemResume ];
-        groupItem.view = segmentedControl;
-        groupItem.target = self;
-        groupItem.action = @selector(selectedToolbarClicked:);
-
-        [groupItem createMenu:@[
-            NSLocalizedString(@"Pause Selected", "Selected toolbar item -> label"),
-            NSLocalizedString(@"Resume Selected", "Selected toolbar item -> label")
-        ]];
-
-        return groupItem;
-    }
-    else if ([ident isEqualToString:ToolbarItemIdentifierFilter])
-    {
-        ButtonToolbarItem* item = [self standardToolbarButtonWithIdentifier:ident];
-        ((NSButtonCell*)((NSButton*)item.view).cell).showsStateBy = NSContentsCellMask; //blue when enabled
-
-        item.label = NSLocalizedString(@"Filter", "Filter toolbar item -> label");
-        item.paletteLabel = NSLocalizedString(@"Toggle Filter", "Filter toolbar item -> palette label");
-        item.toolTip = NSLocalizedString(@"Toggle the filter bar", "Filter toolbar item -> tooltip");
-        item.image = [NSImage imageWithSystemSymbolName:@"magnifyingglass" accessibilityDescription:nil];
-        item.target = self;
-        item.action = @selector(toggleFilterBar:);
-
-        return item;
-    }
-    else if ([ident isEqualToString:ToolbarItemIdentifierQuickLook])
-    {
-        ButtonToolbarItem* item = [self standardToolbarButtonWithIdentifier:ident];
-        ((NSButtonCell*)((NSButton*)item.view).cell).showsStateBy = NSContentsCellMask; //blue when enabled
-
-        item.label = NSLocalizedString(@"Quick Look", "QuickLook toolbar item -> label");
-        item.paletteLabel = NSLocalizedString(@"Quick Look", "QuickLook toolbar item -> palette label");
-        item.toolTip = NSLocalizedString(@"Quick Look", "QuickLook toolbar item -> tooltip");
-        item.image = [NSImage imageNamed:NSImageNameQuickLookTemplate];
-        item.target = self;
-        item.action = @selector(toggleQuickLook:);
-        item.visibilityPriority = NSToolbarItemVisibilityPriorityLow;
-
-        return item;
-    }
-    else if ([ident isEqualToString:ToolbarItemIdentifierShare])
-    {
-        ShareToolbarItem* item = [self toolbarButtonWithIdentifier:ident forToolbarButtonClass:[ShareToolbarItem class]];
-
-        item.label = NSLocalizedString(@"Share", "Share toolbar item -> label");
-        item.paletteLabel = NSLocalizedString(@"Share", "Share toolbar item -> palette label");
-        item.toolTip = NSLocalizedString(@"Share torrent file", "Share toolbar item -> tooltip");
-        item.image = [NSImage imageNamed:NSImageNameShareTemplate];
-        item.visibilityPriority = NSToolbarItemVisibilityPriorityLow;
-
-        NSButton* itemButton = (NSButton*)item.view;
-        itemButton.target = self;
-        itemButton.action = @selector(showToolbarShare:);
-        [itemButton sendActionOn:NSEventMaskLeftMouseDown];
-
-        return item;
-    }
-    else
-    {
-        return nil;
-    }
+    return self.fTableView.numberOfSelectedRows;
 }
 
-- (void)allToolbarClicked:(id)sender
+- (BOOL)mainToolbarInfoVisible
 {
-    NSInteger tagValue = [sender isKindOfClass:[NSSegmentedControl class]] ? [(NSSegmentedControl*)sender selectedTag] :
-                                                                             ((NSControl*)sender).tag;
-    switch (tagValue)
-    {
-    case ToolbarGroupTagPause:
-        [self stopAllTorrents:sender];
-        break;
-    case ToolbarGroupTagResume:
-        [self resumeAllTorrents:sender];
-        break;
-    }
+    return self.fInfoController.window.visible;
 }
 
-- (void)selectedToolbarClicked:(id)sender
+- (BOOL)mainToolbarFilterBarVisible
 {
-    NSInteger tagValue = [sender isKindOfClass:[NSSegmentedControl class]] ? [(NSSegmentedControl*)sender selectedTag] :
-                                                                             ((NSControl*)sender).tag;
-    switch (tagValue)
-    {
-    case ToolbarGroupTagPause:
-        [self stopSelectedTorrents:sender];
-        break;
-    case ToolbarGroupTagResume:
-        [self resumeSelectedTorrents:sender];
-        break;
-    }
+    return !(self.fFilterBar == nil || self.fFilterBar.isHidden);
 }
 
-- (NSArray*)toolbarAllowedItemIdentifiers:(NSToolbar*)toolbar
+- (BOOL)mainToolbarQuickLookVisible
 {
-    return @[
-        ToolbarItemIdentifierCreate,
-        ToolbarItemIdentifierOpenFile,
-        ToolbarItemIdentifierOpenWeb,
-        ToolbarItemIdentifierRemove,
-        ToolbarItemIdentifierPauseResumeSelected,
-        ToolbarItemIdentifierPauseResumeAll,
-        ToolbarItemIdentifierShare,
-        ToolbarItemIdentifierQuickLook,
-        ToolbarItemIdentifierFilter,
-        ToolbarItemIdentifierInfo,
-        NSToolbarSpaceItemIdentifier,
-        NSToolbarFlexibleSpaceItemIdentifier
-    ];
+    return self.fPreviewPanel != nil;
 }
 
-- (NSArray*)toolbarDefaultItemIdentifiers:(NSToolbar*)toolbar
+- (void)mainToolbarCreateFile:(id)sender
 {
-    return @[
-        ToolbarItemIdentifierCreate,
-        ToolbarItemIdentifierOpenFile,
-        ToolbarItemIdentifierRemove,
-        NSToolbarSpaceItemIdentifier,
-        ToolbarItemIdentifierPauseResumeAll,
-        NSToolbarFlexibleSpaceItemIdentifier,
-        ToolbarItemIdentifierShare,
-        ToolbarItemIdentifierQuickLook,
-        ToolbarItemIdentifierFilter,
-        ToolbarItemIdentifierInfo,
-    ];
+    [self createFile:sender];
 }
 
-- (BOOL)validateToolbarItem:(NSToolbarItem*)toolbarItem
+- (void)mainToolbarOpenFile:(id)sender
 {
-    NSString* ident = toolbarItem.itemIdentifier;
+    [self openShowSheet:sender];
+}
 
-    //enable remove item
-    if ([ident isEqualToString:ToolbarItemIdentifierRemove])
-    {
-        return self.fTableView.numberOfSelectedRows > 0;
-    }
+- (void)mainToolbarOpenURL:(id)sender
+{
+    [self openURLShowSheet:sender];
+}
 
-    //enable pause all item
-    if ([ident isEqualToString:ToolbarItemIdentifierPauseAll])
-    {
-        for (Torrent* torrent in self.fTorrents)
-        {
-            if (torrent.active || torrent.waitingToStart)
-            {
-                return YES;
-            }
-        }
-        return NO;
-    }
+- (void)mainToolbarRemoveSelected:(id)sender
+{
+    [self removeNoDelete:sender];
+}
 
-    //enable resume all item
-    if ([ident isEqualToString:ToolbarItemIdentifierResumeAll])
-    {
-        for (Torrent* torrent in self.fTorrents)
-        {
-            if (!torrent.active && !torrent.waitingToStart && !torrent.finishedSeeding)
-            {
-                return YES;
-            }
-        }
-        return NO;
-    }
+- (void)mainToolbarToggleInfo:(id)sender
+{
+    [self showInfo:sender];
+}
 
-    //enable pause item
-    if ([ident isEqualToString:ToolbarItemIdentifierPauseSelected])
-    {
-        for (Torrent* torrent in self.fTableView.selectedTorrents)
-        {
-            if (torrent.active || torrent.waitingToStart)
-            {
-                return YES;
-            }
-        }
-        return NO;
-    }
+- (void)mainToolbarToggleFilterBar:(id)sender
+{
+    [self toggleFilterBar:sender];
+}
 
-    //enable resume item
-    if ([ident isEqualToString:ToolbarItemIdentifierResumeSelected])
-    {
-        for (Torrent* torrent in self.fTableView.selectedTorrents)
-        {
-            if (!torrent.active && !torrent.waitingToStart)
-            {
-                return YES;
-            }
-        }
-        return NO;
-    }
+- (void)mainToolbarToggleQuickLook:(id)sender
+{
+    [self toggleQuickLook:sender];
+}
 
-    //set info item
-    if ([ident isEqualToString:ToolbarItemIdentifierInfo])
-    {
-        ((NSButton*)toolbarItem.view).state = self.fInfoController.window.visible;
-        return YES;
-    }
+- (void)mainToolbarShowShare:(id)sender
+{
+    [self showToolbarShare:sender];
+}
 
-    //set filter item
-    if ([ident isEqualToString:ToolbarItemIdentifierFilter])
-    {
-        BOOL shown = !(self.fFilterBar == nil || self.fFilterBar.isHidden);
-        ((NSButton*)toolbarItem.view).state = shown ? NSControlStateValueOn : NSControlStateValueOff;
-        return YES;
-    }
+- (void)mainToolbarStopAllTorrents:(id)sender
+{
+    [self stopAllTorrents:sender];
+}
 
-    //set quick look item
-    if ([ident isEqualToString:ToolbarItemIdentifierQuickLook])
-    {
-        ((NSButton*)toolbarItem.view).state = self.fPreviewPanel != nil;
-        return self.fTableView.numberOfSelectedRows > 0;
-    }
+- (void)mainToolbarResumeAllTorrents:(id)sender
+{
+    [self resumeAllTorrents:sender];
+}
 
-    //enable share item
-    if ([ident isEqualToString:ToolbarItemIdentifierShare])
-    {
-        return self.fTableView.numberOfSelectedRows > 0;
-    }
+- (void)mainToolbarStopSelectedTorrents:(id)sender
+{
+    [self stopSelectedTorrents:sender];
+}
 
-    return YES;
+- (void)mainToolbarResumeSelectedTorrents:(id)sender
+{
+    [self resumeSelectedTorrents:sender];
 }
 
 - (BOOL)validateMenuItem:(NSMenuItem*)menuItem

--- a/macosx/MainToolbarController.h
+++ b/macosx/MainToolbarController.h
@@ -1,0 +1,39 @@
+// This file Copyright © Transmission authors and contributors.
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
+
+#import <AppKit/AppKit.h>
+
+@class Torrent;
+
+@protocol MainToolbarControllerDelegate<NSObject>
+
+- (NSArray<Torrent*>*)mainToolbarAllTorrents;
+- (NSArray<Torrent*>*)mainToolbarSelectedTorrents;
+- (NSInteger)mainToolbarSelectedTorrentCount;
+
+- (BOOL)mainToolbarInfoVisible;
+- (BOOL)mainToolbarFilterBarVisible;
+- (BOOL)mainToolbarQuickLookVisible;
+
+- (void)mainToolbarCreateFile:(id)sender;
+- (void)mainToolbarOpenFile:(id)sender;
+- (void)mainToolbarOpenURL:(id)sender;
+- (void)mainToolbarRemoveSelected:(id)sender;
+- (void)mainToolbarToggleInfo:(id)sender;
+- (void)mainToolbarToggleFilterBar:(id)sender;
+- (void)mainToolbarToggleQuickLook:(id)sender;
+- (void)mainToolbarShowShare:(id)sender;
+- (void)mainToolbarStopAllTorrents:(id)sender;
+- (void)mainToolbarResumeAllTorrents:(id)sender;
+- (void)mainToolbarStopSelectedTorrents:(id)sender;
+- (void)mainToolbarResumeSelectedTorrents:(id)sender;
+
+@end
+
+@interface MainToolbarController : NSObject<NSToolbarDelegate, NSToolbarItemValidation>
+
+- (instancetype)initWithDelegate:(id<MainToolbarControllerDelegate>)delegate;
+- (NSToolbar*)createToolbar;
+
+@end

--- a/macosx/MainToolbarController.mm
+++ b/macosx/MainToolbarController.mm
@@ -1,0 +1,486 @@
+// This file Copyright © Transmission authors and contributors.
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
+
+#import "MainToolbarController.h"
+
+#import "ButtonToolbarItem.h"
+#import "GroupToolbarItem.h"
+#import "ShareToolbarItem.h"
+#import "Toolbar.h"
+#import "Torrent.h"
+
+typedef NSString* ToolbarItemIdentifier NS_TYPED_EXTENSIBLE_ENUM;
+
+static ToolbarItemIdentifier const ToolbarItemIdentifierCreate = @"Toolbar Create";
+static ToolbarItemIdentifier const ToolbarItemIdentifierOpenFile = @"Toolbar Open";
+static ToolbarItemIdentifier const ToolbarItemIdentifierOpenWeb = @"Toolbar Open Web";
+static ToolbarItemIdentifier const ToolbarItemIdentifierRemove = @"Toolbar Remove";
+static ToolbarItemIdentifier const ToolbarItemIdentifierInfo = @"Toolbar Info";
+static ToolbarItemIdentifier const ToolbarItemIdentifierPauseAll = @"Toolbar Pause All";
+static ToolbarItemIdentifier const ToolbarItemIdentifierResumeAll = @"Toolbar Resume All";
+static ToolbarItemIdentifier const ToolbarItemIdentifierPauseResumeAll = @"Toolbar Pause / Resume All";
+static ToolbarItemIdentifier const ToolbarItemIdentifierPauseSelected = @"Toolbar Pause Selected";
+static ToolbarItemIdentifier const ToolbarItemIdentifierResumeSelected = @"Toolbar Resume Selected";
+static ToolbarItemIdentifier const ToolbarItemIdentifierPauseResumeSelected = @"Toolbar Pause / Resume Selected";
+static ToolbarItemIdentifier const ToolbarItemIdentifierFilter = @"Toolbar Toggle Filter";
+static ToolbarItemIdentifier const ToolbarItemIdentifierQuickLook = @"Toolbar QuickLook";
+static ToolbarItemIdentifier const ToolbarItemIdentifierShare = @"Toolbar Share";
+
+typedef NS_ENUM(NSUInteger, ToolbarGroupTag) { //
+    ToolbarGroupTagPause = 0,
+    ToolbarGroupTagResume = 1
+};
+
+@interface MainToolbarController ()
+
+@property(nonatomic, weak) id<MainToolbarControllerDelegate> delegate;
+
+@end
+
+@implementation MainToolbarController
+
+- (instancetype)initWithDelegate:(id<MainToolbarControllerDelegate>)delegate
+{
+    if ((self = [super init]))
+    {
+        _delegate = delegate;
+    }
+
+    return self;
+}
+
+- (NSToolbar*)createToolbar
+{
+    Toolbar* toolbar = [[Toolbar alloc] initWithIdentifier:@"TRMainToolbar"];
+    toolbar.delegate = self;
+    toolbar.allowsUserCustomization = YES;
+    toolbar.autosavesConfiguration = YES;
+    toolbar.displayMode = NSToolbarDisplayModeIconOnly;
+
+    return toolbar;
+}
+
+- (ButtonToolbarItem*)standardToolbarButtonWithIdentifier:(NSString*)ident
+{
+    return [self toolbarButtonWithIdentifier:ident forToolbarButtonClass:[ButtonToolbarItem class]];
+}
+
+- (__kindof ButtonToolbarItem*)toolbarButtonWithIdentifier:(NSString*)ident forToolbarButtonClass:(Class)klass
+{
+    ButtonToolbarItem* item = [[klass alloc] initWithItemIdentifier:ident];
+
+    NSButton* button = [[NSButton alloc] init];
+    button.bezelStyle = NSBezelStyleTexturedRounded;
+    button.stringValue = @"";
+
+    item.view = button;
+    item.target = self;
+
+    return item;
+}
+
+- (NSToolbarItem*)toolbar:(NSToolbar*)toolbar itemForItemIdentifier:(NSString*)ident willBeInsertedIntoToolbar:(BOOL)flag
+{
+    if ([ident isEqualToString:ToolbarItemIdentifierCreate])
+    {
+        ButtonToolbarItem* item = [self standardToolbarButtonWithIdentifier:ident];
+
+        item.label = NSLocalizedString(@"Create", "Create toolbar item -> label");
+        item.paletteLabel = NSLocalizedString(@"Create Torrent File", "Create toolbar item -> palette label");
+        item.toolTip = NSLocalizedString(@"Create torrent file", "Create toolbar item -> tooltip");
+        item.image = [NSImage imageWithSystemSymbolName:@"doc.badge.plus" accessibilityDescription:nil];
+        item.action = @selector(createFile:);
+        item.autovalidates = NO;
+
+        return item;
+    }
+    else if ([ident isEqualToString:ToolbarItemIdentifierOpenFile])
+    {
+        ButtonToolbarItem* item = [self standardToolbarButtonWithIdentifier:ident];
+
+        item.label = NSLocalizedString(@"Open", "Open toolbar item -> label");
+        item.paletteLabel = NSLocalizedString(@"Open Torrent Files", "Open toolbar item -> palette label");
+        item.toolTip = NSLocalizedString(@"Open torrent files", "Open toolbar item -> tooltip");
+        item.image = [NSImage imageWithSystemSymbolName:@"folder" accessibilityDescription:nil];
+        item.action = @selector(openShowSheet:);
+        item.autovalidates = NO;
+
+        return item;
+    }
+    else if ([ident isEqualToString:ToolbarItemIdentifierOpenWeb])
+    {
+        ButtonToolbarItem* item = [self standardToolbarButtonWithIdentifier:ident];
+
+        item.label = NSLocalizedString(@"Open Address", "Open address toolbar item -> label");
+        item.paletteLabel = NSLocalizedString(@"Open Torrent Address", "Open address toolbar item -> palette label");
+        item.toolTip = NSLocalizedString(@"Open torrent web address", "Open address toolbar item -> tooltip");
+        item.image = [NSImage imageWithSystemSymbolName:@"globe" accessibilityDescription:nil];
+        item.action = @selector(openURLShowSheet:);
+        item.autovalidates = NO;
+
+        return item;
+    }
+    else if ([ident isEqualToString:ToolbarItemIdentifierRemove])
+    {
+        ButtonToolbarItem* item = [self standardToolbarButtonWithIdentifier:ident];
+
+        item.label = NSLocalizedString(@"Remove", "Remove toolbar item -> label");
+        item.paletteLabel = NSLocalizedString(@"Remove Selected", "Remove toolbar item -> palette label");
+        item.toolTip = NSLocalizedString(@"Remove selected transfers", "Remove toolbar item -> tooltip");
+        item.image = [NSImage imageWithSystemSymbolName:@"nosign" accessibilityDescription:nil];
+        item.action = @selector(removeNoDelete:);
+        item.visibilityPriority = NSToolbarItemVisibilityPriorityHigh;
+
+        return item;
+    }
+    else if ([ident isEqualToString:ToolbarItemIdentifierInfo])
+    {
+        ButtonToolbarItem* item = [self standardToolbarButtonWithIdentifier:ident];
+        ((NSButtonCell*)((NSButton*)item.view).cell).showsStateBy = NSContentsCellMask; // blue when enabled
+
+        item.label = NSLocalizedString(@"Inspector", "Inspector toolbar item -> label");
+        item.paletteLabel = NSLocalizedString(@"Toggle Inspector", "Inspector toolbar item -> palette label");
+        item.toolTip = NSLocalizedString(@"Toggle the torrent inspector", "Inspector toolbar item -> tooltip");
+        item.image = [NSImage imageWithSystemSymbolName:@"info.circle" accessibilityDescription:nil];
+        item.action = @selector(showInfo:);
+
+        return item;
+    }
+    else if ([ident isEqualToString:ToolbarItemIdentifierPauseResumeAll])
+    {
+        GroupToolbarItem* groupItem = [[GroupToolbarItem alloc] initWithItemIdentifier:ident];
+
+        NSToolbarItem* itemPause = [self standardToolbarButtonWithIdentifier:ToolbarItemIdentifierPauseAll];
+        NSToolbarItem* itemResume = [self standardToolbarButtonWithIdentifier:ToolbarItemIdentifierResumeAll];
+
+        NSSegmentedControl* segmentedControl = [[NSSegmentedControl alloc] initWithFrame:NSZeroRect];
+        segmentedControl.segmentStyle = NSSegmentStyleTexturedRounded;
+        segmentedControl.trackingMode = NSSegmentSwitchTrackingMomentary;
+        segmentedControl.segmentCount = 2;
+
+        [segmentedControl setTag:ToolbarGroupTagPause forSegment:ToolbarGroupTagPause];
+        [segmentedControl setImage:[NSImage imageWithSystemSymbolName:@"pause.circle.fill" accessibilityDescription:nil]
+                        forSegment:ToolbarGroupTagPause];
+        [segmentedControl setToolTip:NSLocalizedString(@"Pause all transfers", "All toolbar item -> tooltip")
+                          forSegment:ToolbarGroupTagPause];
+
+        [segmentedControl setTag:ToolbarGroupTagResume forSegment:ToolbarGroupTagResume];
+        [segmentedControl setImage:[NSImage imageWithSystemSymbolName:@"arrow.clockwise.circle.fill" accessibilityDescription:nil]
+                        forSegment:ToolbarGroupTagResume];
+        [segmentedControl setToolTip:NSLocalizedString(@"Resume all transfers", "All toolbar item -> tooltip")
+                          forSegment:ToolbarGroupTagResume];
+        if ([toolbar isKindOfClass:Toolbar.class] && ((Toolbar*)toolbar).isRunningCustomizationPalette)
+        {
+            // On macOS 13.2, the palette autolayout will hang unless the segmentedControl width is longer than the groupItem paletteLabel (matters especially in Russian and French).
+            [segmentedControl setWidth:64 forSegment:ToolbarGroupTagPause];
+            [segmentedControl setWidth:64 forSegment:ToolbarGroupTagResume];
+        }
+
+        groupItem.label = NSLocalizedString(@"Apply All", "All toolbar item -> label");
+        groupItem.paletteLabel = NSLocalizedString(@"Pause / Resume All", "All toolbar item -> palette label");
+        groupItem.visibilityPriority = NSToolbarItemVisibilityPriorityHigh;
+        groupItem.subitems = @[ itemPause, itemResume ];
+        groupItem.view = segmentedControl;
+        groupItem.target = self;
+        groupItem.action = @selector(allToolbarClicked:);
+
+        [groupItem createMenu:@[
+            NSLocalizedString(@"Pause All", "All toolbar item -> label"),
+            NSLocalizedString(@"Resume All", "All toolbar item -> label")
+        ]];
+
+        return groupItem;
+    }
+    else if ([ident isEqualToString:ToolbarItemIdentifierPauseResumeSelected])
+    {
+        GroupToolbarItem* groupItem = [[GroupToolbarItem alloc] initWithItemIdentifier:ident];
+
+        NSToolbarItem* itemPause = [self standardToolbarButtonWithIdentifier:ToolbarItemIdentifierPauseSelected];
+        NSToolbarItem* itemResume = [self standardToolbarButtonWithIdentifier:ToolbarItemIdentifierResumeSelected];
+
+        NSSegmentedControl* segmentedControl = [[NSSegmentedControl alloc] initWithFrame:NSZeroRect];
+        segmentedControl.segmentStyle = NSSegmentStyleTexturedRounded;
+        segmentedControl.trackingMode = NSSegmentSwitchTrackingMomentary;
+        segmentedControl.segmentCount = 2;
+
+        [segmentedControl setTag:ToolbarGroupTagPause forSegment:ToolbarGroupTagPause];
+        [segmentedControl setImage:[NSImage imageWithSystemSymbolName:@"pause" accessibilityDescription:nil]
+                        forSegment:ToolbarGroupTagPause];
+        [segmentedControl setToolTip:NSLocalizedString(@"Pause selected transfers", "Selected toolbar item -> tooltip")
+                          forSegment:ToolbarGroupTagPause];
+
+        [segmentedControl setTag:ToolbarGroupTagResume forSegment:ToolbarGroupTagResume];
+        [segmentedControl setImage:[NSImage imageWithSystemSymbolName:@"arrow.clockwise" accessibilityDescription:nil]
+                        forSegment:ToolbarGroupTagResume];
+        [segmentedControl setToolTip:NSLocalizedString(@"Resume selected transfers", "Selected toolbar item -> tooltip")
+                          forSegment:ToolbarGroupTagResume];
+        if ([toolbar isKindOfClass:Toolbar.class] && ((Toolbar*)toolbar).isRunningCustomizationPalette)
+        {
+            // On macOS 13.2, the palette autolayout will hang unless the segmentedControl width is longer than the groupItem paletteLabel (matters especially in Russian and French).
+            [segmentedControl setWidth:64 forSegment:ToolbarGroupTagPause];
+            [segmentedControl setWidth:64 forSegment:ToolbarGroupTagResume];
+        }
+
+        groupItem.label = NSLocalizedString(@"Apply Selected", "Selected toolbar item -> label");
+        groupItem.paletteLabel = NSLocalizedString(@"Pause / Resume Selected", "Selected toolbar item -> palette label");
+        groupItem.visibilityPriority = NSToolbarItemVisibilityPriorityHigh;
+        groupItem.subitems = @[ itemPause, itemResume ];
+        groupItem.view = segmentedControl;
+        groupItem.target = self;
+        groupItem.action = @selector(selectedToolbarClicked:);
+
+        [groupItem createMenu:@[
+            NSLocalizedString(@"Pause Selected", "Selected toolbar item -> label"),
+            NSLocalizedString(@"Resume Selected", "Selected toolbar item -> label")
+        ]];
+
+        return groupItem;
+    }
+    else if ([ident isEqualToString:ToolbarItemIdentifierFilter])
+    {
+        ButtonToolbarItem* item = [self standardToolbarButtonWithIdentifier:ident];
+        ((NSButtonCell*)((NSButton*)item.view).cell).showsStateBy = NSContentsCellMask; // blue when enabled
+
+        item.label = NSLocalizedString(@"Filter", "Filter toolbar item -> label");
+        item.paletteLabel = NSLocalizedString(@"Toggle Filter", "Filter toolbar item -> palette label");
+        item.toolTip = NSLocalizedString(@"Toggle the filter bar", "Filter toolbar item -> tooltip");
+        item.image = [NSImage imageWithSystemSymbolName:@"magnifyingglass" accessibilityDescription:nil];
+        item.action = @selector(toggleFilterBar:);
+
+        return item;
+    }
+    else if ([ident isEqualToString:ToolbarItemIdentifierQuickLook])
+    {
+        ButtonToolbarItem* item = [self standardToolbarButtonWithIdentifier:ident];
+        ((NSButtonCell*)((NSButton*)item.view).cell).showsStateBy = NSContentsCellMask; // blue when enabled
+
+        item.label = NSLocalizedString(@"Quick Look", "QuickLook toolbar item -> label");
+        item.paletteLabel = NSLocalizedString(@"Quick Look", "QuickLook toolbar item -> palette label");
+        item.toolTip = NSLocalizedString(@"Quick Look", "QuickLook toolbar item -> tooltip");
+        item.image = [NSImage imageNamed:NSImageNameQuickLookTemplate];
+        item.action = @selector(toggleQuickLook:);
+        item.visibilityPriority = NSToolbarItemVisibilityPriorityLow;
+
+        return item;
+    }
+    else if ([ident isEqualToString:ToolbarItemIdentifierShare])
+    {
+        ShareToolbarItem* item = [self toolbarButtonWithIdentifier:ident forToolbarButtonClass:[ShareToolbarItem class]];
+
+        item.label = NSLocalizedString(@"Share", "Share toolbar item -> label");
+        item.paletteLabel = NSLocalizedString(@"Share", "Share toolbar item -> palette label");
+        item.toolTip = NSLocalizedString(@"Share torrent file", "Share toolbar item -> tooltip");
+        item.image = [NSImage imageNamed:NSImageNameShareTemplate];
+        item.visibilityPriority = NSToolbarItemVisibilityPriorityLow;
+
+        NSButton* itemButton = (NSButton*)item.view;
+        itemButton.target = self;
+        itemButton.action = @selector(showToolbarShare:);
+        [itemButton sendActionOn:NSEventMaskLeftMouseDown];
+
+        return item;
+    }
+    else
+    {
+        return nil;
+    }
+}
+
+- (void)allToolbarClicked:(id)sender
+{
+    NSInteger tagValue = [sender isKindOfClass:[NSSegmentedControl class]] ? [(NSSegmentedControl*)sender selectedTag] :
+                                                                             ((NSControl*)sender).tag;
+    switch (tagValue)
+    {
+    case ToolbarGroupTagPause:
+        [self.delegate mainToolbarStopAllTorrents:sender];
+        break;
+    case ToolbarGroupTagResume:
+        [self.delegate mainToolbarResumeAllTorrents:sender];
+        break;
+    }
+}
+
+- (void)selectedToolbarClicked:(id)sender
+{
+    NSInteger tagValue = [sender isKindOfClass:[NSSegmentedControl class]] ? [(NSSegmentedControl*)sender selectedTag] :
+                                                                             ((NSControl*)sender).tag;
+    switch (tagValue)
+    {
+    case ToolbarGroupTagPause:
+        [self.delegate mainToolbarStopSelectedTorrents:sender];
+        break;
+    case ToolbarGroupTagResume:
+        [self.delegate mainToolbarResumeSelectedTorrents:sender];
+        break;
+    }
+}
+
+- (NSArray*)toolbarAllowedItemIdentifiers:(NSToolbar*)toolbar
+{
+    return @[
+        ToolbarItemIdentifierCreate,
+        ToolbarItemIdentifierOpenFile,
+        ToolbarItemIdentifierOpenWeb,
+        ToolbarItemIdentifierRemove,
+        ToolbarItemIdentifierPauseResumeSelected,
+        ToolbarItemIdentifierPauseResumeAll,
+        ToolbarItemIdentifierShare,
+        ToolbarItemIdentifierQuickLook,
+        ToolbarItemIdentifierFilter,
+        ToolbarItemIdentifierInfo,
+        NSToolbarSpaceItemIdentifier,
+        NSToolbarFlexibleSpaceItemIdentifier
+    ];
+}
+
+- (NSArray*)toolbarDefaultItemIdentifiers:(NSToolbar*)toolbar
+{
+    return @[
+        ToolbarItemIdentifierCreate,
+        ToolbarItemIdentifierOpenFile,
+        ToolbarItemIdentifierRemove,
+        NSToolbarSpaceItemIdentifier,
+        ToolbarItemIdentifierPauseResumeAll,
+        NSToolbarFlexibleSpaceItemIdentifier,
+        ToolbarItemIdentifierShare,
+        ToolbarItemIdentifierQuickLook,
+        ToolbarItemIdentifierFilter,
+        ToolbarItemIdentifierInfo,
+    ];
+}
+
+- (BOOL)validateToolbarItem:(NSToolbarItem*)toolbarItem
+{
+    NSString* ident = toolbarItem.itemIdentifier;
+
+    // enable remove item
+    if ([ident isEqualToString:ToolbarItemIdentifierRemove])
+    {
+        return [self.delegate mainToolbarSelectedTorrentCount] > 0;
+    }
+
+    // enable pause all item
+    if ([ident isEqualToString:ToolbarItemIdentifierPauseAll])
+    {
+        for (Torrent* torrent in [self.delegate mainToolbarAllTorrents])
+        {
+            if (torrent.active || torrent.waitingToStart)
+            {
+                return YES;
+            }
+        }
+        return NO;
+    }
+
+    // enable resume all item
+    if ([ident isEqualToString:ToolbarItemIdentifierResumeAll])
+    {
+        for (Torrent* torrent in [self.delegate mainToolbarAllTorrents])
+        {
+            if (!torrent.active && !torrent.waitingToStart && !torrent.finishedSeeding)
+            {
+                return YES;
+            }
+        }
+        return NO;
+    }
+
+    // enable pause item
+    if ([ident isEqualToString:ToolbarItemIdentifierPauseSelected])
+    {
+        for (Torrent* torrent in [self.delegate mainToolbarSelectedTorrents])
+        {
+            if (torrent.active || torrent.waitingToStart)
+            {
+                return YES;
+            }
+        }
+        return NO;
+    }
+
+    // enable resume item
+    if ([ident isEqualToString:ToolbarItemIdentifierResumeSelected])
+    {
+        for (Torrent* torrent in [self.delegate mainToolbarSelectedTorrents])
+        {
+            if (!torrent.active && !torrent.waitingToStart)
+            {
+                return YES;
+            }
+        }
+        return NO;
+    }
+
+    // set info item
+    if ([ident isEqualToString:ToolbarItemIdentifierInfo])
+    {
+        ((NSButton*)toolbarItem.view).state = [self.delegate mainToolbarInfoVisible];
+        return YES;
+    }
+
+    // set filter item
+    if ([ident isEqualToString:ToolbarItemIdentifierFilter])
+    {
+        ((NSButton*)toolbarItem.view).state = [self.delegate mainToolbarFilterBarVisible] ? NSControlStateValueOn : NSControlStateValueOff;
+        return YES;
+    }
+
+    // set quick look item
+    if ([ident isEqualToString:ToolbarItemIdentifierQuickLook])
+    {
+        ((NSButton*)toolbarItem.view).state = [self.delegate mainToolbarQuickLookVisible];
+        return [self.delegate mainToolbarSelectedTorrentCount] > 0;
+    }
+
+    // enable share item
+    if ([ident isEqualToString:ToolbarItemIdentifierShare])
+    {
+        return [self.delegate mainToolbarSelectedTorrentCount] > 0;
+    }
+
+    return YES;
+}
+
+- (void)createFile:(id)sender
+{
+    [self.delegate mainToolbarCreateFile:sender];
+}
+
+- (void)openShowSheet:(id)sender
+{
+    [self.delegate mainToolbarOpenFile:sender];
+}
+
+- (void)openURLShowSheet:(id)sender
+{
+    [self.delegate mainToolbarOpenURL:sender];
+}
+
+- (void)removeNoDelete:(id)sender
+{
+    [self.delegate mainToolbarRemoveSelected:sender];
+}
+
+- (void)showInfo:(id)sender
+{
+    [self.delegate mainToolbarToggleInfo:sender];
+}
+
+- (void)toggleFilterBar:(id)sender
+{
+    [self.delegate mainToolbarToggleFilterBar:sender];
+}
+
+- (void)toggleQuickLook:(id)sender
+{
+    [self.delegate mainToolbarToggleQuickLook:sender];
+}
+
+- (void)showToolbarShare:(id)sender
+{
+    [self.delegate mainToolbarShowShare:sender];
+}
+
+@end


### PR DESCRIPTION
## Summary
- Extract macOS toolbar item creation and validation into MainToolbarController
- Keep Controller responsible for app actions/state through a small toolbar delegate bridge
- Add the new toolbar controller to CMake and the Xcode project, and share the transmission-edit Xcode scheme

## Testing
- ./code_style.sh --check
- cmake --build /private/tmp/opencode/transmission-mac-build --target transmission-mac