### PR TITLE
Qt: change settings menu icon to one with symbolic variant

### DIFF
--- a/qt/NativeIcon.cc
+++ b/qt/NativeIcon.cc
@@ -294,7 +294,7 @@ struct Info
     case Type::Settings:
         sf_symbol_name = "gearshape";
         segoe_codepoint = 0xE713U; // Settings
-        xdg_icon_name = "preferences-system";
+        xdg_icon_name = "configure";
         ok_in_gnome_menus = true;
         break;
 


### PR DESCRIPTION
Per the [XDG icon spec](https://specifications.freedesktop.org/icon-naming/latest/#categories), `preferences-system` is described as being the icon for *system* preferences, not application. It also does not have a symbolic variant, at least not in the KDE Breeze icon theme. Other than the turtle icon, this is the only one in transmission-qt that is in full color.

From looking around at a few other KDE applications it appears they are mostly using `configure` instead, which symbolic version is just a symlink.

Before:
<img width="250" height="95" alt="1" src="https://github.com/user-attachments/assets/b0da295b-16be-4f1a-b33f-ed91d1b3f37d" />
After:
<img width="250" height="95" alt="2" src="https://github.com/user-attachments/assets/6dafeb9b-f187-4aa4-8df5-19d7fdd045c7" />

