### PR TITLE
perf: extract small torrent cell from xib

### DIFF
--- a/macosx/SmallTorrentCell.mm
+++ b/macosx/SmallTorrentCell.mm
@@ -14,6 +14,81 @@
 
 @implementation SmallTorrentCell
 
+// Layout
+- (void)setupConstraints
+{
+    __auto_type groupIndicatorView = self.fGroupIndicatorView;
+    __auto_type iconView = self.fIconView;
+    __auto_type actionButton = self.fActionButton;
+    __auto_type stackView = self.fStackView;
+    __auto_type torrentStatusField = self.fTorrentStatusField;
+    __auto_type torrentProgressBarView = self.fTorrentProgressBarView;
+    __auto_type controlButton = self.fControlButton;
+    __auto_type revealButton = self.fRevealButton;
+
+    for (NSView* view in @[
+             groupIndicatorView,
+             iconView,
+             actionButton,
+             torrentProgressBarView,
+             stackView,
+             torrentStatusField,
+             controlButton,
+             revealButton,
+         ])
+    {
+        [self addSubview:view];
+    }
+
+    [NSLayoutConstraint activateConstraints:@[
+        // groupIndicatorView
+        [groupIndicatorView.leadingAnchor constraintEqualToAnchor:self.leadingAnchor],
+        [groupIndicatorView.centerYAnchor constraintEqualToAnchor:self.centerYAnchor],
+        [groupIndicatorView.widthAnchor constraintEqualToConstant:6],
+        [groupIndicatorView.heightAnchor constraintEqualToConstant:6],
+
+        // iconView
+        [iconView.leadingAnchor constraintEqualToAnchor:groupIndicatorView.trailingAnchor constant:8],
+        [iconView.centerYAnchor constraintEqualToAnchor:self.centerYAnchor],
+        [iconView.widthAnchor constraintEqualToConstant:16],
+        [iconView.heightAnchor constraintEqualToConstant:16],
+
+        // actionButton
+        [actionButton.centerXAnchor constraintEqualToAnchor:iconView.centerXAnchor],
+        [actionButton.centerYAnchor constraintEqualToAnchor:iconView.centerYAnchor],
+        [actionButton.widthAnchor constraintEqualToConstant:16],
+        [actionButton.heightAnchor constraintEqualToConstant:16],
+
+        // torrentProgressBarView
+        [torrentProgressBarView.leadingAnchor constraintEqualToAnchor:iconView.trailingAnchor constant:15],
+        [torrentProgressBarView.trailingAnchor constraintEqualToAnchor:self.trailingAnchor constant:-5],
+        [torrentProgressBarView.centerYAnchor constraintEqualToAnchor:self.centerYAnchor],
+        [torrentProgressBarView.heightAnchor constraintEqualToConstant:18],
+
+        // stackView
+        [stackView.leadingAnchor constraintEqualToAnchor:torrentProgressBarView.leadingAnchor],
+        [stackView.topAnchor constraintEqualToAnchor:torrentProgressBarView.topAnchor],
+        [stackView.bottomAnchor constraintEqualToAnchor:torrentProgressBarView.bottomAnchor],
+
+        // torrentStatusField
+        [torrentStatusField.leadingAnchor constraintEqualToAnchor:stackView.trailingAnchor],
+        [torrentStatusField.trailingAnchor constraintEqualToAnchor:torrentProgressBarView.trailingAnchor constant:-3],
+        [torrentStatusField.centerYAnchor constraintEqualToAnchor:torrentProgressBarView.centerYAnchor],
+
+        // controlButton
+        [controlButton.centerYAnchor constraintEqualToAnchor:torrentProgressBarView.centerYAnchor],
+        [controlButton.widthAnchor constraintEqualToConstant:14],
+        [controlButton.heightAnchor constraintEqualToConstant:14],
+
+        // revealButton
+        [revealButton.leadingAnchor constraintEqualToAnchor:controlButton.trailingAnchor constant:3],
+        [revealButton.trailingAnchor constraintEqualToAnchor:torrentProgressBarView.trailingAnchor constant:-3],
+        [revealButton.centerYAnchor constraintEqualToAnchor:controlButton.centerYAnchor],
+        [revealButton.widthAnchor constraintEqualToConstant:14],
+        [revealButton.heightAnchor constraintEqualToConstant:14],
+    ]];
+}
+
 // show fControlButton and fRevealButton
 - (void)mouseEntered:(NSEvent*)event
 {

--- a/macosx/TorrentCell.h
+++ b/macosx/TorrentCell.h
@@ -26,4 +26,6 @@
 
 @property(nonatomic, weak) TorrentTableView* fTorrentTableView;
 
+- (void)setupConstraints;
+
 @end

--- a/macosx/TorrentCell.mm
+++ b/macosx/TorrentCell.mm
@@ -7,8 +7,175 @@
 #import "ProgressGradients.h"
 #import "Torrent.h"
 #import "NSImageAdditions.h"
+#import "TorrentCellControlButton.h"
+#import "TorrentCellActionButton.h"
+#import "TorrentCellRevealButton.h"
 
 @implementation TorrentCell
+
+- (instancetype)initWithFrame:(NSRect)frameRect
+{
+    if (self = [super initWithFrame:frameRect])
+    {
+        [self configureViews];
+        [self setupConstraints];
+    }
+    return self;
+}
+
+- (void)configureViews
+{
+    __auto_type groupIndicatorView = [[NSImageView alloc] init];
+
+    __auto_type iconView = [[NSImageView alloc] init];
+    __auto_type actionButton = [[TorrentCellActionButton alloc] init];
+
+    __auto_type stackView = [[NSStackView alloc] init];
+    stackView.distribution = NSStackViewDistributionFill;
+    stackView.spacing = 4;
+
+    __auto_type torrentTitleField = [[NSTextField alloc] init];
+    torrentTitleField.textColor = NSColor.labelColor;
+    torrentTitleField.backgroundColor = NSColor.textBackgroundColor;
+    torrentTitleField.font = [NSFont systemFontOfSize:12.0 weight:NSFontWeightRegular];
+
+    __auto_type torrentPriorityView = [[NSImageView alloc] init];
+
+    [stackView addArrangedSubview:torrentTitleField];
+    [stackView addArrangedSubview:torrentPriorityView];
+
+    __auto_type torrentProgressField = [[NSTextField alloc] init];
+    torrentProgressField.textColor = NSColor.secondaryLabelColor;
+    torrentProgressField.backgroundColor = NSColor.textBackgroundColor;
+    torrentProgressField.font = [NSFont systemFontOfSize:10.0 weight:NSFontWeightRegular];
+
+    __auto_type torrentStatusField = [[NSTextField alloc] init];
+    torrentStatusField.textColor = NSColor.secondaryLabelColor;
+    torrentStatusField.backgroundColor = NSColor.textBackgroundColor;
+    torrentStatusField.font = [NSFont systemFontOfSize:10.0 weight:NSFontWeightRegular];
+
+    __auto_type torrentProgressBarView = [[NSView alloc] init];
+
+    __auto_type controlButton = [[TorrentCellControlButton alloc] init];
+    __auto_type revealButton = [[TorrentCellRevealButton alloc] init];
+
+    for (NSImageView* imageView in @[ groupIndicatorView, iconView, torrentPriorityView ])
+    {
+        imageView.imageScaling = NSImageScaleProportionallyDown;
+    }
+
+    for (NSTextField* textField in @[ torrentTitleField, torrentProgressField, torrentStatusField ])
+    {
+        textField.editable = NO;
+        textField.selectable = NO;
+        textField.bordered = NO;
+        textField.drawsBackground = NO;
+    }
+
+    for (NSButton* button in @[ actionButton, controlButton, revealButton ])
+    {
+        button.imagePosition = NSImageOnly;
+        button.imageScaling = NSImageScaleProportionallyDown;
+        [button setButtonType:NSButtonTypeMomentaryPushIn];
+        [button setBezelStyle:NSBezelStyleRegularSquare];
+        button.bordered = NO;
+    }
+
+    for (NSView* view in @[
+             groupIndicatorView,
+             iconView,
+             actionButton,
+             stackView,
+             torrentProgressField,
+             torrentStatusField,
+             torrentProgressBarView,
+             controlButton,
+             revealButton,
+         ])
+    {
+        view.translatesAutoresizingMaskIntoConstraints = NO;
+        [self addSubview:view];
+    }
+
+    self.fGroupIndicatorView = groupIndicatorView;
+    self.fIconView = iconView;
+    self.fActionButton = actionButton;
+    self.fStackView = stackView;
+    self.fTorrentTitleField = torrentTitleField;
+    self.fTorrentPriorityView = torrentPriorityView;
+    self.fTorrentProgressField = torrentProgressField;
+    self.fTorrentStatusField = torrentStatusField;
+    self.fTorrentProgressBarView = torrentProgressBarView;
+    self.fControlButton = controlButton;
+    self.fRevealButton = revealButton;
+}
+
+- (void)setupConstraints
+{
+    __auto_type groupIndicatorView = self.fGroupIndicatorView;
+    __auto_type iconView = self.fIconView;
+    __auto_type actionButton = self.fActionButton;
+    __auto_type stackView = self.fStackView;
+    __auto_type torrentProgressField = self.fTorrentProgressField;
+    __auto_type torrentStatusField = self.fTorrentStatusField;
+    __auto_type torrentProgressBarView = self.fTorrentProgressBarView;
+    __auto_type controlButton = self.fControlButton;
+    __auto_type revealButton = self.fRevealButton;
+
+    [NSLayoutConstraint activateConstraints:@[
+        // groupIndicatorView
+        [groupIndicatorView.leadingAnchor constraintEqualToAnchor:self.leadingAnchor],
+        [groupIndicatorView.centerYAnchor constraintEqualToAnchor:self.centerYAnchor],
+        [groupIndicatorView.widthAnchor constraintEqualToConstant:10],
+        [groupIndicatorView.heightAnchor constraintEqualToConstant:10],
+
+        // iconView
+        [iconView.leadingAnchor constraintEqualToAnchor:groupIndicatorView.trailingAnchor constant:3],
+        [iconView.centerYAnchor constraintEqualToAnchor:self.centerYAnchor],
+        [iconView.widthAnchor constraintEqualToConstant:36],
+        [iconView.heightAnchor constraintEqualToConstant:36],
+
+        // actionButton
+        [actionButton.centerXAnchor constraintEqualToAnchor:iconView.centerXAnchor],
+        [actionButton.centerYAnchor constraintEqualToAnchor:iconView.centerYAnchor],
+        [actionButton.widthAnchor constraintEqualToConstant:16],
+        [actionButton.heightAnchor constraintEqualToConstant:16],
+
+        // stackView
+        [stackView.leadingAnchor constraintEqualToAnchor:iconView.trailingAnchor constant:16],
+        [stackView.trailingAnchor constraintLessThanOrEqualToAnchor:torrentProgressBarView.trailingAnchor],
+        [stackView.topAnchor constraintEqualToAnchor:self.topAnchor constant:3],
+        [stackView.leadingAnchor constraintEqualToAnchor:torrentProgressField.leadingAnchor],
+
+        // torrentProgressField
+        [torrentProgressField.leadingAnchor constraintEqualToAnchor:torrentProgressBarView.leadingAnchor],
+        [torrentProgressField.trailingAnchor constraintEqualToAnchor:torrentProgressBarView.trailingAnchor],
+        [torrentProgressField.topAnchor constraintEqualToAnchor:stackView.bottomAnchor constant:1],
+
+        // torrentStatusField
+        [torrentStatusField.leadingAnchor constraintEqualToAnchor:torrentProgressBarView.leadingAnchor],
+        [torrentStatusField.trailingAnchor constraintEqualToAnchor:torrentProgressBarView.trailingAnchor],
+        [torrentStatusField.topAnchor constraintEqualToAnchor:torrentProgressBarView.bottomAnchor constant:1],
+        [torrentStatusField.bottomAnchor constraintEqualToAnchor:self.bottomAnchor constant:-1],
+
+        // torrentProgressBarView
+        [torrentProgressBarView.centerYAnchor constraintEqualToAnchor:torrentProgressBarView.centerYAnchor],
+        [torrentProgressBarView.heightAnchor constraintEqualToConstant:14],
+
+        // controlButton
+        [controlButton.leadingAnchor constraintEqualToAnchor:torrentProgressBarView.trailingAnchor constant:14],
+        [controlButton.centerYAnchor constraintEqualToAnchor:torrentProgressBarView.centerYAnchor],
+        [controlButton.widthAnchor constraintEqualToConstant:14],
+        [controlButton.heightAnchor constraintEqualToConstant:14],
+
+        // revealButton
+        [revealButton.leadingAnchor constraintEqualToAnchor:controlButton.trailingAnchor constant:3],
+        [revealButton.trailingAnchor constraintEqualToAnchor:self.trailingAnchor constant:-8],
+        [revealButton.centerYAnchor constraintEqualToAnchor:controlButton.centerYAnchor],
+        [revealButton.widthAnchor constraintEqualToConstant:14],
+        [revealButton.heightAnchor constraintEqualToConstant:14],
+    ]];
+}
 
 - (void)drawRect:(NSRect)dirtyRect
 {

--- a/macosx/TorrentCell.mm
+++ b/macosx/TorrentCell.mm
@@ -94,7 +94,6 @@
          ])
     {
         view.translatesAutoresizingMaskIntoConstraints = NO;
-        [self addSubview:view];
     }
 
     self.fGroupIndicatorView = groupIndicatorView;
