### PR TITLE
fix: send keepalive messages to idle peers

### DIFF
--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -326,6 +326,8 @@ public:
         io_->set_callbacks(can_read, did_write, got_error, this);
         update_desired_request_count();
 
+        client_sent_at_ = tr_time();
+
         update_active();
     }
 
@@ -1811,6 +1813,8 @@ void tr_peerMsgsImpl::did_write(tr_peerIo* /*io*/, size_t bytes_written, bool wa
 {
     auto* const msgs = static_cast<tr_peerMsgsImpl*>(vmsgs);
 
+    msgs->client_sent_at_ = tr_time();
+
     if (was_piece_data)
     {
         msgs->peer_info->set_latest_piece_data_time(tr_time());
@@ -2039,6 +2043,7 @@ void tr_peerMsgsImpl::check_request_timeout(time_t const now)
     if (client_sent_at_ != 0 && now_sec - client_sent_at_ > KeepaliveIntervalSecs)
     {
         n_bytes_written += protocol_send_keepalive();
+        client_sent_at_ = now_sec;
     }
 
     return n_bytes_written;

--- a/tests/libtransmission/tr-peer-info-test.cc
+++ b/tests/libtransmission/tr-peer-info-test.cc
@@ -137,6 +137,9 @@ TEST_F(PeerInfoTest, updateCanonicalPriority)
         std::tuple{ "[2a03:2880:f177:1cd:face:b00c:0:167]:6882"sv,
                     "[2a03:2880:f177:1cd:face:b00c:0:167]:6881"sv,
                     uint32_t{ 0x67F8FE57 } },
+        // crc32-c(01020201); ports 258/513 sort differently in host order vs. network
+        // byte order, so unlike the pair above this case catches a sort/htons ordering bug
+        std::tuple{ "123.213.32.10:513"sv, "123.213.32.10:258"sv, uint32_t{ 0x0F63009F } },
     };
 
     for (auto const& [client_sockaddr_str, peer_sockaddr_str, expected] : Tests)


### PR DESCRIPTION
### Problem

`client_sent_at_` gates the periodic keepalive in `fill_output_buffer_impl()`
but was never assigned — it stayed `0`, so the keepalive branch never ran and
idle peers received no keepalive, which can drop otherwise-healthy connections.

### Fix

Assign `client_sent_at_`:
- when the peer connection is established,
- on every write to the peer (`did_write()`),
- and immediately after sending a keepalive.

The third assignment is the non-obvious one, and seeding the constructor plus
refreshing in `did_write()` alone is **not** sufficient. `fill_output_buffer_impl()`
runs inside `fill_output_buffer()`'s `while (... != 0)` loop, and
`protocol_send_keepalive()` returns a non-zero byte count, so the loop re-enters
with the same `now_sec`. `did_write()` only updates `client_sent_at_`
asynchronously once the socket flushes, which cannot happen while this thread is
spinning in the loop — so the guard stays true and keepalives are generated in an
infinite loop at 100% CPU with nothing ever reaching the wire.

I verified this on the wire against a minimal BitTorrent peer: with only the two
assignments the daemon livelocks (100% CPU, zero keepalives sent); resetting
`client_sent_at_` at send time exits the loop after a single keepalive, which is
then sent normally (observed one interval after the last write, ~108s with the
default 100s interval, daemon otherwise idle).

### Regression test

The original PR's BEP-40 port-sort change has been **dropped** — it was
backwards versus libtorrent, as noted in review. This keeps the existing
(correct) `sort` → `htons` order and adds the discriminating test that was
requested: the existing same-IP case (ports 6881/6882) sorts identically in host
and network byte order, so it cannot catch a sort/htons ordering mistake. Ports
258/513 flip their ordering under byte-swap, pinning the canonical priority to
crc32c of the byte stream `01 02 02 01` (0x0F63009F) — the stream libtorrent
produces. The full test suite passes, including this case.

Notes: Fixed a bug where keepalive messages were never sent to idle peers,
which could drop otherwise-healthy connections.
