### PR TITLE
fix: connect to a running Qt client instead of starting one

### DIFF
--- a/qt/ComInteropHelper.cc
+++ b/qt/ComInteropHelper.cc
@@ -3,11 +3,16 @@
 // or any future license endorsed by Mnemosyne LLC.
 // License text can be found in the licenses/ folder.
 
+#include <memory>
+
 #include <windows.h>
 #include <objbase.h>
+#include <oleauto.h>
 
 #include <QAxFactory>
+#include <QAxObject>
 #include <QString>
+#include <QUuid>
 #include <QVariant>
 
 #include "ComInteropHelper.h"
@@ -23,18 +28,49 @@ extern bool qAxOutProcServer; // NOLINT
 extern wchar_t qAxModuleFilename[MAX_PATH]; // NOLINT
 extern QString qAxInit(); // NOLINT
 
+namespace
+{
+
+// Returns the interop object of a Qt client that is already running, or nullptr
+// if none is. GetActiveObject reads the running object table and nothing else,
+// so a miss stays a miss.
+//
+// Handing the class id to QAxObject instead would not do: QAxBase::initialize
+// falls through to CoCreateInstance whenever its own lookup comes back empty --
+// including the running-object lookup that a trailing '&' selects -- and
+// CoCreateInstance starts a client from the registered LocalServer32.
+std::unique_ptr<QAxObject> connectToRunningClient()
+{
+    auto* unknown = static_cast<IUnknown*>(nullptr);
+
+    if (::GetActiveObject(QUuid{ QStringLiteral(TR_COM_CLIENT_CLSID) }, nullptr, &unknown) != S_OK || unknown == nullptr)
+    {
+        return {};
+    }
+
+    // QAxObject adopts the reference that GetActiveObject returned.
+    return std::make_unique<QAxObject>(unknown);
+}
+
+} // namespace
+
 ComInteropHelper::ComInteropHelper()
-    : client_{ new QAxObject{ QStringLiteral("Transmission.QtClient") } }
+    : client_{ connectToRunningClient() }
 {
 }
 
 bool ComInteropHelper::isConnected() const
 {
-    return !client_->isNull();
+    return client_ != nullptr;
 }
 
 QVariant ComInteropHelper::addMetainfo(QString const& metainfo) const
 {
+    if (!isConnected())
+    {
+        return {};
+    }
+
     return client_->dynamicCall("AddMetainfo(QString)", metainfo);
 }
 

--- a/qt/InteropObject.h
+++ b/qt/InteropObject.h
@@ -7,6 +7,14 @@
 
 #include <QObject>
 
