### PR TITLE
refactor: move macOS RPC handling out of Controller

### DIFF
--- a/macosx/CMakeLists.txt
+++ b/macosx/CMakeLists.txt
@@ -159,6 +159,8 @@ target_sources(${TR_NAME}-mac
         ProgressBarView.mm
         ProgressGradients.h
         ProgressGradients.mm
+        RpcController.h
+        RpcController.mm
         ShareToolbarItem.h
         ShareToolbarItem.mm
         ShareTorrentFileHelper.h

--- a/macosx/Controller.h
+++ b/macosx/Controller.h
@@ -183,12 +183,4 @@ typedef NS_ENUM(NSUInteger, AddType) { //
 - (IBAction)linkGitHub:(id)sender;
 - (IBAction)linkDonate:(id)sender;
 
-- (void)rpcCallback:(tr_rpc_callback_type)type forTorrentId:(std::optional<tr_torrent_id_t>)torrentId;
-- (void)rpcAddTorrentStruct:(struct tr_torrent*)torrentStruct;
-- (void)rpcRemoveTorrent:(Torrent*)torrent deleteData:(BOOL)deleteData;
-- (void)rpcStartedStoppedTorrent:(Torrent*)torrent;
-- (void)rpcChangedTorrent:(Torrent*)torrent;
-- (void)rpcMovedTorrent:(Torrent*)torrent;
-- (void)rpcUpdateQueue;
-
 @end

--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -46,6 +46,7 @@
 #import "GroupToolbarItem.h"
 #import "ShareToolbarItem.h"
 #import "ShareTorrentFileHelper.h"
+#import "RpcController.h"
 #import "Toolbar.h"
 #import "BlocklistDownloader.h"
 #import "StatusBarController.h"
@@ -371,7 +372,7 @@ static void removeKeRangerRansomware()
     NSLog(@"OSX.KeRanger.A ransomware removal completed, proceeding to normal operation");
 }
 
-@interface Controller ()<UNUserNotificationCenterDelegate, NSURLSessionDataDelegate, NSURLSessionDownloadDelegate, PowerManagerDelegate>
+@interface Controller ()<RpcControllerDelegate, UNUserNotificationCenterDelegate, NSURLSessionDataDelegate, NSURLSessionDownloadDelegate, PowerManagerDelegate>
 
 @property(nonatomic) IBOutlet NSWindow* fWindow;
 @property(nonatomic) NSLayoutConstraint* fMinHeightConstraint;
@@ -428,6 +429,7 @@ static void removeKeRangerRansomware()
 @property(nonatomic) NSTimer* fAutoImportTimer;
 
 @property(nonatomic) NSURLSession* fSession;
+@property(nonatomic) RpcController* fRpcController;
 
 @property(nonatomic) NSMutableSet<Torrent*>* fAddingTransfers;
 
@@ -604,13 +606,7 @@ static void removeKeRangerRansomware()
             [_fDefaults setBool:tr_sessionUsesAltSpeed(_fLib) forKey:@"SpeedLimit"];
         }
 
-        tr_sessionSetRPCCallback(
-            _fLib,
-            [controller = self](tr_rpc_callback_type const type, std::optional<tr_torrent_id_t> const tor_id)
-            {
-                [controller rpcCallback:type forTorrentId:tor_id];
-                return TR_RPC_NOREMOVE; // we'll do the remove manually
-            });
+        _fRpcController = [[RpcController alloc] initWithLib:_fLib delegate:self];
 
         [SUUpdater sharedUpdater].delegate = self;
         _fQuitRequested = NO;
@@ -5411,91 +5407,13 @@ static void removeKeRangerRansomware()
     [NSWorkspace.sharedWorkspace openURL:[NSURL URLWithString:kDonateURL]];
 }
 
