### PR TITLE
fix: replace unsafe signal() with sigaction() across codebase

### DIFF
--- a/cli/cli.cc
+++ b/cli/cli.cc
@@ -399,9 +399,12 @@ int tr_main(int argc, char* argv[])
         return EXIT_FAILURE;
     }
 
-    signal(SIGINT, sigHandler);
+    struct sigaction sa = {};
+    sa.sa_handler = sigHandler;
+    sigemptyset(&sa.sa_mask);
+    sigaction(SIGINT, &sa, nullptr);
 #ifndef _WIN32
-    signal(SIGHUP, sigHandler);
+    sigaction(SIGHUP, &sa, nullptr);
 #endif
     tr_torrentStart(tor);
 

--- a/libtransmission/session-thread.cc
+++ b/libtransmission/session-thread.cc
@@ -230,7 +230,10 @@ private:
     {
 #ifndef _WIN32
         /* Don't exit when writing on a broken socket */
-        (void)signal(SIGPIPE, SIG_IGN);
+        struct sigaction sa = {};
+        sa.sa_handler = SIG_IGN;
+        sigemptyset(&sa.sa_mask);
+        sigaction(SIGPIPE, &sa, nullptr);
 #endif
         tr_evthread_init();
 

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -756,7 +756,10 @@ void tr_session::initImpl(init_data& data)
 
 #ifndef _WIN32
     /* Don't exit when writing on a broken socket */
-    (void)signal(SIGPIPE, SIG_IGN);
+    struct sigaction sa = {};
+    sa.sa_handler = SIG_IGN;
+    sigemptyset(&sa.sa_mask);
+    sigaction(SIGPIPE, &sa, nullptr);
 #endif
 
     tr_logSetQueueEnabled(data.message_queuing_enabled);

--- a/libtransmission/subprocess-posix.cc
+++ b/libtransmission/subprocess-posix.cc
@@ -8,6 +8,7 @@
 #include <csignal>
 #include <cstdlib>
 #include <map>
+#include <mutex>
 #include <string>
 #include <string_view>
 
@@ -118,18 +119,25 @@ bool tr_spawn_async(
     std::string_view work_dir,
     tr_error* error)
 {
-    static bool sigchld_handler_set = false;
+    static std::once_flag sigchld_once;
 
-    if (!sigchld_handler_set)
+    int saved_errno = 0;
+    std::call_once(sigchld_once, [&]()
     {
-        /* FIXME: "The effects of signal() in a multithreaded process are unspecified." © man 2 signal */
-        if (signal(SIGCHLD, &handle_sigchld) == SIG_ERR) // NOLINT(performance-no-int-to-ptr)
+        struct sigaction sa = {};
+        sa.sa_handler = &handle_sigchld;
+        sigemptyset(&sa.sa_mask);
+        sa.sa_flags = SA_RESTART | SA_NOCLDSTOP;
+        if (sigaction(SIGCHLD, &sa, nullptr) == -1)
         {
-            set_system_error(error, errno, "Call to signal()");
-            return false;
+            saved_errno = errno;
         }
+    });
 
-        sigchld_handler_set = true;
+    if (saved_errno != 0)
+    {
+        set_system_error(error, saved_errno, "Call to sigaction()");
+        return false;
     }
 
     auto pipe_fds = std::array<int, 2>{};


### PR DESCRIPTION
POSIX specifies that \signal()\ has undefined behavior in multithreaded processes. This replaces all \signal()\ calls across the codebase with \sigaction()\, which is thread-safe.

Changes:
- **session-thread.cc**: SIGPIPE ignore in the session thread
- **session.cc**: SIGPIPE ignore during session initialization
- **subprocess-posix.cc**: SIGCHLD handler, also replaces the non-atomic \static bool\ guard with \std::once_flag\ + \std::call_once\ and adds \SA_RESTART | SA_NOCLDSTOP\ flags
- **cli.cc**: SIGINT and SIGHUP handlers for the CLI client

Notes: Fixed unsafe signal handling in multithreaded contexts that could cause undefined behavior per POSIX spec.