@@ -121,6 +120,21 @@
     __auto_type torrentProgressBarView = self.fTorrentProgressBarView;
     __auto_type controlButton = self.fControlButton;
     __auto_type revealButton = self.fRevealButton;
+
+    for (NSView* view in @[
+             groupIndicatorView,
+             iconView,
+             actionButton,
+             stackView,
+             torrentProgressField,
+             torrentStatusField,
+             torrentProgressBarView,
+             controlButton,
+             revealButton,
+         ])
+    {
+        [self addSubview:view];
+    }
 
     [NSLayoutConstraint activateConstraints:@[
         // groupIndicatorView

--- a/macosx/TorrentCellActionButton.h
+++ b/macosx/TorrentCellActionButton.h
@@ -4,5 +4,7 @@
 
 #import <Cocoa/Cocoa.h>
 
+@class TorrentCell;
 @interface TorrentCellActionButton : NSButton
+@property(nonatomic, weak) IBOutlet TorrentCell* torrentCell;
 @end

--- a/macosx/TorrentCellActionButton.mm
+++ b/macosx/TorrentCellActionButton.mm
@@ -11,7 +11,6 @@
 @property(nonatomic) NSTrackingArea* fTrackingArea;
 @property(nonatomic) NSImage* fImage;
 @property(nonatomic) NSImage* fAlternativeImage;
-@property(nonatomic, weak) IBOutlet TorrentCell* torrentCell;
 @property(nonatomic, readonly) TorrentTableView* torrentTableView;
 @property(nonatomic) NSUserDefaults* fDefaults;
 @end
@@ -35,6 +34,23 @@
 
     // disable button click highlighting
     [self.cell setHighlightsBy:NSNoCellMask];
+}
+
+- (instancetype)initWithFrame:(NSRect)frameRect
+{
+    if (self = [super initWithFrame:frameRect])
+    {
+        self.fDefaults = NSUserDefaults.standardUserDefaults;
+        self.fImage = [NSImage imageNamed:@"ActionHover"];
+
+        // hide image by default and show only on hover
+        self.fAlternativeImage = [[NSImage alloc] init];
+        self.image = self.fAlternativeImage;
+
+        // disable button click highlighting
+        [self.cell setHighlightsBy:NSNoCellMask];
+    }
+    return self;
 }
 
 - (void)mouseEntered:(NSEvent*)event

--- a/macosx/TorrentCellControlButton.h
+++ b/macosx/TorrentCellControlButton.h
@@ -4,8 +4,10 @@
 
 #import <Cocoa/Cocoa.h>
 
+@class TorrentCell;
 @interface TorrentCellControlButton : NSButton
 
+@property(nonatomic, weak) IBOutlet TorrentCell* torrentCell;
 - (void)resetImage;
 
 @end

--- a/macosx/TorrentCellControlButton.mm
+++ b/macosx/TorrentCellControlButton.mm
@@ -10,7 +10,6 @@
 @interface TorrentCellControlButton ()
 @property(nonatomic) NSTrackingArea* fTrackingArea;
 @property(nonatomic, copy) NSString* controlImageSuffix;
-@property(nonatomic, weak) IBOutlet TorrentCell* torrentCell;
 @property(nonatomic, readonly) TorrentTableView* torrentTableView;
 @end
 
@@ -27,6 +26,16 @@
 
     self.controlImageSuffix = @"Off";
     [self updateImage];
+}
+
+- (instancetype)initWithFrame:(NSRect)frameRect
+{
+    if (self = [super initWithFrame:frameRect])
+    {
+        self.controlImageSuffix = @"Off";
+        [self updateImage];
+    }
+    return self;
 }
 
 - (void)resetImage