-- (void)rpcCallback:(tr_rpc_callback_type)type forTorrentId:(std::optional<tr_torrent_id_t>)torrentId
+- (Torrent*)rpcController:(RpcController*)controller torrentForId:(tr_torrent_id_t)torrent_id
 {
-    @autoreleasepool
-    {
-        dispatch_async(dispatch_get_main_queue(), ^{
-            //get the torrent
-            Torrent* torrent = nil;
-            if (torrentId.has_value() && (type != TR_RPC_TORRENT_ADDED && type != TR_RPC_SESSION_CHANGED && type != TR_RPC_SESSION_CLOSE))
-            {
-                torrent = [self torrentForId:*torrentId];
-
-                if (!torrent)
-                {
-                    NSLog(@"No torrent found matching the given torrent id from the RPC callback!");
-                    return;
-                }
-            }
-
-            switch (type)
-            {
-            case TR_RPC_TORRENT_ADDED:
-                if (torrentId.has_value())
-                {
-                    if (auto* const torrentStruct = tr_torrentFindFromId(self.fLib, *torrentId); torrentStruct != nullptr)
-                    {
-                        [self rpcAddTorrentStruct:torrentStruct];
-                    }
-                }
-                break;
-
-            case TR_RPC_TORRENT_STARTED:
-            case TR_RPC_TORRENT_STOPPED:
-                [self rpcStartedStoppedTorrent:torrent];
-                break;
-
-            case TR_RPC_TORRENT_REMOVING:
-                [self rpcRemoveTorrent:torrent deleteData:NO];
-                break;
-
-            case TR_RPC_TORRENT_TRASHING:
-                [self rpcRemoveTorrent:torrent deleteData:YES];
-                break;
-
-            case TR_RPC_TORRENT_CHANGED:
-                [self rpcChangedTorrent:torrent];
-                break;
-
-            case TR_RPC_TORRENT_MOVED:
-                [self rpcMovedTorrent:torrent];
-                break;
-
-            case TR_RPC_SESSION_QUEUE_POSITIONS_CHANGED:
-                [self rpcUpdateQueue];
-                break;
-
-            case TR_RPC_SESSION_CHANGED:
-                [self.prefsController rpcUpdatePrefs];
-                break;
-
-            case TR_RPC_SESSION_CLOSE:
-                self.fQuitRequested = YES;
-                [NSApp terminate:self];
-                break;
-
-            default:
-                NSAssert1(NO, @"Unknown RPC command received: %d", type);
-            }
-        });
-    }
+    return [self torrentForId:torrent_id];
 }
 
-- (void)rpcAddTorrentStruct:(struct tr_torrent*)torrentStruct
+- (void)rpcController:(RpcController*)controller addTorrent:(Torrent*)torrent
 {
-    NSString* location = tr_strv_to_utf8_nsstring(tr_torrentGetDownloadDir(torrentStruct));
-
-    Torrent* torrent = [[Torrent alloc] initWithTorrentStruct:torrentStruct location:location lib:self.fLib];
-
-    //change the location if the group calls for it (this has to wait until after the torrent is created)
-    if ([GroupsController.groups usesCustomDownloadLocationForIndex:torrent.groupValue])
-    {
-        location = [GroupsController.groups customDownloadLocationForIndex:torrent.groupValue];
-        [torrent changeDownloadFolderBeforeUsing:location determinationType:TorrentDeterminationAutomatic];
-    }
-
-    [torrent update];
     [self.fTorrents addObject:torrent];
 
     if (!self.fAddingTransfers)
@@ -5507,24 +5425,20 @@ static void removeKeRangerRansomware()
     [self fullUpdateUI];
 }
 
-- (void)rpcRemoveTorrent:(Torrent*)torrent deleteData:(BOOL)deleteData
+- (void)rpcController:(RpcController*)controller removeTorrent:(Torrent*)torrent deleteData:(BOOL)deleteData
 {
     [self confirmRemoveTorrents:@[ torrent ] deleteData:deleteData];
 }
 
-- (void)rpcStartedStoppedTorrent:(Torrent*)torrent
+- (void)rpcControllerDidStartOrStopTorrent:(RpcController*)controller
 {
-    [torrent update];
-
     [self updateUI];
     [self applyFilter];
     [self updateTorrentHistory];
 }
 
-- (void)rpcChangedTorrent:(Torrent*)torrent
+- (void)rpcControllerDidChangeTorrent:(RpcController*)controller torrent:(Torrent*)torrent
 {
-    [torrent update];
-
     if ([self.fTableView.selectedTorrents containsObject:torrent])
     {
         [self.fInfoController updateInfoStats]; //this will reload the file table
@@ -5532,18 +5446,15 @@ static void removeKeRangerRansomware()
     }
 }
 
