### PR TITLE
fix: migrate 4.0.x resume data for torrents with zero-length files

### DIFF
--- a/libtransmission/quark.cc
+++ b/libtransmission/quark.cc
@@ -487,6 +487,7 @@ auto constexpr MyStatic = std::array<std::string_view, TR_N_KEYS>{
     "rename_partial_files"sv, // rpc, tr_session::Settings
     "reqq"sv, // BEP0010; BT protocol, rpc, tr_session::Settings
     "result"sv, // rpc
+    "resume_filenames_need_verification"sv, // .resume
     "rpc-authentication-required"sv, // daemon, rpc server settings
     "rpc-bind-address"sv, // daemon, rpc server settings
     "rpc-enabled"sv, // daemon, rpc server settings

--- a/libtransmission/quark.h
+++ b/libtransmission/quark.h
@@ -498,6 +498,7 @@ enum // NOLINT(performance-enum-size)
     TR_KEY_rename_partial_files,
     TR_KEY_reqq,
     TR_KEY_result,
+    TR_KEY_resume_filenames_need_verification,
     TR_KEY_rpc_authentication_required_kebab_APICOMPAT,
     TR_KEY_rpc_bind_address_kebab_APICOMPAT,
     TR_KEY_rpc_enabled_kebab_APICOMPAT,

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -9,7 +9,10 @@
 #include <cstring>
 #include <ctime>
 #include <limits>
+#include <optional>
+#include <string>
 #include <string_view>
+#include <unordered_set>
 #include <vector>
 
 #include <fmt/format.h>
@@ -398,7 +401,137 @@ void save_filenames(tr_variant::Map& map, tr_torrent const* tor)
     map.insert_or_assign(TR_KEY_files, std::move(list));
 }
 
-tr_resume::fields_t load_filenames(tr_variant::Map const& map, tr_torrent* tor)
+auto validated_filenames(tr_variant::Vector const& list, tr_torrent const* tor, bool const log_errors)
+    -> std::optional<std::vector<std::string>>
+{
+    auto const n_files = tor->file_count();
+    auto const n_list = std::size(list);
+    if (n_list != n_files)
+    {
+        if (log_errors)
+        {
+            tr_logAddWarnTor(
+                tor,
+                fmt::format("Couldn't load filenames from resume file: expected {} entries, got {}", n_files, n_list));
+        }
+        return {};
+    }
+
+    // Empty entries are valid in resume files written by Transmission 3.x
+    // and mean "use the path from metainfo".
+    auto filenames = std::vector<std::string>{};
+    filenames.reserve(n_files);
+    // The owning vector is fully reserved before string_views into its strings
+    // are stored in the set, so the views stay valid throughout validation.
+    auto unique_filenames = std::unordered_set<std::string_view>{};
+    unique_filenames.reserve(n_files);
+
+    for (tr_file_index_t i = 0; i < n_files; ++i)
+    {
+        auto const sv = list[i].value_if<std::string_view>();
+        if (!sv)
+        {
+            if (log_errors)
+            {
+                tr_logAddWarnTor(tor, fmt::format("Couldn't load filename {} from resume file: invalid value", i));
+            }
+            return {};
+        }
+
+        filenames.emplace_back(std::empty(*sv) ? tor->file_subpath(i) : *sv);
+        auto const& filename = filenames.back();
+        if (!unique_filenames.emplace(std::string_view{ filename }).second)
+        {
+            if (log_errors)
+            {
+                tr_logAddWarnTor(tor, fmt::format("Couldn't load filenames from resume file: duplicate path '{:s}'", filename));
+            }
+            return {};
+        }
+    }
+
+    return filenames;
+}
+
+bool migrate_legacy_zero_file_layout(tr_variant::Map& map, tr_torrent* tor, tr_torrent::ResumeHelper& helper)
+{
+    auto const n_files = tor->file_count();
+    auto n_zero_files = tr_file_index_t{};
+    for (tr_file_index_t file = 0; file < n_files; ++file)
+    {
+        n_zero_files += tor->file_size(file) == 0U ? 1U : 0U;
+    }
+
+    if (n_zero_files == 0U)
+    {
+        return false;
+    }
+
+    auto* const filenames = map.find_if<tr_variant::Vector>(TR_KEY_files);
+    auto* const dnd = map.find_if<tr_variant::Vector>(TR_KEY_dnd);
+    auto* const priorities = map.find_if<tr_variant::Vector>(TR_KEY_priority);
+    auto* const progress = map.find_if<tr_variant::Map>(TR_KEY_progress);
+    auto* const mtimes = progress != nullptr ? progress->find_if<tr_variant::Vector>(TR_KEY_mtimes) : nullptr;
+    auto const n_legacy_files = n_files - n_zero_files;
+
+    // Transmission 4.0.x omitted zero-length files from its in-memory file
+    // list, so all four per-file arrays were saved with this shorter length.
+    // Require the complete signature before treating a short resume file as
+    // that legacy layout rather than arbitrary corruption.
+    if (filenames == nullptr || dnd == nullptr || priorities == nullptr || mtimes == nullptr ||
+        std::size(*filenames) != n_legacy_files || std::size(*dnd) != n_legacy_files ||
+        std::size(*priorities) != n_legacy_files || std::size(*mtimes) != n_legacy_files)
+    {
+        return false;
+    }
+
+    auto const expand = [tor, n_files](tr_variant::Vector const& old, auto&& make_zero_value)
+    {
+        auto expanded = tr_variant::Vector{};
+        expanded.reserve(n_files);
+        auto old_index = size_t{};
+        for (tr_file_index_t file = 0; file < n_files; ++file)
+        {
+            if (tor->file_size(file) == 0U)
+            {
+                expanded.emplace_back(make_zero_value(file));
+            }
+            else
+            {
+                expanded.emplace_back(old[old_index++].clone());
+            }
+        }
+        return expanded;
+    };
+
+    auto expanded_filenames = expand(
+        *filenames,
+        [tor](tr_file_index_t const file) { return tr_variant{ tor->file_subpath(file) }; });
+    if (!validated_filenames(expanded_filenames, tor, false))
+    {
+        return false;
+    }
+
+    auto expanded_dnd = expand(*dnd, [](tr_file_index_t) { return tr_variant{ false }; });
+    auto expanded_priorities = expand(*priorities, [](tr_file_index_t) { return tr_variant{ TR_PRI_NORMAL }; });
+    auto expanded_mtimes = expand(*mtimes, [](tr_file_index_t) { return tr_variant{ int64_t{ 0 } }; });
+
+    *filenames = std::move(expanded_filenames);
+    *dnd = std::move(expanded_dnd);
+    *priorities = std::move(expanded_priorities);
+    *mtimes = std::move(expanded_mtimes);
+
+    helper.load_resume_filenames_need_verification(true);
+    tr_logAddWarnTor(
+        tor,
+        fmt::format(
+            "Migrated resume data by restoring {} zero-length file entr{}; local data must be verified",
+            n_zero_files,
+            n_zero_files == 1U ? "y" : "ies"));
+    return true;
+}
+
+tr_resume::fields_t load_filenames(tr_variant::Map const& map, tr_torrent* tor, tr_torrent::ResumeHelper& helper)
 {
     auto const* const list = map.find_if<tr_variant::Vector>(TR_KEY_files);
     if (list == nullptr)
@@ -406,14 +539,16 @@ tr_resume::fields_t load_filenames(tr_variant::Map const& map, tr_torrent* tor)
         return {};
     }
 
