### PR TITLE
refactor: split macOS auto import controller

### DIFF
--- a/macosx/AutoImportController.h
+++ b/macosx/AutoImportController.h
@@ -1,0 +1,25 @@
+// This file Copyright © Transmission authors and contributors.
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
+
+#import <Foundation/Foundation.h>
+
+#import "VDKQueue.h"
+
+@protocol AutoImportControllerDelegate;
+
+@interface AutoImportController : NSObject<VDKQueueDelegate>
+
+- (instancetype)initWithDefaults:(NSUserDefaults*)defaults delegate:(id<AutoImportControllerDelegate>)delegate;
+
+@property(nonatomic, readonly) VDKQueue* fileWatcherQueue;
+
+- (void)checkAutoImportDirectory;
+
+@end
+
+@protocol AutoImportControllerDelegate<NSObject>
+
+- (void)autoImportController:(AutoImportController*)controller openTorrentFile:(NSString*)path;
+
+@end

--- a/macosx/AutoImportController.mm
+++ b/macosx/AutoImportController.mm
@@ -1,0 +1,194 @@
+// This file Copyright © Transmission authors and contributors.
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
+
+#if __has_feature(modules)
+@import AppKit;
+@import UserNotifications;
+#else
+#import <AppKit/AppKit.h>
+#import <UserNotifications/UserNotifications.h>
+#endif
+
+#include <libtransmission/torrent-metainfo.h>
+
+#import "AutoImportController.h"
+
+@interface AutoImportController ()
+
+@property(nonatomic, readonly) NSUserDefaults* fDefaults;
+@property(nonatomic, weak) id<AutoImportControllerDelegate> delegate;
+@property(nonatomic) NSMutableArray<NSString*>* fAutoImportedNames;
+@property(nonatomic) NSTimer* fAutoImportTimer;
+
+@end
+
+@implementation AutoImportController
+
+- (instancetype)initWithDefaults:(NSUserDefaults*)defaults delegate:(id<AutoImportControllerDelegate>)delegate
+{
+    if ((self = [super init]))
+    {
+        _fDefaults = defaults;
+        _delegate = delegate;
+
+        _fileWatcherQueue = [[VDKQueue alloc] init];
+        _fileWatcherQueue.delegate = self;
+
+        [self updateWatchedAutoImportDirectory];
+
+        [NSNotificationCenter.defaultCenter addObserver:self selector:@selector(changeAutoImport)
+                                                   name:@"AutoImportSettingChange"
+                                                 object:nil];
+        [NSNotificationCenter.defaultCenter addObserver:self selector:@selector(beginCreateFile:) name:@"BeginCreateTorrentFile"
+                                                 object:nil];
+    }
+
+    return self;
+}
+
+- (void)dealloc
+{
+    [NSNotificationCenter.defaultCenter removeObserver:self];
+    [self.fAutoImportTimer invalidate];
+    [self.fileWatcherQueue removeAllPaths];
+}
+
+- (void)VDKQueue:(VDKQueue*)queue receivedNotification:(NSString*)notification forPath:(NSString*)fpath
+{
+    // Don't assume that just because we're watching for write notification, we'll only receive write notifications.
+    if (![self.fDefaults boolForKey:@"AutoImport"] || ![self.fDefaults stringForKey:@"AutoImportDirectory"])
+    {
+        return;
+    }
+
+    if (self.fAutoImportTimer.valid)
+    {
+        [self.fAutoImportTimer invalidate];
+    }
+
+    // Check again in 10 seconds in case torrent file wasn't complete.
+    __weak __auto_type weakSelf = self;
+    self.fAutoImportTimer = [NSTimer scheduledTimerWithTimeInterval:10.0 repeats:NO block:^(NSTimer* _Nonnull __unused timer) {
+        [weakSelf checkAutoImportDirectory];
+    }];
+
+    [self checkAutoImportDirectory];
+}
+
+- (void)changeAutoImport
+{
+    if (self.fAutoImportTimer.valid)
+    {
+        [self.fAutoImportTimer invalidate];
+    }
+    self.fAutoImportTimer = nil;
+
+    self.fAutoImportedNames = nil;
+
+    [self updateWatchedAutoImportDirectory];
+    [self checkAutoImportDirectory];
+}
+
+- (void)updateWatchedAutoImportDirectory
+{
+    [self.fileWatcherQueue removeAllPaths];
+
+    NSString* path = [self.fDefaults stringForKey:@"AutoImportDirectory"];
+    if ([self.fDefaults boolForKey:@"AutoImport"] && path)
+    {
+        [self.fileWatcherQueue addPath:path.stringByExpandingTildeInPath notifyingAbout:VDKQueueNotifyAboutWrite];
+    }
+}
+
+- (void)checkAutoImportDirectory
+{
+    NSString* path;
+    if (![self.fDefaults boolForKey:@"AutoImport"] || !(path = [self.fDefaults stringForKey:@"AutoImportDirectory"]))
+    {
+        return;
+    }
+
+    path = path.stringByExpandingTildeInPath;
+
+    NSArray<NSString*>* importedNames;
+    if (!(importedNames = [NSFileManager.defaultManager contentsOfDirectoryAtPath:path error:NULL]))
+    {
+        return;
+    }
+
+    // Only check files that have not been checked yet.
+    NSMutableArray* newNames = [importedNames mutableCopy];
+
+    if (self.fAutoImportedNames)
+    {
+        [newNames removeObjectsInArray:self.fAutoImportedNames];
+    }
+    else
+    {
+        self.fAutoImportedNames = [[NSMutableArray alloc] init];
+    }
+    [self.fAutoImportedNames setArray:importedNames];
+
+    for (NSString* file in newNames)
+    {
+        if ([file hasPrefix:@"."])
+        {
+            continue;
+        }
+
+        NSString* fullFile = [path stringByAppendingPathComponent:file];
+
+        if (!([[NSWorkspace.sharedWorkspace typeOfFile:fullFile error:NULL] isEqualToString:@"org.bittorrent.torrent"] ||
+              [fullFile.pathExtension caseInsensitiveCompare:@"torrent"] == NSOrderedSame))
+        {
+            continue;
+        }
+
+        NSDictionary<NSFileAttributeKey, id>* fileAttributes = [NSFileManager.defaultManager attributesOfItemAtPath:fullFile
+                                                                                                              error:nil];
+        if (fileAttributes.fileSize == 0)
+        {
+            // Workaround for Firefox downloads happening in two steps: first time being an empty file.
+            [self.fAutoImportedNames removeObject:file];
+            continue;
+        }
+
+        auto metainfo = tr_torrent_metainfo{};
+        if (!metainfo.parse_torrent_file(fullFile.UTF8String))
+        {
+            continue;
+        }
+
+        [self.delegate autoImportController:self openTorrentFile:fullFile];
+
+        NSString* notificationTitle = NSLocalizedString(@"Torrent File Auto Added", "notification title");
+
+        NSString* identifier = [@"Torrent File Auto Added " stringByAppendingString:file];
+        UNMutableNotificationContent* content = [UNMutableNotificationContent new];
+        content.title = notificationTitle;
+        content.body = file;
+
+        UNNotificationRequest* request = [UNNotificationRequest requestWithIdentifier:identifier content:content trigger:nil];
+        [UNUserNotificationCenter.currentNotificationCenter addNotificationRequest:request withCompletionHandler:nil];
+    }
+}
+
+- (void)beginCreateFile:(NSNotification*)notification
+{
+    if (![self.fDefaults boolForKey:@"AutoImport"])
+    {
+        return;
+    }
+
+    NSString* location = ((NSURL*)notification.object).path;
+    NSString* path = [self.fDefaults stringForKey:@"AutoImportDirectory"];
+
+    NSString* parentPath = location.stringByDeletingLastPathComponent.stringByExpandingTildeInPath;
+    if (location && path && [parentPath isEqualToString:path.stringByExpandingTildeInPath])
+    {
+        [self.fAutoImportedNames addObject:location.lastPathComponent];
+    }
+}
+
+@end

