### PR TITLE
fix: git hygiene and cross-platform portability improvements

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,15 @@
+* text=auto
+
+*.png binary
+*.ico binary
+*.icns binary
+*.jpg binary
+*.gif binary
+*.psd binary
+*.bmp binary
+*.torrent binary
+*.a binary
+
 # libtransmission
 libtransmission/mime-types.h linguist-generated=true
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,11 @@
 .idea
 .vscode
 .DS_Store
+Thumbs.db
+*.swp
+
+*.o
+*.obj
 
 /beta
 /build

--- a/code_style.sh
+++ b/code_style.sh
@@ -68,8 +68,12 @@ if [ -z "${clang_format_exe}" ]; then
 fi
 
 # format C/C++
-clang_format_args="$([ -n "$fix" ] && echo '-i' || echo '--dry-run --Werror')"
-if ! find_cfiles -exec "${clang_format_exe}" $clang_format_args '{}' '+'; then
+if [ -n "$fix" ]; then
+  clang_format_args=(-i)
+else
+  clang_format_args=(--dry-run --Werror)
+fi
+if ! find_cfiles -exec "${clang_format_exe}" "${clang_format_args[@]}" '{}' '+'; then
   [ -n "$fix" ] || echo 'C/C++ code needs formatting'
   exitcode=1
 fi

--- a/extras/send-email-when-torrent-done.sh
+++ b/extras/send-email-when-torrent-done.sh
@@ -6,7 +6,7 @@
 
 # Where "nail" is installed on your system.
 # We need this to actually send the mail, so make sure it's installed
-NAIL=/usr/bin/nail
+NAIL=$(command -v nail || echo /usr/bin/nail)
 
 # REQUIRED CHANGE #1: you must set SMTP_SERVER
 # http://www.host45.com/resources/ispsmtps.php has a list of ISP's smtp servers
@@ -47,7 +47,7 @@ SMTP_SERVER=your.smtp.server
 
 SUBJECT="Torrent Done!"
 FROM_ADDR="transmission@localhost.localdomain"
-TMPFILE=$(mktemp -t transmission.XXXXXXXXXX)
+TMPFILE=$(mktemp "${TMPDIR:-/tmp}/transmission.XXXXXXXXXX")
 echo "Transmission finished downloading \"$TR_TORRENT_NAME\" on $TR_TIME_LOCALTIME" > "$TMPFILE"
 $NAIL -v -S from="$FROM_ADDR" -S smtp -s "$SUBJECT" -S smtp=$SMTP_SERVER "$TO_ADDR" < "$TMPFILE"
 rm "$TMPFILE"

--- a/libtransmission/platform.cc
+++ b/libtransmission/platform.cc
@@ -331,6 +331,10 @@ std::string tr_getSessionIdDir()
 {
 #ifndef _WIN32
 
+    if (auto const dir = tr_env_get_string("TMPDIR"sv); !std::empty(dir))
+    {
+        return dir;
+    }
     return std::string{ "/tmp"sv };
 
 #else


### PR DESCRIPTION
Git hygiene and cross-platform fixes:

- **.gitattributes**: Add \* text=auto\ for automatic line-ending normalization preventing CRLF corruption on Windows checkouts. Add explicit binary declarations for image, icon, and other binary file types.
- **.gitignore**: Add missing patterns for \Thumbs.db\, vim swap files (\*.swp\), and compiled object files (\*.o\, \*.obj\).
- **platform.cc**: Respect \TMPDIR\ environment variable for session-id directory before falling back to \/tmp\, fixing sandboxed macOS apps and container environments where \/tmp\ may not be writable.
- **send-email-when-torrent-done.sh**: Use \command -v\ for nail path resolution instead of hardcoded \/usr/bin/nail\. Use POSIX-compatible \mktemp\ instead of the non-portable \-t\ flag.
- **code_style.sh**: Use bash array for clang-format arguments instead of unquoted string expansion to prevent word-splitting bugs.

Notes: Fixed portability issues for Windows developers, sandboxed macOS, and non-Linux Unix systems. Improved shell script robustness.