### PR TITLE
fix: Rebuild wishlist when new files are wanted.

### DIFF
--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -480,6 +480,7 @@ public:
         , tor{ tor_in }
         , tags_{ {
               tor_in->done_.connect_scoped([this](tr_torrent*, bool) { on_torrent_done(); }),
+              tor_in->undone_.connect_scoped([this](tr_torrent*) { on_torrent_undone(); }),
               tor_in->doomed_.connect_scoped([this](tr_torrent*) { on_torrent_doomed(); }),
               tor_in->got_bad_piece_.connect_scoped([this](tr_torrent*, tr_piece_index_t p) { on_got_bad_piece(p); }),
               tor_in->got_metainfo_.connect_scoped([this](tr_torrent*) { on_got_metainfo(); }),
@@ -823,6 +824,14 @@ private:
         wishlist_controller.reset();
     }
 
+    void on_torrent_undone()
+    {
+        if (is_running && !wishlist_controller)
+        {
+            wishlist_controller = std::make_unique<WishlistController>(*this);
+        }
+    }
+
     void on_swarm_is_all_upload_only()
     {
         auto const lock = unique_lock();
@@ -1040,7 +1049,7 @@ EXIT:
     // number of bad pieces a peer is allowed to send before we ban them
     static auto constexpr MaxBadPiecesPerPeer = 5U;
 
-    std::array<sigslot::scoped_connection, 8> const tags_;
+    std::array<sigslot::scoped_connection, 9> const tags_;
 
     mutable std::optional<bool> pool_is_all_upload_only_;
 };

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1871,6 +1871,10 @@ void tr_torrent::recheck_completeness()
 
             done_(this, recent_change);
         }
+        else
+        {
+            undone_(this);
+        }
 
         session->onTorrentCompletenessChanged(id(), completeness_, was_running);
 

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -1014,6 +1014,8 @@ struct tr_torrent
     // ---
 
     sigslot::signal<tr_torrent*, bool /*because_downloaded_last_piece*/> done_;
+    // fires when completeness transitions away from done (e.g. a file is marked wanted again)
+    sigslot::signal<tr_torrent*> undone_;
     sigslot::signal<tr_torrent*, tr_piece_index_t> got_bad_piece_;
     sigslot::signal<tr_torrent*, tr_piece_index_t> piece_completed_;
     sigslot::signal<tr_torrent*> doomed_;

--- a/tests/libtransmission/torrent-test.cc
+++ b/tests/libtransmission/torrent-test.cc
@@ -101,6 +101,37 @@ TEST_F(TorrentTest, queueMoveTop)
     }
 }
 
+TEST_F(TorrentTest, undoneFiresWhenTorrentLeavesDoneState)
+{
+    // file 0's first piece is deliberately wrong, so it starts out incomplete
+    // files 1 and 2 are already correct on disk.
+    auto* const tor = zeroTorrentInit(ZeroTorrentState::Partial);
+    static constexpr auto File0 = tr_file_index_t{ 0 };
+    ASSERT_FALSE(tor->is_done());
+
+    auto done_count = 0;
+    auto undone_count = 0;
+    auto const done_tag = tor->done_.connect_scoped([&done_count](tr_torrent*, bool) { ++done_count; });
+    auto const undone_tag = tor->undone_.connect_scoped([&undone_count](tr_torrent*) { ++undone_count; });
+
+    // unwant file 0: every remaining wanted file is already complete, so the torrent becomes "done"
+    tor->set_files_wanted(&File0, 1, false);
+    EXPECT_TRUE(tor->is_done());
+    EXPECT_EQ(1, done_count);
+    EXPECT_EQ(0, undone_count);
+
+    // want file 0 again while it's still missing data: the torrent leaves the "done" state
+    tor->set_files_wanted(&File0, 1, true);
+    EXPECT_FALSE(tor->is_done());
+    EXPECT_EQ(1, done_count);
+    EXPECT_EQ(1, undone_count);
+
+    // re-asserting the same wanted state is not a transition and should not re-fire either signal
+    tor->set_files_wanted(&File0, 1, true);
+    EXPECT_EQ(1, done_count);
+    EXPECT_EQ(1, undone_count);
+}
+
 TEST_F(TorrentTest, queueMoveBottom)
 {
     static constexpr auto ExpectedQueuePosition = std::array{ 1, 2, 0, 3 };


### PR DESCRIPTION
A torrent may be "done" (all wanted files complete) because the user has unselected some files for download. If the user later checks some of those files, the peer-mgr's wishlist controller was not rebuilt so the newly-wanted files are never requested. The user has to restart transmission to download the files.

This fixes the issue by adding an undone signal that rebuilds the wishlist
Fixes #8332

Notes: Fixes a bug where files didn't download after being toggled from "don't download" to "download" on a torrent that was previously "complete".