--- a/macosx/CMakeLists.txt
+++ b/macosx/CMakeLists.txt
@@ -44,6 +44,8 @@ target_sources(${TR_NAME}-mac
         AddMagnetWindowController.mm
         AddWindowController.h
         AddWindowController.mm
+        AutoImportController.h
+        AutoImportController.mm
         Badger.h
         Badger.mm
         BadgeView.h

--- a/macosx/Controller.h
+++ b/macosx/Controller.h
@@ -9,8 +9,6 @@
 
 #include <libtransmission/transmission.h>
 
-#import "VDKQueue.h"
-
 @class AddMagnetWindowController;
 @class AddWindowController;
 @class MessageWindowController;
@@ -26,7 +24,7 @@ typedef NS_ENUM(NSUInteger, AddType) { //
 };
 
 @interface Controller
-    : NSObject<NSApplicationDelegate, NSMenuItemValidation, NSPopoverDelegate, NSSharingServiceDelegate, NSSharingServicePickerDelegate, NSSoundDelegate, NSToolbarDelegate, NSToolbarItemValidation, NSWindowDelegate, QLPreviewPanelDataSource, QLPreviewPanelDelegate, VDKQueueDelegate, SUUpdaterDelegate>
+    : NSObject<NSApplicationDelegate, NSMenuItemValidation, NSPopoverDelegate, NSSharingServiceDelegate, NSSharingServicePickerDelegate, NSSoundDelegate, NSToolbarDelegate, NSToolbarItemValidation, NSWindowDelegate, QLPreviewPanelDataSource, QLPreviewPanelDelegate, SUUpdaterDelegate>
 
 - (void)openFiles:(NSArray<NSString*>*)filenames addType:(AddType)type forcePath:(NSString*)path;
 
@@ -138,13 +136,6 @@ typedef NS_ENUM(NSUInteger, AddType) { //
 - (IBAction)toggleSpeedLimit:(id)sender;
 - (IBAction)speedLimitChanged:(id)sender;
 - (void)altSpeedToggledCallbackIsLimited:(NSDictionary*)dict;
-
-- (void)changeAutoImport;
-- (void)checkAutoImportDirectory;
-
-- (void)beginCreateFile:(NSNotification*)notification;
-
-@property(nonatomic, readonly) VDKQueue* fileWatcherQueue;
 
 - (void)torrentTableViewSelectionDidChange:(NSNotification*)notification;
 

--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -23,8 +23,6 @@
 #include <libtransmission/values.h>
 #include <libtransmission/variant.h>
 
-#import "VDKQueue.h"
-
 #import "CocoaCompatibility.h"
 
 #import "Controller.h"
@@ -40,6 +38,7 @@
 #import "URLSheetWindowController.h"
 #import "AddWindowController.h"
 #import "AddMagnetWindowController.h"
+#import "AutoImportController.h"
 #import "MessageWindowController.h"
 #import "GlobalOptionsPopoverViewController.h"
 #import "ButtonToolbarItem.h"
@@ -371,7 +370,7 @@ static void removeKeRangerRansomware()
     NSLog(@"OSX.KeRanger.A ransomware removal completed, proceeding to normal operation");
 }
 
-@interface Controller ()<UNUserNotificationCenterDelegate, NSURLSessionDataDelegate, NSURLSessionDownloadDelegate, PowerManagerDelegate>
+@interface Controller ()<AutoImportControllerDelegate, UNUserNotificationCenterDelegate, NSURLSessionDataDelegate, NSURLSessionDownloadDelegate, PowerManagerDelegate>
 
 @property(nonatomic) IBOutlet NSWindow* fWindow;
 @property(nonatomic) NSLayoutConstraint* fMinHeightConstraint;
@@ -424,8 +423,7 @@ static void removeKeRangerRansomware()
 
 @property(nonatomic) Badger* fBadger;
 
-@property(nonatomic) NSMutableArray<NSString*>* fAutoImportedNames;
-@property(nonatomic) NSTimer* fAutoImportTimer;
+@property(nonatomic) AutoImportController* fAutoImportController;
 
 @property(nonatomic) NSURLSession* fSession;
 
@@ -579,9 +577,8 @@ static void removeKeRangerRansomware()
 
         _fInfoController = [[InfoWindowController alloc] init];
 
-        //needs to be done before init-ing the prefs controller
-        _fileWatcherQueue = [[VDKQueue alloc] init];
-        _fileWatcherQueue.delegate = self;
+        // Needs to be done before init-ing the prefs controller.
+        _fAutoImportController = [[AutoImportController alloc] initWithDefaults:_fDefaults delegate:self];
 
         _prefsController = [[PrefsController alloc] initWithHandle:_fLib];
 
@@ -791,8 +788,6 @@ static void removeKeRangerRansomware()
                name:NSOutlineViewSelectionDidChangeNotification
              object:self.fTableView];
 