+#ifdef ENABLE_COM_INTEROP
+// The class id a running Qt client is registered under. transmission-qt.idl and
+// dist/msi/components/QtClient.wxs spell it out again, each in the form its own
+// format wants -- bare and uppercase for MIDL, braced for WiX -- so no one
+// definition can serve all three. Changing it here means changing it there.
+#define TR_COM_CLIENT_CLSID "{0e2c952c-0597-491f-ba26-249d7e6fab49}"
+#endif
+
 class InteropObject : public QObject
 {
     Q_OBJECT
@@ -16,7 +24,7 @@ class InteropObject : public QObject
 #endif
 
 #ifdef ENABLE_COM_INTEROP
-    Q_CLASSINFO("ClassID", "{0e2c952c-0597-491f-ba26-249d7e6fab49}")
+    Q_CLASSINFO("ClassID", TR_COM_CLIENT_CLSID)
     Q_CLASSINFO("InterfaceID", "{9402f54f-4906-4f20-ad73-afcfeb5b228d}")
     Q_CLASSINFO("RegisterObject", "yes")
     Q_CLASSINFO("CoClassAlias", "QtClient")

--- a/tests/qt/CMakeLists.txt
+++ b/tests/qt/CMakeLists.txt
@@ -14,6 +14,7 @@ function(add_trqt_test source)
     set_property(TARGET ${target} PROPERTY AUTOMOC ON)
     set_property(TARGET ${target} PROPERTY AUTORCC ON)
     add_test(NAME QT.${test_name} COMMAND ${target})
+    set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} APPEND PROPERTY QT_TEST_TARGETS ${target})
 
     if(UNIX AND NOT APPLE)
         set_tests_properties(
@@ -27,11 +28,15 @@ add_trqt_test(prefs-test.cc)
 add_trqt_test(rpcclient-test.cc)
 add_trqt_test(session-test.cc)
 
+if(ENABLE_QT_COM_INTEROP)
+    add_trqt_test(com-interop-test.cc)
+endif()
+
+get_property(QT_TEST_TARGETS DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY QT_TEST_TARGETS)
+
 add_custom_target(qt-tests
     DEPENDS
-        qt-test-prefs
-        qt-test-rpcclient
-        qt-test-session)
+        ${QT_TEST_TARGETS})
 
 set_property(
     TARGET qt-tests

--- a/tests/qt/com-interop-test.cc
+++ b/tests/qt/com-interop-test.cc
@@ -1,0 +1,77 @@
+// This file Copyright © Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
+
+#include <windows.h>
+#include <objbase.h>
+
+#include <QApplication>
+#include <QString>
+#include <QTest>
+#include <QVariant>
+
+#include "ComInteropHelper.h"
+#include "InteropObject.h"
+
+// ComInteropHelper answers one question: is a Qt client already running, and if
+// so, how do I reach it? A helper that claims a connection it does not have
+// sends torrents nowhere, and one that starts a client in order to answer
+// leaves a stray process holding a torrent the user cannot see.
+//
+// No client is registered until the last case, which registers one and never
+// unregisters it. These run in declaration order.
+class ComInteropTest : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    static void initTestCase()
+    {
+        ComInteropHelper::initialize();
+    }
+
+    static void cleanupTestCase()
+    {
+        ::CoUninitialize();
+    }
+
+    static void does_not_start_a_client_to_answer_the_query()
+    {
+        // Asking twice catches a lookup that answers itself by starting a
+        // client: the second helper would find what the first one launched.
+        auto const first = ComInteropHelper{};
+        QVERIFY(!first.isConnected());
+
+        auto const second = ComInteropHelper{};
+        QVERIFY(!second.isConnected());
+    }
+
+    static void add_metainfo_reports_failure_when_not_connected()
+    {
+        // An invalid variant is what the caller tests to decide whether the
+        // torrent was delegated. A default-constructed `true` would make it
+        // drop the torrent and exit.
+        auto const response = ComInteropHelper{}.addMetainfo(
+            QStringLiteral("magnet:?xt=urn:btih:00000000000000000000000000000000000000ff"));
+
+        QVERIFY(!response.isValid());
+    }
+
+    static void registers_and_then_finds_a_running_client()
+    {
+        ComInteropHelper::registerObject(nullptr);
+
+        QVERIFY(ComInteropHelper{}.isConnected());
+    }
+};
+
+int main(int argc, char** argv)
+{
+    auto const app = QApplication{ argc, argv };
+
+    auto test = ComInteropTest{};
+    return QTest::qExec(&test, argc, argv);
+}
+
+#include "com-interop-test.moc"


### PR DESCRIPTION
## Description

Opening a torrent on Windows should hand it to a client that's already running. Two things stopped that from working:

1. **The client was looked up by ProgID.** `QAxBase::setControl()` resolves a ProgID through the registry: `CLSIDFromProgID()`, then a fallback lookup under `HKLM\Software\Classes`. Only the MSI writes that mapping, so any packaging that doesn't run it (portable zips, scoop, choco) could never resolve the name, and every torrent opened another client.

2. **Resolution then fell through to `CoCreateInstance`.** `QAxBase::initialize()` ends with an unconditional `CoCreateInstance(..., d->classContext, ...)`. For a class registered under `LocalServer32`, that *starts* a server when none is running. A miss therefore launched a client and reported success, so `tryDelegate()` handed the torrent to a process it had just started, then exited.

Now, `GetActiveObject()` reads the running object table and nothing else. It answers the question actually being asked, and it takes the class id directly: no registry lookup, and a miss stays a miss. The class id moves into `TR_COM_CLIENT_CLSID` so the `Q_CLASSINFO` and the lookup can't drift apart. The value is unchanged; `transmission-qt.idl` and the installer's registry entries name the same id.

Tests covering both halves run when building with `ENABLE_QT_COM_INTEROP`.

#255 conflates two independent bugs; this is the hand-off half. #9022 covers the other, where nothing detected two sessions sharing one config dir.

Notes: On Windows, opening a torrent or magnet link now adds it to the running
Transmission window instead of starting a second copy.

## Checklist

- [x] I have manually written or manually audited all changes in this PR and vouch for them.
