### PR TITLE
fix: directory handle leak and uint32 overflow

### DIFF
--- a/libtransmission/completion.cc
+++ b/libtransmission/completion.cc
@@ -213,7 +213,7 @@ uint64_t tr_completion::count_has_bytes_in_span(tr_byte_span_t span) const
     // the first block
     if (has_block(begin_block))
     {
-        uint64_t u = begin_block + 1;
+        uint64_t u = static_cast<uint64_t>(begin_block) + 1;
         u *= tr_block_info::BlockSize;
         u -= begin_byte;
         total += u;

--- a/libtransmission/torrent-files.cc
+++ b/libtransmission/torrent-files.cc
@@ -74,6 +74,18 @@ void depth_first_walk(std::string_view const path, file_func_t const& func, std:
     {
         if (auto const odir = tr_sys_dir_open(path); odir != TR_BAD_SYS_DIR)
         {
+            struct DirGuard
+            {
+                tr_sys_dir_t h;
+                ~DirGuard()
+                {
+                    if (h != TR_BAD_SYS_DIR)
+                    {
+                        tr_sys_dir_close(h);
+                    }
+                }
+            } guard{ odir };
+
             char const* name_cstr = nullptr;
             while ((name_cstr = tr_sys_dir_read_name(odir)) != nullptr)
             {
@@ -85,8 +97,6 @@ void depth_first_walk(std::string_view const path, file_func_t const& func, std:
 
                 depth_first_walk(tr_pathbuf{ path, '/', name }, func, max_depth ? *max_depth - 1 : max_depth);
             }
-
-            tr_sys_dir_close(odir);
         }
     }
 


### PR DESCRIPTION
Two defensive fixes:

- **torrent-files.cc**: Wrap directory handle in a RAII guard (`DirGuard` struct with destructor) in `depth_first_walk()` to prevent leaking the handle if the recursive call throws an exception. Previously `tr_sys_dir_close()` would be skipped during stack unwinding.
- **completion.cc**: Cast `begin_block` to `uint64_t` before adding 1 to prevent `uint32_t` overflow for torrents approaching 64 TiB with 16 KiB blocks.

Notes: Fixed potential resource leak during torrent file enumeration. Fixed integer overflow in completion size calculation for very large torrents.