-    [nc addObserver:self selector:@selector(changeAutoImport) name:@"AutoImportSettingChange" object:nil];
-
     [nc addObserver:self selector:@selector(updateForAutoSize) name:@"AutoSizeSettingChange" object:nil];
 
     [nc addObserver:self selector:@selector(updateForExpandCollapse) name:@"OutlineExpandCollapse" object:nil];
@@ -802,9 +797,6 @@ static void removeKeRangerRansomware()
     [nc addObserver:self selector:@selector(fullUpdateUI) name:@"UpdateTorrentsState" object:nil];
 
     [nc addObserver:self selector:@selector(applyFilter) name:@"ApplyFilter" object:nil];
-
-    //open newly created torrent file
-    [nc addObserver:self selector:@selector(beginCreateFile:) name:@"BeginCreateTorrentFile" object:nil];
 
     //open newly created torrent file
     [nc addObserver:self selector:@selector(openCreatedFile:) name:@"OpenCreatedTorrentFile" object:nil];
@@ -899,7 +891,7 @@ static void removeKeRangerRansomware()
     }
 
     //auto importing
-    [self checkAutoImportDirectory];
+    [self.fAutoImportController checkAutoImportDirectory];
 
     //registering the Web UI to Bonjour
     if ([self.fDefaults boolForKey:@"RPC"] && [self.fDefaults boolForKey:@"RPCWebDiscovery"])
