### PR TITLE
fix: reject non-http(s) blocklist URLs

### DIFF
--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -2199,11 +2199,22 @@ using SessionAccessors = std::pair<SessionGetter, SessionSetter>;
     map.try_emplace(
         TR_KEY_blocklist_url,
         [](tr_session const& src) -> tr_variant { return src.blocklistUrl(); },
-        [](tr_session& tgt, tr_variant const& src, ErrorInfo& /*err*/)
+        [](tr_session& tgt, tr_variant const& src, ErrorInfo& err)
         {
             if (auto const val = src.value_if<std::string_view>())
             {
-                tgt.setBlocklistUrl(*val);
+                if (!tr_urlIsValid(*val))
+                {
+                    err = { JsonRpc::Error::INVALID_PARAMS, "invalid URL" };
+                }
+                else if (auto const parsed = tr_urlParse(*val); parsed && parsed->scheme != "http" && parsed->scheme != "https")
+                {
+                    err = { JsonRpc::Error::INVALID_PARAMS, "only http and https URLs are allowed" };
+                }
+                else
+                {
+                    tgt.setBlocklistUrl(*val);
+                }
             }
         });
 


### PR DESCRIPTION
The blocklist URL is fetched with libcurl (set verbatim as `CURLOPT_URL`) and
nothing sets `CURLOPT_PROTOCOLS`, so libcurl accepts its default scheme set —
including non-HTTP schemes like `file://`, `ftp://`, `gopher://`, `dict://` (and
`scp://`/`sftp://` when built with SSH). Since the URL is RPC-settable, a client
could make the daemon read from its own local filesystem (`file://`) or originate
arbitrary non-web requests to internal hosts/ports (`gopher://`/`dict://` — blind
SSRF / request smuggling). The body is parsed as a blocklist and only the rule
count is returned, so it isn't content disclosure, but the daemon still performs
the access. A blocklist is only ever http(s), so it now rejects any other scheme.

Verified on the wire: setting the blocklist URL over RPC to `file://`, `ftp://`,
`gopher://`, `dict://`, `scp://` and `udp://` is rejected, while `http://` and
`https://` are accepted.

Split out from #8987 per review.

Notes: The blocklist URL set over RPC now only accepts http and https URLs.
