### PR TITLE
fix: make tr_torrentStat() non-blocking off the session thread

### DIFF
--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -456,6 +456,11 @@ public:
         return std::unique_lock(session_mutex_);
     }
 
+    [[nodiscard]] auto try_unique_lock() const
+    {
+        return std::unique_lock(session_mutex_, std::try_to_lock);
+    }
+
     [[nodiscard]] constexpr auto const& settings() const noexcept
     {
         return settings_;

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -10,10 +10,13 @@
 #include <cstddef> // size_t
 #include <ctime>
 #include <map>
+#include <memory>
+#include <mutex>
 #include <sstream>
 #include <ranges>
 #include <string>
 #include <string_view>
+#include <tuple> // std::ignore
 #include <utility>
 #include <vector>
 
@@ -1037,6 +1040,10 @@ void tr_torrent::init(tr_ctor const& ctor)
     {
         date_done_ = now_sec;
     }
+
+    // seed stats_snapshot_ so tr_torrentStat() has a fallback
+    // if its first call comes while the session lock is contended
+    std::ignore = stats();
 }
 
 void tr_torrent::set_metainfo(tr_torrent_metainfo tm)
@@ -1392,12 +1399,35 @@ tr_stat tr_torrent::stats() const
     TR_ASSERT(stats.size_when_done <= this->total_size());
     TR_ASSERT(stats.left_until_done <= stats.size_when_done);
     TR_ASSERT(stats.desired_available <= stats.left_until_done);
+
+    {
+        auto const snapshot_lock = std::lock_guard{ stats_snapshot_mutex_ };
+        stats_snapshot_ = std::make_shared<tr_stat const>(stats);
+    }
+
     return stats;
 }
 
 tr_stat tr_torrentStat(tr_torrent* const tor)
 {
     tr_return_val_if_fail(tr_isTorrent(tor), {});
+
+    if (tor->session->am_in_session_thread())
+    {
+        return tor->stats();
+    }
+
+    if (auto const lock = tor->session->try_unique_lock(); lock)
+    {
+        return tor->stats();
+    }
+
+    // The session thread is holding the lock, possibly blocked on slow
+    // disk I/O. Return the most recent snapshot rather than blocking.
+    if (auto const snapshot = tor->stats_snapshot(); snapshot)
+    {
+        return *snapshot;
+    }
 
     return tor->stats();
 }
@@ -1413,11 +1443,24 @@ std::vector<tr_stat> tr_torrentStat(tr_torrent* const* torrents, size_t n_torren
     {
         ret.reserve(n_torrents);
 
-        auto const lock = torrents[0]->unique_lock();
+        auto* const session = torrents[0]->session;
 
-        for (size_t idx = 0U; idx != n_torrents; ++idx)
+        if (auto const lock = session->try_unique_lock(); lock || session->am_in_session_thread())
         {
-            ret.emplace_back(torrents[idx]->stats());
+            for (size_t idx = 0U; idx != n_torrents; ++idx)
+            {
+                ret.emplace_back(torrents[idx]->stats());
+            }
+        }
+        else
+        {
+            // The session thread is holding the lock, possibly blocked on slow
+            // disk I/O. Return the most recent snapshots rather than blocking.
+            for (size_t idx = 0U; idx != n_torrents; ++idx)
+            {
+                auto const snapshot = torrents[idx]->stats_snapshot();
+                ret.emplace_back(snapshot ? *snapshot : torrents[idx]->stats());
+            }
         }
     }
 

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -14,6 +14,7 @@
 #include <ctime>
 #include <functional>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <span>
 #include <string>
@@ -645,6 +646,14 @@ struct tr_torrent
     ///
 
     [[nodiscard]] tr_stat stats() const;
+
+    // the most recent stats() result, readable without the session lock.
+    // may be stale; empty until stats() has run at least once.
+    [[nodiscard]] std::shared_ptr<tr_stat const> stats_snapshot() const
+    {
+        auto const lock = std::lock_guard{ stats_snapshot_mutex_ };
+        return stats_snapshot_;
+    }
 
     [[nodiscard]] constexpr auto queue_direction() const noexcept
     {
@@ -1390,6 +1399,13 @@ private:
     tr_sha1_digest_t obfuscated_hash_ = {};
 
     mutable SimpleSmoothedSpeed eta_speed_;
+
+    // copy of the last stats() result, served by tr_torrentStat() when the
+    // session mutex is contended so UI polling never blocks behind disk I/O.
+    // stats_snapshot_mutex_ is a leaf lock: hold it only to copy the pointer,
+    // never while acquiring the session lock or calling out.
+    mutable std::shared_ptr<tr_stat const> stats_snapshot_;
+    mutable std::mutex stats_snapshot_mutex_;
 
     tr_files_wanted files_wanted_{ &fpm_ };
     tr_file_priorities file_priorities_{ &fpm_ };

--- a/tests/libtransmission/torrent-test.cc
+++ b/tests/libtransmission/torrent-test.cc
@@ -4,8 +4,13 @@
 // License text can be found in the licenses/ folder.
 
 #include <array>
+#include <atomic>
 #include <cstddef>
+#include <future>
 #include <ranges>
+#include <thread>
+
+#include <libtransmission/transmission.h>
 
 #include <libtransmission/torrent.h>
 
@@ -125,4 +130,46 @@ TEST_F(TorrentTest, queueMoveBottom)
     {
         EXPECT_EQ(ExpectedQueuePosition[i], torrents[i]->queue_position()) << i;
     }
+}
+
+TEST_F(TorrentTest, statDoesNotBlockWhenSessionLockIsContended)
+{
+    auto* const tor = torrentInitFromFile(TorFilenames[0]);
+
+    // refresh the snapshot with an uncontended call
+    auto const baseline = tr_torrentStat(tor);
+
+    // hold the session lock on another thread, simulating a session
+    // thread that's stuck in slow disk I/O
+    auto lock_held = std::atomic<bool>{ false };
+    auto locked = std::promise<void>{};
+    auto release = std::promise<void>{};
+    auto blocker = std::thread(
+        [tor, &lock_held, &locked, &release]()
+        {
+            auto const lock = tor->unique_lock();
+            lock_held = true;
+            locked.set_value();
+            release.get_future().wait();
+            lock_held = false;
+        });
+    locked.get_future().wait();
+
+    // `lock_held` can only be cleared after `release` is set, so if these
+    // calls had blocked on the lock, it would still read true afterwards
+    auto const stats = tr_torrentStat(tor);
+    EXPECT_TRUE(lock_held) << "tr_torrentStat() blocked until the session lock was released";
+    EXPECT_EQ(baseline.id, stats.id);
+    EXPECT_EQ(baseline.activity, stats.activity);
+
+    auto const batched = tr_torrentStat(&tor, 1U);
+    EXPECT_TRUE(lock_held) << "batched tr_torrentStat() blocked until the session lock was released";
+    ASSERT_EQ(1U, std::size(batched));
+    EXPECT_EQ(baseline.id, batched.front().id);
+
+    release.set_value();
+    blocker.join();
+
+    auto const fresh = tr_torrentStat(tor);
+    EXPECT_EQ(baseline.id, fresh.id);
 }


### PR DESCRIPTION
Makes tr_torrentStat() non-blocking for callers outside the session thread. Each time stats are computed, a snapshot is saved; if a caller can't acquire the session lock immediately, it gets the most recent snapshot instead of waiting. During a disk stall the UI now shows briefly stale numbers rather than beachballing, and values self-correct on the next tick once the lock frees up. Behavior on the session thread itself is unchanged. ref #8928 