@@ -1049,14 +1041,6 @@ static void removeKeRangerRansomware()
 
     [self.fTimer invalidate];
 
-    if (self.fAutoImportTimer)
-    {
-        if (self.fAutoImportTimer.valid)
-        {
-            [self.fAutoImportTimer invalidate];
-        }
-    }
-
     //remove all torrent downloads
     [self.fSession invalidateAndCancel];
 
@@ -1081,7 +1065,7 @@ static void removeKeRangerRansomware()
     [self updateTorrentHistory];
     [self.fTableView saveCollapsedGroups];
 
-    _fileWatcherQueue = nil;
+    self.fAutoImportController = nil;
 
     //complete cleanup: this can take many seconds
     tr_sessionClose(self.fLib);
@@ -3554,128 +3538,9 @@ static void removeKeRangerRansomware()
     self.fSoundPlaying = NO;
 }
 
-- (void)VDKQueue:(VDKQueue*)queue receivedNotification:(NSString*)notification forPath:(NSString*)fpath
+- (void)autoImportController:(AutoImportController*)controller openTorrentFile:(NSString*)path
 {
-    //don't assume that just because we're watching for write notification, we'll only receive write notifications
-
-    if (![self.fDefaults boolForKey:@"AutoImport"] || ![self.fDefaults stringForKey:@"AutoImportDirectory"])
-    {
-        return;
-    }
-
-    if (self.fAutoImportTimer.valid)
-    {
-        [self.fAutoImportTimer invalidate];
-    }
-
-    //check again in 10 seconds in case torrent file wasn't complete
-    __weak __auto_type weakSelf = self;
-    self.fAutoImportTimer = [NSTimer scheduledTimerWithTimeInterval:10.0 repeats:NO block:^(NSTimer* _Nonnull timer) {
-        [weakSelf checkAutoImportDirectory];
-    }];
-
-    [self checkAutoImportDirectory];
-}
-
-- (void)changeAutoImport
-{
-    if (self.fAutoImportTimer.valid)
-    {
-        [self.fAutoImportTimer invalidate];
-    }
-    self.fAutoImportTimer = nil;
-
-    self.fAutoImportedNames = nil;
-
-    [self checkAutoImportDirectory];
-}
-
-- (void)checkAutoImportDirectory
-{
-    NSString* path;
-    if (![self.fDefaults boolForKey:@"AutoImport"] || !(path = [self.fDefaults stringForKey:@"AutoImportDirectory"]))
-    {
-        return;
-    }
-
-    path = path.stringByExpandingTildeInPath;
-
-    NSArray<NSString*>* importedNames;
-    if (!(importedNames = [NSFileManager.defaultManager contentsOfDirectoryAtPath:path error:NULL]))
-    {
-        return;
-    }
-
-    //only check files that have not been checked yet
-    NSMutableArray* newNames = [importedNames mutableCopy];
-
-    if (self.fAutoImportedNames)
-    {
-        [newNames removeObjectsInArray:self.fAutoImportedNames];
-    }
-    else
-    {
-        self.fAutoImportedNames = [[NSMutableArray alloc] init];
-    }
-    [self.fAutoImportedNames setArray:importedNames];
-
-    for (NSString* file in newNames)
-    {
-        if ([file hasPrefix:@"."])
-        {
-            continue;
-        }
-
-        NSString* fullFile = [path stringByAppendingPathComponent:file];
-
-        if (!([[NSWorkspace.sharedWorkspace typeOfFile:fullFile error:NULL] isEqualToString:@"org.bittorrent.torrent"] ||
-              [fullFile.pathExtension caseInsensitiveCompare:@"torrent"] == NSOrderedSame))
-        {
-            continue;
-        }
-
-        NSDictionary<NSFileAttributeKey, id>* fileAttributes = [NSFileManager.defaultManager attributesOfItemAtPath:fullFile
-                                                                                                              error:nil];
-        if (fileAttributes.fileSize == 0)
-        {
-            // Workaround for Firefox downloads happening in two steps: first time being an empty file
-            [self.fAutoImportedNames removeObject:file];
-            continue;
-        }
-
-        auto metainfo = tr_torrent_metainfo{};
-        if (!metainfo.parse_torrent_file(fullFile.UTF8String))
-        {
-            continue;
-        }
-
-        [self openFiles:@[ fullFile ] addType:AddTypeAuto forcePath:nil];
-
-        NSString* notificationTitle = NSLocalizedString(@"Torrent File Auto Added", "notification title");
-
-        NSString* identifier = [@"Torrent File Auto Added " stringByAppendingString:file];
-        UNMutableNotificationContent* content = [UNMutableNotificationContent new];
-        content.title = notificationTitle;
-        content.body = file;
-
-        UNNotificationRequest* request = [UNNotificationRequest requestWithIdentifier:identifier content:content trigger:nil];
-        [UNUserNotificationCenter.currentNotificationCenter addNotificationRequest:request withCompletionHandler:nil];
-    }
-}
-
-- (void)beginCreateFile:(NSNotification*)notification
-{
-    if (![self.fDefaults boolForKey:@"AutoImport"])
-    {
-        return;
-    }
-
-    NSString *location = ((NSURL*)notification.object).path, *path = [self.fDefaults stringForKey:@"AutoImportDirectory"];
-
-    if (location && path && [location.stringByDeletingLastPathComponent.stringByExpandingTildeInPath isEqualToString:path.stringByExpandingTildeInPath])
-    {
-        [self.fAutoImportedNames addObject:location.lastPathComponent];
-    }
+    [self openFiles:@[ path ] addType:AddTypeAuto forcePath:nil];
 }
 
 - (NSInteger)outlineView:(NSOutlineView*)outlineView numberOfChildrenOfItem:(id)item

