### PR TITLE
feat: add "Sort by Uploaded" mode (GTK, Qt, macOS)

### DIFF
--- a/gtk/Torrent.cc
+++ b/gtk/Torrent.cc
@@ -818,6 +818,11 @@ Storage Torrent::get_total_size() const
     return impl_->get_cache().total_size;
 }
 
+Storage Torrent::get_uploaded_ever() const
+{
+    return impl_->get_cache().uploaded_ever;
+}
+
 float Torrent::get_ratio() const
 {
     return impl_->get_cache().ratio;

--- a/gtk/Torrent.h
+++ b/gtk/Torrent.h
@@ -102,6 +102,7 @@ public:
     Speed get_speed_up() const;
     tr_torrent& get_underlying() const;
     Storage get_total_size() const;
+    Storage get_uploaded_ever() const;
     unsigned int get_trackers() const;
 
     Glib::RefPtr<Gio::Icon> get_icon() const;

--- a/gtk/TorrentSorter.cc
+++ b/gtk/TorrentSorter.cc
@@ -142,6 +142,17 @@ int compare_by_size(Torrent const& lhs, Torrent const& rhs)
 }
 
 // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
+int compare_by_uploaded(Torrent const& lhs, Torrent const& rhs)
+{
+    if (auto val = -tr_compare_3way(lhs.get_uploaded_ever(), rhs.get_uploaded_ever()); val != 0)
+    {
+        return val;
+    }
+
+    return compare_by_name(lhs, rhs);
+}
+
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 int compare_by_progress(Torrent const& lhs, Torrent const& rhs)
 {
     if (auto val = -tr_compare_3way(lhs.get_percent_complete(), rhs.get_percent_complete()); val != 0)
@@ -205,6 +216,7 @@ void TorrentSorter::set_mode(SortMode const mode)
         { SortMode::SortByRatio, &compare_by_ratio },
         { SortMode::SortBySize, &compare_by_size },
         { SortMode::SortByState, &compare_by_state },
+        { SortMode::SortByUploaded, &compare_by_uploaded },
     } };
 
     auto const iter = CompareFuncs.find(mode);
