### PR TITLE
fix: redact the salted RPC password from the debug log

### DIFF
--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -963,7 +963,7 @@ void tr_rpc_server::set_password(std::string_view password) noexcept
 {
     auto const is_salted = tr_ssha1_test(password);
     settings_.salted_password = is_salted ? password : tr_ssha1(password);
-    tr_logAddDebug(fmt::format("setting our salted password to '{:s}'", settings_.salted_password));
+    tr_logAddDebug("setting salted password (value redacted)");
 }
 
 void tr_rpc_server::set_password_enabled(bool enabled)


### PR DESCRIPTION
`set_password()` wrote the salted RPC password to the debug log; this logs a
fixed placeholder instead so the credential never reaches the log.

This PR has been narrowed to a single change per review; the other hardening
changes from the original bundle are being split into their own focused PRs.

Notes: Stopped logging the salted RPC password at debug level.