--- a/macosx/PrefsController.mm
+++ b/macosx/PrefsController.mm
@@ -6,8 +6,6 @@
 
 #include <libtransmission/string-utils.h>
 
-#import "VDKQueue.h"
-
 #import "PrefsController.h"
 #import "BlocklistDownloaderViewController.h"
 #import "BlocklistScheduler.h"
@@ -151,14 +149,6 @@ static NSString* const kWebUIURLFormat = @"http://localhost:%ld/";
         if ([_fDefaults boolForKey:@"RandomPort"])
         {
             [_fDefaults setInteger:tr_sessionGetPeerPort(_fHandle) forKey:@"BindPort"];
-        }
-
-        //set auto import
-        NSString* autoPath;
-        if ([_fDefaults boolForKey:@"AutoImport"] && (autoPath = [_fDefaults stringForKey:@"AutoImportDirectory"]))
-        {
-            [((Controller*)NSApp.delegate).fileWatcherQueue addPath:autoPath.stringByExpandingTildeInPath
-                                                     notifyingAbout:VDKQueueNotifyAboutWrite];
         }
 
         //set blocklist scheduler
@@ -1058,20 +1048,8 @@ static NSString* const kWebUIURLFormat = @"http://localhost:%ld/";
 
 - (void)setAutoImport:(id)sender
 {
-    NSString* path;
-    if ((path = [self.fDefaults stringForKey:@"AutoImportDirectory"]))
+    if ([self.fDefaults stringForKey:@"AutoImportDirectory"])
     {
-        VDKQueue* watcherQueue = ((Controller*)NSApp.delegate).fileWatcherQueue;
-        if ([self.fDefaults boolForKey:@"AutoImport"])
-        {
-            path = path.stringByExpandingTildeInPath;
-            [watcherQueue addPath:path notifyingAbout:VDKQueueNotifyAboutWrite];
-        }
-        else
-        {
-            [watcherQueue removeAllPaths];
-        }
-
         [NSNotificationCenter.defaultCenter postNotificationName:@"AutoImportSettingChange" object:self];
     }
     else
@@ -1093,12 +1071,8 @@ static NSString* const kWebUIURLFormat = @"http://localhost:%ld/";
     [panel beginSheetModalForWindow:self.window completionHandler:^(NSInteger result) {
         if (result == NSModalResponseOK)
         {
-            VDKQueue* watcherQueue = ((Controller*)NSApp.delegate).fileWatcherQueue;
-            [watcherQueue removeAllPaths];
-
             NSString* path = (panel.URLs[0]).path;
             [self.fDefaults setObject:path forKey:@"AutoImportDirectory"];
-            [watcherQueue addPath:path.stringByExpandingTildeInPath notifyingAbout:VDKQueueNotifyAboutWrite];
 
             [NSNotificationCenter.defaultCenter postNotificationName:@"AutoImportSettingChange" object:self];
         }


### PR DESCRIPTION
## Summary
- add a dedicated macOS AutoImportController for VDKQueue callbacks, auto-import scanning, timers, and notifications
- remove auto-import watcher ownership from Controller and PrefsController
- keep Controller responsible only for opening auto-imported torrent files via delegate callback

## Testing
- git diff --check
- cmake -B build-mac -DENABLE_MAC=ON -DCMAKE_BUILD_TYPE=Debug
- cmake --build build-mac --target transmission-mac

Note: the macOS build emitted existing local warnings about Homebrew dylibs built for a newer macOS version than the deployment target.