-- (void)rpcMovedTorrent:(Torrent*)torrent
+- (void)rpcControllerDidMoveTorrent:(RpcController*)controller torrent:(Torrent*)torrent
 {
-    [torrent update];
-    [torrent updateTimeMachineExclude];
-
     if ([self.fTableView.selectedTorrents containsObject:torrent])
     {
         [self.fInfoController updateInfoStats];
     }
 }
 
-- (void)rpcUpdateQueue
+- (void)rpcControllerDidUpdateQueue:(RpcController*)controller
 {
     [Torrent updateTorrents:self.fTorrents];
 
@@ -5552,6 +5463,17 @@ static void removeKeRangerRansomware()
     [self.fTorrents sortUsingDescriptors:descriptors];
 
     [self sortTorrentsAndIncludeQueueOrder:YES];
+}
+
+- (void)rpcControllerDidChangeSession:(RpcController*)controller
+{
+    [self.prefsController rpcUpdatePrefs];
+}
+
+- (void)rpcControllerDidRequestSessionClose:(RpcController*)controller
+{
+    self.fQuitRequested = YES;
+    [NSApp terminate:self];
 }
 
 @end

--- a/macosx/RpcController.h
+++ b/macosx/RpcController.h
@@ -1,0 +1,30 @@
+// This file Copyright © Transmission authors and contributors.
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
+
+#import <Foundation/Foundation.h>
+
+#include <libtransmission/transmission.h>
+
+@class RpcController;
+@class Torrent;
+
+@protocol RpcControllerDelegate<NSObject>
+
+- (Torrent*)rpcController:(RpcController*)controller torrentForId:(tr_torrent_id_t)torrent_id;
+- (void)rpcController:(RpcController*)controller addTorrent:(Torrent*)torrent;
+- (void)rpcController:(RpcController*)controller removeTorrent:(Torrent*)torrent deleteData:(BOOL)deleteData;
+- (void)rpcControllerDidStartOrStopTorrent:(RpcController*)controller;
+- (void)rpcControllerDidChangeTorrent:(RpcController*)controller torrent:(Torrent*)torrent;
+- (void)rpcControllerDidMoveTorrent:(RpcController*)controller torrent:(Torrent*)torrent;
+- (void)rpcControllerDidUpdateQueue:(RpcController*)controller;
+- (void)rpcControllerDidChangeSession:(RpcController*)controller;
+- (void)rpcControllerDidRequestSessionClose:(RpcController*)controller;
+
+@end
+
+@interface RpcController : NSObject
+
+- (instancetype)initWithLib:(tr_session*)lib delegate:(id<RpcControllerDelegate>)delegate;
+
+@end