@@ -237,7 +249,7 @@ int TorrentSorter::compare(Torrent const& lhs, Torrent const& rhs) const
 void TorrentSorter::update(Torrent::ChangeFlags changes)
 {
     using Flag = Torrent::ChangeFlag;
-    static auto TR_CONSTEXPR23 CompareFlags = std::array<std::pair<CompareFunc, Torrent::ChangeFlags>, 9U>{ {
+    static auto TR_CONSTEXPR23 CompareFlags = std::array<std::pair<CompareFunc, Torrent::ChangeFlags>, 10U>{ {
         { &compare_by_activity, Flag::ACTIVE_PEER_COUNT | Flag::QUEUE_POSITION | Flag::SPEED_DOWN | Flag::SPEED_UP },
         { &compare_by_age, Flag::ADDED_DATE | Flag::NAME },
         { &compare_by_eta, Flag::ETA | Flag::NAME },
@@ -247,6 +259,7 @@ void TorrentSorter::update(Torrent::ChangeFlags changes)
         { &compare_by_ratio, Flag::QUEUE_POSITION | Flag::RATIO },
         { &compare_by_size, Flag::NAME | Flag::TOTAL_SIZE },
         { &compare_by_state, Flag::ACTIVITY | Flag::QUEUE_POSITION },
+        { &compare_by_uploaded, Flag::LONG_PROGRESS | Flag::NAME },
     } };
 
     if (auto const iter = std::ranges::find_if(

--- a/gtk/transmission-ui.xml
+++ b/gtk/transmission-ui.xml
@@ -240,6 +240,11 @@
         </item>
         <item>
           <attribute name="action">win.sort-torrents</attribute>
+          <attribute name="label" translatable="yes">Sort by _Uploaded</attribute>
+          <attribute name="target">sort_by_uploaded</attribute>
+        </item>
+        <item>
+          <attribute name="action">win.sort-torrents</attribute>
           <attribute name="label" translatable="yes">Sort by Time _Left</attribute>
           <attribute name="target">sort_by_time_left</attribute>
         </item>

--- a/libtransmission-app/converters.cc
+++ b/libtransmission-app/converters.cc
@@ -171,6 +171,7 @@ auto constexpr SortKeys = std::array<std::pair<std::string_view, SortMode>, Sort
     { "sort_by_ratio", SortMode::SortByRatio },
     { "sort_by_size", SortMode::SortBySize },
     { "sort_by_state", SortMode::SortByState },
+    { "sort_by_uploaded", SortMode::SortByUploaded },
 } };
 
 bool to_sort_mode(tr_variant const& src, SortMode* tgt)

--- a/libtransmission-app/display-modes.h
+++ b/libtransmission-app/display-modes.h
@@ -34,9 +34,10 @@ enum class SortMode : uint8_t
     SortByRatio,
     SortBySize,
     SortByState,
+    SortByUploaded,
     SortById,
 };
-inline auto constexpr SortModeCount = 10U;
+inline auto constexpr SortModeCount = 11U;
 inline auto constexpr DefaultSortMode = SortMode::SortByName;
 
 enum class StatsMode : uint8_t

--- a/macosx/Base.lproj/MainMenu.xib
+++ b/macosx/Base.lproj/MainMenu.xib
@@ -780,6 +780,11 @@
                                                 <action selector="setSort:" target="206" id="1934"/>
                                             </connections>
                                         </menuItem>
+                                        <menuItem title="Uploaded" tag="9" id="upL-00-0001">
+                                            <connections>
+                                                <action selector="setSort:" target="206" id="upL-00-0002"/>
+                                            </connections>
+                                        </menuItem>
                                         <menuItem isSeparatorItem="YES" id="2881">
                                             <modifierMask key="keyEquivalentModifierMask" command="YES"/>
                                         </menuItem>

--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -97,6 +97,7 @@ static SortType const SortTypeOrder = @"Order";
 static SortType const SortTypeActivity = @"Activity";
 static SortType const SortTypeSize = @"Size";
 static SortType const SortTypeETA = @"ETA";
+static SortType const SortTypeUploaded = @"Uploaded";
 
 typedef NS_ENUM(NSUInteger, SortTag) {
     SortTagOrder = 0,
@@ -107,7 +108,8 @@ typedef NS_ENUM(NSUInteger, SortTag) {
     SortTagTracker = 5,
     SortTagActivity = 6,
     SortTagSize = 7,
-    SortTagETA = 8
+    SortTagETA = 8,
+    SortTagUploaded = 9
 };
 
 typedef NS_ENUM(NSUInteger, SortOrderTag) { //
@@ -2739,6 +2741,9 @@ static void removeKeRangerRansomware()
     case SortTagETA:
         sortType = SortTypeETA;
         break;
+    case SortTagUploaded:
+        sortType = SortTypeUploaded;
+        break;
     default:
         NSAssert1(NO, @"Unknown sort tag received: %ld", senderMenuItem.tag);
         return;
@@ -2834,6 +2839,12 @@ static void removeKeRangerRansomware()
         NSSortDescriptor* sizeDescriptor = [NSSortDescriptor sortDescriptorWithKey:@"totalSizeSelected" ascending:asc];
 
         descriptors = @[ sizeDescriptor, nameDescriptor ];
+    }
+    else if ([sortType isEqualToString:SortTypeUploaded])
+    {
+        NSSortDescriptor* uploadDescriptor = [NSSortDescriptor sortDescriptorWithKey:@"uploadedTotal" ascending:!asc];
+
+        descriptors = @[ uploadDescriptor, nameDescriptor ];
     }
     else if ([sortType isEqualToString:SortTypeName])
     {
@@ -4638,6 +4649,9 @@ static void removeKeRangerRansomware()
             break;
         case SortTagETA:
             sortType = SortTypeETA;
+            break;
+        case SortTagUploaded:
+            sortType = SortTypeUploaded;
             break;
         default:
             NSAssert1(NO, @"Unknown sort tag received: %ld", [menuItem tag]);

--- a/qt/MainWindow.cc
+++ b/qt/MainWindow.cc
@@ -159,7 +159,7 @@ MainWindow::MainWindow(Session& session, Prefs& prefs, TorrentModel& model, bool
     ui_.listView->setModel(&filter_model_);
     connect(ui_.listView->selectionModel(), &QItemSelectionModel::selectionChanged, refresh_action_sensitivity_soon);
 
-    auto const sort_modes = std::array<std::pair<QAction*, SortMode>, 9U>{ {
+    auto const sort_modes = std::array<std::pair<QAction*, SortMode>, 10U>{ {
         { ui_.action_SortByActivity, SortMode::SortByActivity },
         { ui_.action_SortByAge, SortMode::SortByAge },
         { ui_.action_SortByETA, SortMode::SortByEta },
@@ -169,6 +169,7 @@ MainWindow::MainWindow(Session& session, Prefs& prefs, TorrentModel& model, bool
         { ui_.action_SortByRatio, SortMode::SortByRatio },
         { ui_.action_SortBySize, SortMode::SortBySize },
         { ui_.action_SortByState, SortMode::SortByState },
+        { ui_.action_SortByUploaded, SortMode::SortByUploaded },
     } };
 
     // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)

--- a/qt/MainWindow.ui
+++ b/qt/MainWindow.ui
@@ -260,6 +260,7 @@
     <addaction name="action_SortByRatio"/>
     <addaction name="action_SortBySize"/>
     <addaction name="action_SortByState"/>
+    <addaction name="action_SortByUploaded"/>
     <addaction name="action_SortByETA"/>
     <addaction name="separator"/>
     <addaction name="action_ReverseSortOrder"/>
@@ -583,6 +584,14 @@
    </property>
    <property name="text">
     <string>Sort by Stat&amp;e</string>
+   </property>
+  </action>
+  <action name="action_SortByUploaded">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Sort by Upl&amp;oaded</string>
    </property>
   </action>
   <action name="action_SortByTracker">

--- a/qt/TorrentFilter.cc
+++ b/qt/TorrentFilter.cc
@@ -184,6 +184,14 @@ bool TorrentFilter::lessThan(QModelIndex const& left, QModelIndex const& right) 
 
         break;
 
+    case SortMode::SortByUploaded:
+        if (val == 0)
+        {
+            val = a->uploadedEver() <=> b->uploadedEver();
+        }
+
+        break;
+
     case SortMode::SortByEta:
         if (val == 0)
         {


### PR DESCRIPTION
## What

Adds a new torrent-list sort mode based on each torrent's lifetime uploaded bytes (`tr_stat::uploaded_ever`), selectable from the **View** menu in all three desktop clients. Closes #7316.

This lets you see which torrents you've seeded the most / least — something the existing **Sort by Ratio** doesn't show, since ratio hides absolute transfer volume.

## Why

Requested in #7316. The data is already collected per torrent in every frontend; only the comparator and menu wiring are new. No libtransmission, RPC, or settings-schema changes are needed.

## Behavior

- **Default (non-reversed) order:** most-uploaded first, consistent with the existing **Size / Age / Ratio** modes.
- **Tiebreaker:** torrent name (matches every other mode).
- Simpler than ratio: uploaded bytes are a plain monotonic `uint64_t`, so there is no `TR_RATIO_INF` / NA edge case to handle.

Reversed sort works the same as for the other modes (descending toggle in the same menu).

## Changes

| Area | What |
|---|---|
| `libtransmission-app` (shared by GTK + Qt) | New `SortByUploaded` enum value (`SortModeCount` 10 → 11) and `"sort_by_uploaded"` serialization key |
| `gtk` | New `Torrent::get_uploaded_ever()` accessor (value already cached), `compare_by_uploaded` comparator wired into the `CompareFuncs` map and the `CompareFlags` re-sort table (`LONG_PROGRESS` is the change-flag `uploaded_ever` updates under), and a **Sort by Uploaded** menu item |
| `qt` | New `SortMode::SortByUploaded` case in `TorrentFilter::lessThan` using the existing `Torrent::uploadedEver()` getter, plus the action and menu entry |
| `macosx` | `SortTypeUploaded` / `SortTagUploaded` (=9), matching cases in `setSort:` and `validateMenuItem:`, an `NSSortDescriptor` keyed on the existing `uploadedTotal` property, and a `menuItem` in `MainMenu.xib` |

## Verification

- ✅ macOS client builds cleanly (`xcodebuild -target Transmission -configuration "Release - Debug" -arch arm64` → `** BUILD SUCCEEDED **`), including recompilation of `Controller.mm` and the `MainMenu.xib`.
- ✅ `libtransmission-app` builds (CMake/Ninja) — the enum + serialization changes compile cleanly.
- ✅ `clang-format --dry-run --Werror` on all 7 changed C/C++ files: no violations. Pre-commit `code_style.sh --check` passes.
- ⚠️ GTK and Qt builds could not be exercised in this environment (gtkmm / Qt not installed locally). The edits mirror the existing Size/Ratio patterns and use already-present accessors, but a CI run on those frontends is the real confirmation.

## Notes

The macOS sort menu items are re-sorted alphabetically at runtime (`Controller.mm`), so the new **Uploaded** entry finds its own position automatically. The Xcode `<menuItem>` insertion order is therefore not load-bearing.

I did **not** add a list column for uploaded bytes — sorting is independent of any visible column, matching how Ratio sort already works without a dedicated column.