-    auto const n_files = tor->file_count();
-    auto const n_list = std::size(*list);
-    for (tr_file_index_t i = 0; i < n_files && i < n_list; ++i)
+    auto const filenames = validated_filenames(*list, tor, true);
+    if (!filenames)
     {
-        if (auto const sv = (*list)[i].value_if<std::string_view>(); sv && !std::empty(*sv))
-        {
-            tor->set_file_subpath(i, *sv);
-        }
+        helper.load_resume_filenames_need_verification(true);
+        return {};
+    }
+
+    for (tr_file_index_t i = 0, n = tor->file_count(); i < n; ++i)
+    {
+        tor->set_file_subpath(i, (*filenames)[i]);
     }
 
     return tr_resume::Filenames;
@@ -646,13 +781,13 @@ tr_resume::fields_t load_from_file(tr_torrent* tor, tr_torrent::ResumeHelper& he
     }
 
     tr::api_compat::convert_incoming_data(*otop);
-    auto const* const p_map = otop->get_if<tr_variant::Map>();
+    auto* const p_map = otop->get_if<tr_variant::Map>();
     if (p_map == nullptr)
     {
         tr_logAddDebugTor(tor, fmt::format("Resume file '{}' does not contain a benc dict", filename));
         return {};
     }
-    auto const& map = *p_map;
+    auto& map = *p_map;
 
     tr_logAddDebugTor(tor, fmt::format("Read resume file '{}'", filename));
     auto fields_loaded = tr_resume::fields_t{};
@@ -802,7 +937,13 @@ tr_resume::fields_t load_from_file(tr_torrent* tor, tr_torrent::ResumeHelper& he
     // will know where to look
     if ((fields_to_load & tr_resume::Filenames) != 0)
     {
-        fields_loaded |= load_filenames(map, tor);
+        if (auto const b = map.value_if<bool>(TR_KEY_resume_filenames_need_verification); b && *b)
+        {
+            helper.load_resume_filenames_need_verification(true);
+        }
+
+        migrate_legacy_zero_file_layout(map, tor, helper);
+        fields_loaded |= load_filenames(map, tor, helper);
     }
 
     // Note: load_progress() should come before load_file_priorities()
@@ -974,6 +1115,10 @@ void save(tr_torrent* const tor, tr_torrent::ResumeHelper const& helper)
     map.try_emplace(TR_KEY_max_peers, tor->peer_limit());
     map.try_emplace(TR_KEY_bandwidth_priority, tor->get_priority());
     map.try_emplace(TR_KEY_paused, !helper.start_when_stable());
+    if (helper.resume_filenames_need_verification())
+    {
+        map.try_emplace(TR_KEY_resume_filenames_need_verification, true);
+    }
     map.try_emplace(TR_KEY_sequential_download, tor->is_sequential_download());
     map.try_emplace(TR_KEY_sequential_download_from_piece, tor->sequential_download_from_piece());
     save_peers(map, tor);

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -601,6 +601,37 @@ void freeTorrent(tr_torrent* tor)
 } // namespace start_stop_helpers
 } // namespace
 