--- a/macosx/TorrentCellRevealButton.h
+++ b/macosx/TorrentCellRevealButton.h
@@ -4,5 +4,7 @@
 
 #import <Cocoa/Cocoa.h>
 
+@class TorrentCell;
 @interface TorrentCellRevealButton : NSButton
+@property(nonatomic, weak) IBOutlet TorrentCell* torrentCell;
 @end

--- a/macosx/TorrentCellRevealButton.mm
+++ b/macosx/TorrentCellRevealButton.mm
@@ -9,7 +9,6 @@
 @interface TorrentCellRevealButton ()
 @property(nonatomic) NSTrackingArea* fTrackingArea;
 @property(nonatomic, copy) NSString* revealImageString;
-@property(nonatomic, weak) IBOutlet TorrentCell* torrentCell;
 @property(nonatomic, readonly) TorrentTableView* torrentTableView;
 @end
 
@@ -26,6 +25,16 @@
 
     self.revealImageString = @"RevealOff";
     [self updateImage];
+}
+
+- (instancetype)initWithFrame:(NSRect)frameRect
+{
+    if (self = [super initWithFrame:frameRect])
+    {
+        self.revealImageString = @"RevealOff";
+        [self updateImage];
+    }
+    return self;
 }
 
 - (void)mouseEntered:(NSEvent*)event

