### PR TITLE
fix: correct unsigned underflow in bitfield count_flags()

### DIFF
--- a/libtransmission/bitfield.cc
+++ b/libtransmission/bitfield.cc
@@ -95,7 +95,7 @@ size_t tr_bitfield::count_flags(size_t begin, size_t end) const noexcept
 
         auto i = begin & 7U;
         val <<= i;
-        i = (begin - end) & 7U;
+        i = (end - begin) & 7U;
         val >>= i;
         ret = std::popcount(val);
     }
@@ -142,7 +142,7 @@ size_t tr_bitfield::count_flags(size_t begin, size_t end) const noexcept
         }
     }
 
-    TR_ASSERT(ret <= (begin - end));
+    TR_ASSERT(ret <= (end - begin));
     return ret;
 }
 


### PR DESCRIPTION
Fixes two reversed subtraction operands in \count_flags()\ in bitfield.cc where \(begin - end)\ was used instead of \(end - begin)\. Since \egin < end\ and both are \size_t\ (unsigned), the subtraction underflows to a very large value instead of the intended difference.

- **Line 98**: Shift amount \(begin - end) & 7U\ -> \(end - begin) & 7U\. This caused wrong bit counting for bitfields spanning a single byte.
- **Line 145**: Assertion \TR_ASSERT(ret <= (begin - end))\ -> \(end - begin)\. This made the assertion always true, providing no validation.

Notes: Fixed unsigned integer underflow that produced incorrect bit counts for single-byte bitfields.