+bool tr_torrent::set_local_error_if_resume_filenames_need_verification()
+{
+    if (!resume_filenames_need_verification_)
+    {
+        return false;
+    }
+
+    tr_logAddTraceTor(this, "Invalid file paths were found in the resume data");
+    error().set_local_error(
+        _("Paused torrent because invalid file paths were found in its resume data. "
+          "Restore the filenames if necessary, then use \"Verify Local Data\"."));
+    return true;
+}
+
+bool tr_torrent::clear_resume_filenames_need_verification()
+{
+    if (!resume_filenames_need_verification_)
+    {
+        return false;
+    }
+
+    resume_filenames_need_verification_ = false;
+    if (error().is_local_error())
+    {
+        error().clear();
+    }
+
+    set_dirty();
+    return true;
+}
+
 // has_any_local_data is true or false if we know whether or not local data exists,
 // or unset if we don't know and need to check for ourselves
 void tr_torrent::start(bool bypass_queue, std::optional<bool> has_any_local_data)
@@ -608,6 +639,16 @@ void tr_torrent::start(bool bypass_queue, std::optional<bool> has_any_local_data
     using namespace start_stop_helpers;
 
     auto const lock = unique_lock();
+
+    // Loading the canonical metainfo paths while retaining completion data
+    // from a conflicting resume file could make us transfer corrupt bytes.
+    // Keep the torrent stopped until the user verifies its local data.
+    if (set_local_error_if_resume_filenames_need_verification())
+    {
+        start_when_stable_ = false;
+        set_is_queued(false);
+        return;
+    }
 
     switch (activity())
     {
@@ -1029,7 +1070,10 @@ void tr_torrent::init(tr_ctor const& ctor)
     }
     else
     {
-        set_local_error_if_files_disappeared(this, has_any_local_data);
+        if (!set_local_error_if_resume_filenames_need_verification())
+        {
+            set_local_error_if_files_disappeared(this, has_any_local_data);
+        }
     }
 
     // Recover from the bug reported at https://github.com/transmission/transmission/issues/6899
@@ -1597,7 +1641,11 @@ void tr_torrentVerify(tr_torrent* tor)
                 tor->stop_now();
             }
 