--- a/macosx/TorrentTableView.mm
+++ b/macosx/TorrentTableView.mm
@@ -281,7 +281,17 @@ static NSTimeInterval const kToggleProgressSeconds = 0.175;
         }
         else
         {
-            torrentCell = [outlineView makeViewWithIdentifier:@"TorrentCell" owner:self];
+            torrentCell = [outlineView makeViewWithIdentifier:@"NewTorrentCell" owner:self];
+            if (!torrentCell)
+            {
+                torrentCell = [[TorrentCell alloc] initWithFrame:NSZeroRect];
+                torrentCell.identifier = @"NewTorrentCell";
+            }
+
+            ((TorrentCellControlButton*)torrentCell.fControlButton).torrentCell = torrentCell;
+            ((TorrentCellRevealButton*)torrentCell.fRevealButton).torrentCell = torrentCell;
+            ((TorrentCellActionButton*)torrentCell.fActionButton).torrentCell = torrentCell;
+
             torrentCell.fTorrentProgressField.stringValue = torrent.progressString;
 
             // set torrent icon and error badge

--- a/macosx/TorrentTableView.mm
+++ b/macosx/TorrentTableView.mm
@@ -250,7 +250,12 @@ static NSTimeInterval const kToggleProgressSeconds = 0.175;
         TorrentCell* torrentCell;
         if (minimal)
         {
-            torrentCell = [outlineView makeViewWithIdentifier:@"SmallTorrentCell" owner:self];
+            torrentCell = [outlineView makeViewWithIdentifier:@"NewSmallTorrentCell" owner:self];
+            if (!torrentCell)
+            {
+                torrentCell = [[SmallTorrentCell alloc] initWithFrame:NSZeroRect];
+                torrentCell.identifier = @"NewSmallTorrentCell";
+            }
 
             // set torrent icon or error badge
             torrentCell.fIconView.image = error ? [NSImage imageNamed:NSImageNameCaution] : torrent.icon;
@@ -278,6 +283,10 @@ static NSTimeInterval const kToggleProgressSeconds = 0.175;
                 torrentCell.fControlButton.hidden = YES;
                 torrentCell.fRevealButton.hidden = YES;
             }
+
+            ((TorrentCellControlButton*)torrentCell.fControlButton).torrentCell = torrentCell;
+            ((TorrentCellRevealButton*)torrentCell.fRevealButton).torrentCell = torrentCell;
+            ((TorrentCellActionButton*)torrentCell.fActionButton).torrentCell = torrentCell;
         }
         else
         {


### PR DESCRIPTION
To increase flexibility when editing the small torrent cell.
Based on #8547

Extracting the cell from the XIB unlocks:
1. Encapsulating static data inside the cell (e.g., `NSLocalizedString` or custom colors).
2. Implementing a proper `ProgressView` using `CALayer` to improve performance by offloading computations to the GPU.

### Results

This PR changes the behavior related to multiple invocations of `awakeFromNib` in `TorrentTableView` according to the [Apple documentation](https://apple.com).

> This method is usually called by the delegate in [tableView(_:viewFor:row:)](https://apple.com), but it can also be overridden to provide custom views for the identifier. Note that [awakeFromNib()](https://apple.com) is called each time this method is called, meaning that `awakeFromNib()` will trigger for the owner bundle repeatedly if the owner is passed down during instantiation.