--- a/macosx/RpcController.mm
+++ b/macosx/RpcController.mm
@@ -1,0 +1,151 @@
+// This file Copyright © Transmission authors and contributors.
+// It may be used under the MIT (SPDX: MIT) license.
+// License text can be found in the licenses/ folder.
+
+#include <optional>
+
+#include <libtransmission/string-utils.h>
+#include <libtransmission/transmission.h>
+
+#import "RpcController.h"
+
+#import "GroupsController.h"
+#import "Torrent.h"
+
+@interface RpcController ()
+
+@property(nonatomic, readonly) tr_session* fLib;
+@property(nonatomic, weak) id<RpcControllerDelegate> delegate;
+
+@end
+
+@implementation RpcController
+
+- (instancetype)initWithLib:(tr_session*)lib delegate:(id<RpcControllerDelegate>)delegate
+{
+    if ((self = [super init]))
+    {
+        _fLib = lib;
+        _delegate = delegate;
+
+        tr_sessionSetRPCCallback(
+            _fLib,
+            [controller = self](tr_rpc_callback_type const type, std::optional<tr_torrent_id_t> const torrent_id)
+            {
+                [controller rpcCallback:type forTorrentId:torrent_id];
+                return TR_RPC_NOREMOVE; // We'll do the remove manually.
+            });
+    }
+
+    return self;
+}
+
+- (void)rpcCallback:(tr_rpc_callback_type)type forTorrentId:(std::optional<tr_torrent_id_t>)torrent_id
+{
+    @autoreleasepool
+    {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            Torrent* torrent = nil;
+            if (torrent_id.has_value() && (type != TR_RPC_TORRENT_ADDED && type != TR_RPC_SESSION_CHANGED && type != TR_RPC_SESSION_CLOSE))
+            {
+                torrent = [self.delegate rpcController:self torrentForId:*torrent_id];
+
+                if (!torrent)
+                {
+                    NSLog(@"No torrent found matching the given torrent id from the RPC callback!");
+                    return;
+                }
+            }
+
+            switch (type)
+            {
+            case TR_RPC_TORRENT_ADDED:
+                if (torrent_id.has_value())
+                {
+                    if (auto* const torrentStruct = tr_torrentFindFromId(self.fLib, *torrent_id); torrentStruct != nullptr)
+                    {
+                        [self addTorrentWithStruct:torrentStruct];
+                    }
+                }
+                break;
+
+            case TR_RPC_TORRENT_STARTED:
+            case TR_RPC_TORRENT_STOPPED:
+                [self startedStoppedTorrent:torrent];
+                break;
+
+            case TR_RPC_TORRENT_REMOVING:
+                [self.delegate rpcController:self removeTorrent:torrent deleteData:NO];
+                break;
+
+            case TR_RPC_TORRENT_TRASHING:
+                [self.delegate rpcController:self removeTorrent:torrent deleteData:YES];
+                break;
+
+            case TR_RPC_TORRENT_CHANGED:
+                [self changedTorrent:torrent];
+                break;
+
+            case TR_RPC_TORRENT_MOVED:
+                [self movedTorrent:torrent];
+                break;
+
+            case TR_RPC_SESSION_QUEUE_POSITIONS_CHANGED:
+                [self.delegate rpcControllerDidUpdateQueue:self];
+                break;
+
+            case TR_RPC_SESSION_CHANGED:
+                [self.delegate rpcControllerDidChangeSession:self];
+                break;
+
+            case TR_RPC_SESSION_CLOSE:
+                [self.delegate rpcControllerDidRequestSessionClose:self];
+                break;
+
+            default:
+                NSAssert1(NO, @"Unknown RPC command received: %d", type);
+            }
+        });
+    }
+}
+
+- (void)addTorrentWithStruct:(struct tr_torrent*)torrentStruct
+{
+    NSString* location = tr_strv_to_utf8_nsstring(tr_torrentGetDownloadDir(torrentStruct));
+
+    Torrent* torrent = [[Torrent alloc] initWithTorrentStruct:torrentStruct location:location lib:self.fLib];
+
+    // Change the location if the group calls for it (this has to wait until after the torrent is created).
+    if ([GroupsController.groups usesCustomDownloadLocationForIndex:torrent.groupValue])
+    {
+        location = [GroupsController.groups customDownloadLocationForIndex:torrent.groupValue];
+        [torrent changeDownloadFolderBeforeUsing:location determinationType:TorrentDeterminationAutomatic];
+    }
+
+    [torrent update];
+    [self.delegate rpcController:self addTorrent:torrent];
+}
+
+- (void)startedStoppedTorrent:(Torrent*)torrent
+{
+    [torrent update];
+
+    [self.delegate rpcControllerDidStartOrStopTorrent:self];
+}
+
+- (void)changedTorrent:(Torrent*)torrent
+{
+    [torrent update];
+
+    [self.delegate rpcControllerDidChangeTorrent:self torrent:torrent];
+}
+
+- (void)movedTorrent:(Torrent*)torrent
+{
+    [torrent update];
+    [torrent updateTimeMachineExclude];
+
+    [self.delegate rpcControllerDidMoveTorrent:self torrent:torrent];
+}
+
+@end


### PR DESCRIPTION
## Summary
- add a focused RpcController for macOS RPC callbacks
- move RPC torrent/session event handling out of Controller
- keep Controller as the delegate for app-owned UI and session responses

## Verification
- git diff --check
- cmake --build build-mac --target transmission-mac

Refs #8972