-            if (did_files_disappear(tor))
+            if (tor->set_local_error_if_resume_filenames_need_verification())
+            {
+                tor->start_when_stable_ = false;
+            }
+            else if (did_files_disappear(tor))
             {
                 tor->error().set_local_error(
                     _("Paused torrent as no data was found! Ensure your drives are connected or use \"Set Location\", "
@@ -1731,7 +1779,14 @@ void tr_torrent::VerifyMediator::on_verify_done(bool const aborted)
                     tor->update_file_path(file, {});
                 }
 
+                auto const repaired_resume_filenames = tor->clear_resume_filenames_need_verification();
+
                 tor->recheck_completeness();
+
+                if (repaired_resume_filenames)
+                {
+                    tor->save_resume_file();
+                }
 
                 if (tor->verify_done_callback_)
                 {
@@ -2689,6 +2744,18 @@ void tr_torrent::ResumeHelper::load_incomplete_dir(std::string_view const dir) n
     {
         tor_.current_dir_ = tor_.incomplete_dir_;
     }
+}
+
+// ---
+
+void tr_torrent::ResumeHelper::load_resume_filenames_need_verification(bool const val) noexcept
+{
+    tor_.resume_filenames_need_verification_ = val;
+}
+
+bool tr_torrent::ResumeHelper::resume_filenames_need_verification() const noexcept
+{
+    return tor_.resume_filenames_need_verification_;
 }
 
 // ---

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -60,6 +60,7 @@ namespace tr::test
 
 class RenameTest_multifileTorrent_Test;
 class RenameTest_singleFilenameTorrent_Test;
+class ResumeTest;
 
 } // namespace tr::test
 
@@ -79,6 +80,7 @@ struct tr_torrent
         void load_incomplete_dir(std::string_view dir) noexcept;
         void load_seconds_downloading_before_current_start(time_t when) noexcept;
         void load_seconds_seeding_before_current_start(time_t when) noexcept;
+        void load_resume_filenames_need_verification(bool val) noexcept;
         void load_start_when_stable(bool val) noexcept;
 
         [[nodiscard]] tr_bitfield const& blocks() const noexcept;
@@ -89,11 +91,13 @@ struct tr_torrent
         [[nodiscard]] time_t date_done() const noexcept;
         [[nodiscard]] time_t seconds_downloading(time_t now) const noexcept;
         [[nodiscard]] time_t seconds_seeding(time_t now) const noexcept;
+        [[nodiscard]] bool resume_filenames_need_verification() const noexcept;
         [[nodiscard]] bool start_when_stable() const noexcept;
 
     private:
         friend class tr::test::RenameTest_multifileTorrent_Test;
         friend class tr::test::RenameTest_singleFilenameTorrent_Test;
+        friend class tr::test::ResumeTest;
         friend struct tr_torrent;
 
         explicit ResumeHelper(tr_torrent& tor)
@@ -1341,6 +1345,9 @@ private:
 
     void start_in_session_thread();
 
+    [[nodiscard]] bool set_local_error_if_resume_filenames_need_verification();
+    [[nodiscard]] bool clear_resume_filenames_need_verification();
+
     void stop_now();
 
     [[nodiscard]] bool is_new_torrent_a_seed();
@@ -1441,6 +1448,8 @@ private:
     bool finished_seeding_by_idle_ = false;
 
     bool needs_completeness_check_ = true;
+
+    bool resume_filenames_need_verification_ = false;
 
     bool sequential_download_ = false;
 

--- a/tests/libtransmission/CMakeLists.txt
+++ b/tests/libtransmission/CMakeLists.txt
@@ -41,6 +41,7 @@ target_sources(libtransmission-test
         quark-test.cc
         remove-test.cc
         rename-test.cc
+        resume-test.cc
         rpc-test.cc
         serializer-tests.cc
         session-alt-speeds-test.cc

--- a/tests/libtransmission/resume-test.cc
+++ b/tests/libtransmission/resume-test.cc
@@ -1,0 +1,387 @@
+// This file Copyright © Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
+
+#include <array>
+#include <cstdint>
+#include <initializer_list>
+#include <iterator>
+#include <string_view>
+#include <utility>
+
+#include <libtransmission/transmission.h>
+
+#include <libtransmission/crypto-utils.h>
+#include <libtransmission/error.h>
+#include <libtransmission/quark.h>
+#include <libtransmission/resume.h>
+#include <libtransmission/torrent-ctor.h>
+#include <libtransmission/torrent.h>
+#include <libtransmission/variant.h>
+
+#include "gtest/gtest.h"
+#include "test-fixtures.h"
+
+using namespace std::literals;
+
+namespace tr::test
+{
+
+class ResumeTest : public SessionTest
+{
+protected:
+    static constexpr auto OriginalFilenames = std::array<std::string_view, 6>{
+        "root/zero-first"sv, "root/a"sv, "root/zero"sv, "root/b"sv, "root/c"sv, "root/zero-last"sv,
+    };
+
+    void SetUp() override
+    {
+        SessionTest::SetUp();
+
+        ctor_ = tr_ctorNew(session_);
+        auto const metainfo = tr_base64_decode(
+            "ZDQ6aW5mb2Q1OmZpbGVzbGQ2Omxlbmd0aGkwZTQ6cGF0aGwxMDp6ZXJvLWZpcnN0ZWVkNjpsZW5n"
+            "dGhpMWU0OnBhdGhsMTphZWVkNjpsZW5ndGhpMGU0OnBhdGhsNDp6ZXJvZWVkNjpsZW5ndGhpMWU0"
+            "OnBhdGhsMTpiZWVkNjpsZW5ndGhpMWU0OnBhdGhsMTpjZWVkNjpsZW5ndGhpMGU0OnBhdGhsOTp6"
+            "ZXJvLWxhc3RlZWU0Om5hbWU0OnJvb3QxMjpwaWVjZSBsZW5ndGhpMTYzODRlNjpwaWVjZXMyMDqp"
+            "mT42RwaBaro+JXF4UMJsnNDYnWVl");
+        auto error = tr_error{};
+        ASSERT_TRUE(tr_ctorSetMetainfo(ctor_, std::data(metainfo), std::size(metainfo), &error));
+        ASSERT_FALSE(error) << error;
+        tr_ctorSetPaused(ctor_, TR_FORCE, true);
+
+        tor_ = createTorrentAndWaitForVerifyDone(ctor_);
+        ASSERT_NE(nullptr, tor_);
+        ASSERT_EQ(OriginalFilenames.size(), tor_->file_count());
+        expectOriginalFilenames();
+    }
+
+    void TearDown() override
+    {
+        if (ctor_ != nullptr)
+        {
+            tr_ctorFree(ctor_);
+        }
+        SessionTest::TearDown();
+    }
+
+    void writeResume(tr_variant::Map map)
+    {
+        ASSERT_TRUE(tr_variant_serde::benc().to_file(tr_variant{ std::move(map) }, tor_->resume_file()));
+    }
+
+    void writeFilenames(std::initializer_list<std::string_view> filenames, bool const needs_verification = false)
+    {
+        auto list = tr_variant::Vector{};
+        list.reserve(filenames.size());
+        for (auto const filename : filenames)
+        {
+            list.emplace_back(tr_variant::unmanaged_string(filename));
+        }
+
+        auto map = tr_variant::Map{};
+        map.try_emplace(TR_KEY_files, std::move(list));
+        if (needs_verification)
+        {
+            map.try_emplace(TR_KEY_resume_filenames_need_verification, true);
+        }
+        writeResume(std::move(map));
+    }
+
+    tr_resume::fields_t loadFilenames()
+    {
+        auto helper = tr_torrent::ResumeHelper{ *tor_ };
+        return tr_resume::load(tor_, helper, tr_resume::Filenames, *ctor_);
+    }
+
+    tr_resume::fields_t loadFields(tr_resume::fields_t const fields)
+    {
+        auto helper = tr_torrent::ResumeHelper{ *tor_ };
+        return tr_resume::load(tor_, helper, fields, *ctor_);
+    }
+
+    void writeLegacyZeroFileLayout(
+        std::array<std::string_view, 3> const& filenames,
+        std::array<bool, 3> const& dnd,
+        std::array<tr_priority_t, 3> const& priorities,
+        std::array<time_t, 3> const& mtimes)
+    {
+        auto filename_list = tr_variant::Vector{};
+        auto dnd_list = tr_variant::Vector{};
+        auto priority_list = tr_variant::Vector{};
+        auto mtime_list = tr_variant::Vector{};
+        for (size_t i = 0; i < filenames.size(); ++i)
+        {
+            filename_list.emplace_back(tr_variant::unmanaged_string(filenames[i]));
+            dnd_list.emplace_back(dnd[i]);
+            priority_list.emplace_back(priorities[i]);
+            mtime_list.emplace_back(mtimes[i]);
+        }
+
+        auto progress = tr_variant::Map{};
+        progress.try_emplace(TR_KEY_mtimes, std::move(mtime_list));
+
+        auto map = tr_variant::Map{};
+        map.try_emplace(TR_KEY_files, std::move(filename_list));
+        map.try_emplace(TR_KEY_dnd, std::move(dnd_list));
+        map.try_emplace(TR_KEY_priority, std::move(priority_list));
+        map.try_emplace(TR_KEY_progress, std::move(progress));
+        writeResume(std::move(map));
+    }
+
+    void saveResume()
+    {
+        auto const helper = tr_torrent::ResumeHelper{ *tor_ };
+        tr_resume::save(tor_, helper);
+    }
+
+    [[nodiscard]] bool resumeFilenamesNeedVerification() const
+    {
+        auto const helper = tr_torrent::ResumeHelper{ *tor_ };
+        return helper.resume_filenames_need_verification();
+    }
+
+    [[nodiscard]] bool startWhenStable() const
+    {
+        auto const helper = tr_torrent::ResumeHelper{ *tor_ };
+        return helper.start_when_stable();
+    }
+
+    void setResumeFilenamesNeedVerification(bool const val)
+    {
+        auto helper = tr_torrent::ResumeHelper{ *tor_ };
+        helper.load_resume_filenames_need_verification(val);
+    }
+
+    void expectOriginalFilenames() const
+    {
+        for (tr_file_index_t i = 0; i < OriginalFilenames.size(); ++i)
+        {
+            EXPECT_EQ(OriginalFilenames[i], tor_->file_subpath(i));
+        }
+    }
+
+    void createCompleteFiles() const
+    {
+        createFileWithContents(tr_pathbuf{ tor_->download_dir(), "/root/zero-first" }, ""sv);
+        createFileWithContents(tr_pathbuf{ tor_->download_dir(), "/root/a" }, "a"sv);
+        createFileWithContents(tr_pathbuf{ tor_->download_dir(), "/root/zero" }, ""sv);
+        createFileWithContents(tr_pathbuf{ tor_->download_dir(), "/root/b" }, "b"sv);
+        createFileWithContents(tr_pathbuf{ tor_->download_dir(), "/root/c" }, "c"sv);
+        createFileWithContents(tr_pathbuf{ tor_->download_dir(), "/root/zero-last" }, ""sv);
+    }
+
+    tr_ctor* ctor_ = nullptr;
+    tr_torrent* tor_ = nullptr;
+};
+
+TEST_F(ResumeTest, rejectsWrongFilenameCount)
+{
+    // This has the legacy nonzero-file count, but not the other three
+    // per-file arrays required to identify a Transmission 4.0.x layout.
+    writeFilenames({ "root/renamed-a"sv, "root/renamed-b"sv, "root/renamed-c"sv });
+
+    auto const loaded = loadFilenames();
+
+    EXPECT_EQ(decltype(loaded){ 0 }, (loaded & tr_resume::Filenames));
+    EXPECT_TRUE(resumeFilenamesNeedVerification());
+    expectOriginalFilenames();
+}
+
+TEST_F(ResumeTest, migratesLegacyLayoutWithMultipleZeroLengthFilesAndQuarantines)
+{
+    writeLegacyZeroFileLayout(
+        { "root/renamed-a"sv, "root/renamed-b"sv, "root/renamed-c"sv },
+        { true, false, true },
+        { TR_PRI_HIGH, TR_PRI_LOW, TR_PRI_HIGH },
+        { 101, 102, 103 });
+
+    auto const requested = tr_resume::Filenames | tr_resume::Progress | tr_resume::FilePriorities | tr_resume::Dnd;
+    auto const loaded = loadFields(requested);
+
+    EXPECT_EQ(requested, (loaded & requested));
+    EXPECT_TRUE(resumeFilenamesNeedVerification());
+    EXPECT_EQ(OriginalFilenames[0], tor_->file_subpath(0));
+    EXPECT_EQ("root/renamed-a"sv, tor_->file_subpath(1));
+    EXPECT_EQ(OriginalFilenames[2], tor_->file_subpath(2));
+    EXPECT_EQ("root/renamed-b"sv, tor_->file_subpath(3));
+    EXPECT_EQ("root/renamed-c"sv, tor_->file_subpath(4));
+    EXPECT_EQ(OriginalFilenames[5], tor_->file_subpath(5));
+
+    EXPECT_TRUE(tr_torrentFile(tor_, 0).wanted);
+    EXPECT_FALSE(tr_torrentFile(tor_, 1).wanted);
+    EXPECT_TRUE(tr_torrentFile(tor_, 2).wanted);
+    EXPECT_TRUE(tr_torrentFile(tor_, 3).wanted);
+    EXPECT_FALSE(tr_torrentFile(tor_, 4).wanted);
+    EXPECT_TRUE(tr_torrentFile(tor_, 5).wanted);
+
+    EXPECT_EQ(TR_PRI_NORMAL, tr_torrentFile(tor_, 0).priority);
+    EXPECT_EQ(TR_PRI_HIGH, tr_torrentFile(tor_, 1).priority);
+    EXPECT_EQ(TR_PRI_NORMAL, tr_torrentFile(tor_, 2).priority);
+    EXPECT_EQ(TR_PRI_LOW, tr_torrentFile(tor_, 3).priority);
+    EXPECT_EQ(TR_PRI_HIGH, tr_torrentFile(tor_, 4).priority);
+    EXPECT_EQ(TR_PRI_NORMAL, tr_torrentFile(tor_, 5).priority);
+
+    saveResume();
+    auto const saved = tr_variant_serde::benc().parse_file(tor_->resume_file());
+    ASSERT_TRUE(saved);
+    auto const* const map = saved->get_if<tr_variant::Map>();
+    ASSERT_NE(nullptr, map);
+    EXPECT_TRUE(map->value_if<bool>(TR_KEY_resume_filenames_need_verification).value_or(false));
+    auto const* const filenames = map->find_if<tr_variant::Vector>(TR_KEY_files);
+    auto const* const dnd = map->find_if<tr_variant::Vector>(TR_KEY_dnd);
+    auto const* const priorities = map->find_if<tr_variant::Vector>(TR_KEY_priority);
+    auto const* const progress = map->find_if<tr_variant::Map>(TR_KEY_progress);
+    auto const* const mtimes = progress != nullptr ? progress->find_if<tr_variant::Vector>(TR_KEY_mtimes) : nullptr;
+    ASSERT_NE(nullptr, filenames);
+    ASSERT_NE(nullptr, dnd);
+    ASSERT_NE(nullptr, priorities);
+    ASSERT_NE(nullptr, mtimes);
+    EXPECT_EQ(OriginalFilenames.size(), filenames->size());
+    EXPECT_EQ(OriginalFilenames.size(), dnd->size());
+    EXPECT_EQ(OriginalFilenames.size(), priorities->size());
+    EXPECT_EQ(OriginalFilenames.size(), mtimes->size());
+}
+
+TEST_F(ResumeTest, rejectsLegacySizedLayoutWhenReconstructedPathsCollide)
+{
+    writeLegacyZeroFileLayout(
+        { "root/a"sv, "root/a"sv, "root/c"sv },
+        { false, false, false },
+        { TR_PRI_NORMAL, TR_PRI_NORMAL, TR_PRI_NORMAL },
+        { 101, 102, 103 });
+
+    auto const loaded = loadFields(tr_resume::Filenames | tr_resume::Progress | tr_resume::FilePriorities | tr_resume::Dnd);
+
+    EXPECT_EQ(decltype(loaded){ 0 }, (loaded & tr_resume::Filenames));
+    EXPECT_EQ(decltype(loaded){ 0 }, (loaded & tr_resume::FilePriorities));
+    EXPECT_EQ(decltype(loaded){ 0 }, (loaded & tr_resume::Dnd));
+    EXPECT_TRUE(resumeFilenamesNeedVerification());
+    expectOriginalFilenames();
+}
+
+TEST_F(ResumeTest, rejectsStoredPathCollidingWithMetainfoPathTransactionally)
+{
+    writeFilenames({ ""sv, ""sv, "root/renamed-zero"sv, ""sv, "root/renamed-c"sv, "root/a"sv });
+
+    auto const loaded = loadFilenames();
+
+    EXPECT_EQ(decltype(loaded){ 0 }, (loaded & tr_resume::Filenames));
+    EXPECT_TRUE(resumeFilenamesNeedVerification());
+    expectOriginalFilenames();
+}
+
+TEST_F(ResumeTest, acceptsLegacyEmptyPaths)
+{
+    writeFilenames({ ""sv, ""sv, "root/renamed-zero"sv, ""sv, ""sv, ""sv });
+
+    auto const loaded = loadFilenames();
+
+    EXPECT_NE(decltype(loaded){ 0 }, (loaded & tr_resume::Filenames));
+    EXPECT_FALSE(resumeFilenamesNeedVerification());
+    EXPECT_EQ(OriginalFilenames[0], tor_->file_subpath(0));
+    EXPECT_EQ(OriginalFilenames[1], tor_->file_subpath(1));
+    EXPECT_EQ("root/renamed-zero"sv, tor_->file_subpath(2));
+    EXPECT_EQ(OriginalFilenames[3], tor_->file_subpath(3));
+    EXPECT_EQ(OriginalFilenames[4], tor_->file_subpath(4));
+    EXPECT_EQ(OriginalFilenames[5], tor_->file_subpath(5));
+}
+
+TEST_F(ResumeTest, rejectsEntireListWhenAnElementIsNotAString)
+{
+    auto list = tr_variant::Vector{};
+    list.emplace_back(tr_variant::unmanaged_string("root/renamed-zero-first"sv));
+    list.emplace_back(tr_variant::unmanaged_string("root/renamed-a"sv));
+    list.emplace_back(tr_variant::unmanaged_string("root/renamed-zero"sv));
+    list.emplace_back(tr_variant::unmanaged_string("root/renamed-b"sv));
+    list.emplace_back(tr_variant::unmanaged_string("root/renamed-c"sv));
+    list.emplace_back(int64_t{ 1 });
+    auto map = tr_variant::Map{};
+    map.try_emplace(TR_KEY_files, std::move(list));
+    writeResume(std::move(map));
+
+    auto const loaded = loadFilenames();
+
+    EXPECT_EQ(decltype(loaded){ 0 }, (loaded & tr_resume::Filenames));
+    EXPECT_TRUE(resumeFilenamesNeedVerification());
+    expectOriginalFilenames();
+}
+
+TEST_F(ResumeTest, quarantineSurvivesResumeRewriteAndReload)
+{
+    writeFilenames({ "root/zero-first"sv, "root/a"sv, "root/zero"sv, "root/b"sv, "root/c"sv });
+    auto const initially_loaded = loadFilenames();
+    ASSERT_EQ(decltype(initially_loaded){ 0 }, (initially_loaded & tr_resume::Filenames));
+
+    saveResume();
+    setResumeFilenamesNeedVerification(false);
+    ASSERT_FALSE(resumeFilenamesNeedVerification());
+
+    auto const loaded = loadFilenames();
+
+    EXPECT_NE(decltype(loaded){ 0 }, (loaded & tr_resume::Filenames));
+    EXPECT_TRUE(resumeFilenamesNeedVerification());
+    expectOriginalFilenames();
+
+    tr_torrentStart(tor_);
+    auto const stats = tr_torrentStat(tor_);
+    EXPECT_EQ(TR_STATUS_STOPPED, stats.activity);
+    EXPECT_EQ(tr_stat::Error::LocalError, stats.error);
+    EXPECT_FALSE(stats.error_string.empty());
+    EXPECT_FALSE(startWhenStable());
+}
+
+TEST_F(ResumeTest, successfulVerifyClearsQuarantineRewritesResumeAndKeepsTorrentStopped)
+{
+    writeFilenames({ "root/zero-first"sv, "root/a"sv, "root/zero"sv, "root/b"sv, "root/c"sv });
+    auto const loaded = loadFilenames();
+    ASSERT_EQ(decltype(loaded){ 0 }, (loaded & tr_resume::Filenames));
+    tr_torrentStart(tor_);
+    ASSERT_FALSE(startWhenStable());
+    createCompleteFiles();
+
+    blockingTorrentVerify(tor_);
+
+    EXPECT_FALSE(resumeFilenamesNeedVerification());
+    EXPECT_FALSE(startWhenStable());
+    auto const stats = tr_torrentStat(tor_);
+    EXPECT_EQ(TR_STATUS_STOPPED, stats.activity);
+    EXPECT_EQ(tr_stat::Error::Ok, stats.error);
+
+    auto const saved = tr_variant_serde::benc().parse_file(tor_->resume_file());
+    ASSERT_TRUE(saved);
+    auto const* const map = saved->get_if<tr_variant::Map>();
+    ASSERT_NE(nullptr, map);
+    EXPECT_FALSE(map->value_if<bool>(TR_KEY_resume_filenames_need_verification).value_or(false));
+    auto const* const filenames = map->find_if<tr_variant::Vector>(TR_KEY_files);
+    ASSERT_NE(nullptr, filenames);
+    ASSERT_EQ(OriginalFilenames.size(), filenames->size());
+    for (tr_file_index_t i = 0; i < OriginalFilenames.size(); ++i)
+    {
+        auto const filename = (*filenames)[i].value_if<std::string_view>();
+        ASSERT_TRUE(filename);
+        EXPECT_EQ(OriginalFilenames[i], *filename);
+    }
+}
+
+TEST_F(ResumeTest, abortedVerifyKeepsQuarantine)
+{
+    writeFilenames({ "root/zero-first"sv, "root/a"sv, "root/zero"sv, "root/b"sv, "root/c"sv });
+    auto const loaded = loadFilenames();
+    ASSERT_EQ(decltype(loaded){ 0 }, (loaded & tr_resume::Filenames));
+    tr_torrentStart(tor_);
+    ASSERT_FALSE(startWhenStable());
+
+    auto mediator = tr_torrent::VerifyMediator{ tor_ };
+    mediator.on_verify_started();
+    mediator.on_verify_done(true);
+
+    EXPECT_TRUE(resumeFilenamesNeedVerification());
+    EXPECT_FALSE(startWhenStable());
+    auto const stats = tr_torrentStat(tor_);
+    EXPECT_EQ(TR_STATUS_STOPPED, stats.activity);
+    EXPECT_EQ(tr_stat::Error::LocalError, stats.error);
+}
+
+} // namespace tr::test


### PR DESCRIPTION
Fixes #9000
Fixes #8791 
Fixes #8959 

## Summary

Transmission 4.0.x omitted zero-length files from the metainfo file list. Support for creating zero-length files was added by [#6232](https://github.com/transmission/transmission/pull/6232) / [ed4fad9b](https://github.com/transmission/transmission/commit/ed4fad9b1868bbdddfe58d4aaf55032ba3eac70a), so 4.1.x now includes those files. However, no migration was added for the per-file arrays already stored in 4.0.x `.resume` files.

For a torrent with `N` metainfo files and `K` zero-length files, 4.0.x wrote `files`, `dnd`, `priority`, and `progress.mtimes` arrays with `N-K` entries. An unpatched 4.1.x client sees `N` files. The old filename loader accepted the shorter array and applied each available entry by index, shifting every stored path after an omitted zero-length file.

This is a data-integrity regression. Logical file indices can be redirected to the wrong physical paths, and two indices can eventually refer to the same path. Subsequent downloads, uploads, resume rewrites, and verification then operate on the shifted mapping.

## What this PR does

This PR adds two layers of protection.

First, resume filename loading becomes transactional:

- the filename list must have exactly the current metainfo file count;
- every element must be a string;
- legacy empty entries continue to mean “use the canonical metainfo path”;
- effective paths must be unique by exact string comparison;
- no rename is applied until the entire list has passed validation.

If an inconsistent mapping cannot be migrated safely, Transmission rejects the complete stored filename list, falls back to canonical metainfo paths, and places the torrent in a persistent verification quarantine.

Second, this PR recognizes and migrates the primary resume layout written by Transmission 4.0.x. Migration is attempted only when all of the following are true:

- the torrent contains at least one zero-length file;
- `files`, `dnd`, `priority`, and `progress.mtimes` are all present;
- all four arrays have exactly `N-K` entries;
- inserting entries at the known zero-length file positions produces a complete, valid, unique filename mapping.

For a recognized layout, the migration inserts canonical/default entries for zero-length files and preserves the stored filename, selection, priority, and mtime state of every nonzero file. The migrated torrent is still quarantined until its local data is verified.

The quarantine uses the existing torrent error and start paths, so no frontend-specific GTK, Qt, or Web UI changes are required. It:

- blocks both automatic and manual starts;
- persists across resume rewrites and process restarts;
- reports that filenames may need restoration and that local data must be verified;
- permits an explicit `Verify Local Data` operation;
- remains set if verification is aborted;
- is cleared after a successful verification, which also rewrites the corrected resume state;
- leaves the torrent stopped after verification so that restarting it remains an explicit user decision.

## Why validation alone is not sufficient

A minimal fix could reject every short filename array and use the canonical metainfo paths. That prevents a new positional shift, but it discards legitimate renames stored by 4.0.x. It also loses the correspondence needed to find existing data when renamed files or directories no longer match the metainfo layout.

That fallback is especially destructive when followed by verification. Verification checks bytes at the paths currently assigned to each file; it cannot infer the intended file-index-to-path mapping. If the mapping is wrong, correct data may be reported missing, progress can collapse, completed filenames can regain the `.part` suffix, and large amounts of data may be downloaded again.

The 4.0.x form is safely recognizable because all four per-file arrays were written from the same old file list. Requiring their complete, matching signature lets us restore the omitted positions without guessing. This preserves legitimate user state while the quarantine prevents the client from trusting payload data merely because the mapping was reconstructed.

Migration is therefore part of the safety fix, not only a convenience. Without it, installing the fix on an untouched 4.0.x profile could itself turn a detectable compatibility problem into a destructive manual recovery procedure.

Already rewritten 4.1.x resumes are intentionally not reconstructed. Once an unpatched 4.1.x client has expanded and saved the shifted state, the original cross-array signature is gone and stored renames cannot always be distinguished from corruption. Those ambiguous cases are quarantined and require manual filename recovery followed by verification.

## Why verification remains mandatory

Restoring the mapping does not prove that the payload is intact. An unpatched 4.1.x client may already have downloaded or uploaded through the shifted mapping before this version sees the resume file. For that reason, even a successfully migrated torrent is not started automatically.

Automatic verification would not solve the mapping problem: it validates the currently selected paths, so running it before paths are reconstructed or manually restored can discard valid completion state. The safe order is:

1. reconstruct the proven 4.0.x layout, or let the user restore an ambiguous mapping;
2. keep the torrent stopped;
3. verify the local data explicitly;
4. save the corrected full-length resume state.

## Impact on large sessions

This regression was investigated on a long-running seedbox with about 14,000 torrents, where many affected torrents were found, and the same pattern was observed on other servers. Affected torrents may remain unnoticed until they next perform file I/O or are verified, so the consequences can appear gradually after an upgrade.

The startup work added by this PR is metadata-only and linear in each torrent's file count. It does not read or hash payload data and does not start automatic verification. Valid resumes continue normally. Only torrents with a recognized legacy layout or an invalid filename mapping are stopped.

This distinction matters operationally: validation prevents further damage, while deterministic migration preserves the paths and per-file state that would otherwise need to be reconstructed manually across potentially many torrents.

## Preventing corrupt uploads and peer penalties

A corrupt upload is possible here because the 4.0.x `files` and `progress.mtimes` arrays are shifted together. During [resume mtime validation](https://github.com/transmission/transmission/blob/7c3d461c9de0ab21fe4226e740374257e57b3e12/libtransmission/torrent.cc#L2581-L2600), the mtime stored at a logical file index can therefore match the wrong physical file selected by the shifted path, leaving the corresponding `checked_pieces` bits set.

When a peer requests a block, Transmission [checks `has_piece()`, calls `ensure_piece_is_checked()`, and then reads and sends the block](https://github.com/transmission/transmission/blob/7c3d461c9de0ab21fe4226e740374257e57b3e12/libtransmission/peer-msgs.cc#L2084-L2110). [`ensure_piece_is_checked()` returns immediately](https://github.com/transmission/transmission/blob/7c3d461c9de0ab21fe4226e740374257e57b3e12/libtransmission/torrent.cc#L2557-L2571) for a piece whose checked bit is already set, so no new hash is calculated in this case. The read can consequently use the shifted path and send bytes from the wrong physical file.

The receiver rejects those bytes when the completed piece fails its hash. Peer implementations may attribute repeated corrupt pieces to the sender and penalize or ban it according to their own policy.

Transmission itself uses this kind of protection: its peer manager [assigns strikes to peers blamed for corrupt pieces](https://github.com/transmission/transmission/blob/7c3d461c9de0ab21fe4226e740374257e57b3e12/libtransmission/peer-mgr.cc#L859-L873) and [bans a peer after five strikes](https://github.com/transmission/transmission/blob/7c3d461c9de0ab21fe4226e740374257e57b3e12/libtransmission/peer-mgr.cc#L1040-L1041). The quarantine therefore protects not only local data, but also other peers and the affected client's reputation in the swarm.

## Tests

The regression tests cover:

- rejection of an incompatible filename count when the full migration signature is absent;
- migration with zero-length files at the beginning, middle, and end of the file list, including preservation of nonzero-file state and mandatory quarantine;
- rejection when reconstructed paths collide;
- transactional rejection of a stored path colliding with a canonical metainfo path;
- compatibility with legacy empty filename entries;
- transactional rejection of a non-string filename element;
- quarantine persistence across resume rewrite and reload;
- successful verification clearing quarantine, rewriting resume data, and keeping the torrent stopped;
- aborted verification retaining quarantine.

## Related reports

[#8791](https://github.com/transmission/transmission/issues/8791) reports a 4.0.6 to 4.1.1 transition with changed file structure and destructive verification results and is strongly consistent with this regression. [#8959](https://github.com/transmission/transmission/issues/8959) may also be related.

cc @ckerr @tearfur