### PR TITLE
fix: prevent format string vulnerability in tr_getopt_usage()

### DIFF
--- a/libtransmission/tr-getopt.cc
+++ b/libtransmission/tr-getopt.cc
@@ -180,7 +180,13 @@ void tr_getopt_usage(char const* app_name, char const* description, struct tr_op
         description = "Usage: %s [options]";
     }
 
-    printf(description, app_name);
+    auto usage_line = std::string{ description };
+    auto const pos = usage_line.find("%s");
+    if (pos != std::string::npos)
+    {
+        usage_line.replace(pos, 2, app_name);
+    }
+    fputs(usage_line.c_str(), stdout);
     printf("\n\nOptions:\n");
     getopts_usage_line(&help, long_width, short_width, arg_width);
 


### PR DESCRIPTION
The \	r_getopt_usage()\ function passes the \description\ parameter directly as a format string to \printf()\, which could be exploited if a caller passes user-controllable text containing format specifiers.

This replaces \printf(description, app_name)\ with manual \%s\ substitution in a std::string copy, then outputs the result via \puts()\. No format specifiers from \description\ are ever interpreted by a printf-family function.

Notes: Fixed a format string vulnerability in command-line help display.