### PR TITLE
feat: hold a lock on the session's config dir

### DIFF
--- a/Transmission.xcodeproj/project.pbxproj
+++ b/Transmission.xcodeproj/project.pbxproj
@@ -310,6 +310,7 @@
 		BEFC1E530C07861A00B0BB3C /* open-files.cc in Sources */ = {isa = PBXBuildFile; fileRef = BEFC1E1A0C07861A00B0BB3C /* open-files.cc */; };
 		BEFC1E550C07861A00B0BB3C /* completion.h in Headers */ = {isa = PBXBuildFile; fileRef = BEFC1E1C0C07861A00B0BB3C /* completion.h */; };
 		BEFC1E560C07861A00B0BB3C /* completion.cc in Sources */ = {isa = PBXBuildFile; fileRef = BEFC1E1D0C07861A00B0BB3C /* completion.cc */; };
+		ED0C0D1A2E5F400100112233 /* config-dir-lock.cc in Sources */ = {isa = PBXBuildFile; fileRef = ED0C0D1B2E5F400100112233 /* config-dir-lock.cc */; };
 		BEFC1E570C07861A00B0BB3C /* clients.h in Headers */ = {isa = PBXBuildFile; fileRef = BEFC1E1E0C07861A00B0BB3C /* clients.h */; };
 		BEFC1E580C07861A00B0BB3C /* clients.cc in Sources */ = {isa = PBXBuildFile; fileRef = BEFC1E1F0C07861A00B0BB3C /* clients.cc */; };
 		C1033E071A3279B800EF44D8 /* crypto-utils-fallback.cc in Sources */ = {isa = PBXBuildFile; fileRef = C1033E031A3279B800EF44D8 /* crypto-utils-fallback.cc */; };
@@ -1161,6 +1162,8 @@
 		BEFC1E1A0C07861A00B0BB3C /* open-files.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "open-files.cc"; sourceTree = "<group>"; };
 		BEFC1E1C0C07861A00B0BB3C /* completion.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; path = completion.h; sourceTree = "<group>"; };
 		BEFC1E1D0C07861A00B0BB3C /* completion.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = completion.cc; sourceTree = "<group>"; };
+		ED0C0D1B2E5F400100112233 /* config-dir-lock.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "config-dir-lock.cc"; sourceTree = "<group>"; };
+		ED0C0D1C2E5F400100112233 /* config-dir-lock.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; path = "config-dir-lock.h"; sourceTree = "<group>"; };
 		BEFC1E1E0C07861A00B0BB3C /* clients.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; path = clients.h; sourceTree = "<group>"; };
 		BEFC1E1F0C07861A00B0BB3C /* clients.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = clients.cc; sourceTree = "<group>"; };
 		C1033E031A3279B800EF44D8 /* crypto-utils-fallback.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "crypto-utils-fallback.cc"; sourceTree = "<group>"; };
@@ -1940,6 +1943,8 @@
 				BEFC1E1E0C07861A00B0BB3C /* clients.h */,
 				BEFC1E1D0C07861A00B0BB3C /* completion.cc */,
 				BEFC1E1C0C07861A00B0BB3C /* completion.h */,
+				ED0C0D1B2E5F400100112233 /* config-dir-lock.cc */,
+				ED0C0D1C2E5F400100112233 /* config-dir-lock.h */,
 				C1033E041A3279B800EF44D8 /* crypto-utils-ccrypto.cc */,
 				C1033E031A3279B800EF44D8 /* crypto-utils-fallback.cc */,
 				C1033E051A3279B800EF44D8 /* crypto-utils.cc */,
@@ -3410,6 +3415,7 @@
 				BEFC1E530C07861A00B0BB3C /* open-files.cc in Sources */,
 				C1FEE5781C3223CC00D62832 /* watchdir-generic.cc in Sources */,
 				BEFC1E560C07861A00B0BB3C /* completion.cc in Sources */,
+				ED0C0D1A2E5F400100112233 /* config-dir-lock.cc in Sources */,
 				BEFC1E580C07861A00B0BB3C /* clients.cc in Sources */,
 				C1425B381EE9C805001DB852 /* peer-socket.cc in Sources */,
 				A2BE9C520C1E4AF5002D16E6 /* makemeta.cc in Sources */,

--- a/daemon/daemon.cc
+++ b/daemon/daemon.cc
@@ -853,6 +853,16 @@ int tr_daemon::start([[maybe_unused]] bool foreground)
             return TR_RPC_OK;
         });
     tr_logAddInfo(fmt::format(fmt::runtime(_("Loading settings from '{path}'")), fmt::arg("path", config_dir_)));
+
+    if (!tr_sessionOwnsConfigDir(session))
+    {
+        tr_logAddWarn(
+            fmt::format(
+                fmt::runtime(_(
+                    "Couldn't lock '{path}'. Another instance may be running; if so, both will overwrite each other's settings.")),
+                fmt::arg("path", config_dir_)));
+    }
+
     tr_sessionSaveSettings(session, config_dir_, settings_);
 
     auto const* const settings_map = settings_.get_if<tr_variant::Map>();

--- a/libtransmission/CMakeLists.txt
+++ b/libtransmission/CMakeLists.txt
@@ -45,6 +45,8 @@ target_sources(${TR_NAME}
         clients.h
         completion.cc
         completion.h
+        config-dir-lock.cc
+        config-dir-lock.h
         constants.h
         crypto-utils-ccrypto.cc
         crypto-utils-fallback.cc

--- a/libtransmission/config-dir-lock.cc
+++ b/libtransmission/config-dir-lock.cc
@@ -1,0 +1,70 @@
+// This file Copyright © Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
+
+#include <string_view>
+#include <utility>
+
+#include "libtransmission/config-dir-lock.h"
+#include "libtransmission/file.h"
+#include "libtransmission/tr-strbuf.h"
+
+using namespace std::literals;
+
+namespace
+{
+// Only the file's identity matters, never its contents, so every version of
+// Transmission agreeing on the name is the whole requirement.
+auto constexpr LockFilename = "lock"sv;
+} // namespace
+
+tr_config_dir_lock tr_config_dir_lock::create(std::string_view config_dir)
+{
+    auto const filename = tr_pathbuf{ config_dir, '/', LockFilename };
+
+    auto const handle = tr_sys_file_open(filename, TR_SYS_FILE_READ | TR_SYS_FILE_WRITE | TR_SYS_FILE_CREATE, 0600);
+    if (handle == TR_BAD_SYS_FILE)
+    {
+        return {};
+    }
+
+    if (!tr_sys_file_lock(handle, TR_SYS_FILE_LOCK_EX | TR_SYS_FILE_LOCK_NB))
+    {
+        tr_sys_file_close(handle);
+        return {};
+    }
+
+    return tr_config_dir_lock{ handle };
+}
+
+tr_config_dir_lock::tr_config_dir_lock(tr_config_dir_lock&& that) noexcept
+    : handle_{ std::exchange(that.handle_, TR_BAD_SYS_FILE) }
+{
+}
+
+tr_config_dir_lock& tr_config_dir_lock::operator=(tr_config_dir_lock&& that) noexcept
+{
+    if (this != &that)
+    {
+        close();
+        handle_ = std::exchange(that.handle_, TR_BAD_SYS_FILE);
+    }
+
+    return *this;
+}
+
+tr_config_dir_lock::~tr_config_dir_lock()
+{
+    close();
+}
+
+void tr_config_dir_lock::close() noexcept
+{
+    if (handle_ != TR_BAD_SYS_FILE)
+    {
+        // Closing the descriptor releases the lock.
+        tr_sys_file_close(handle_);
+        handle_ = TR_BAD_SYS_FILE;
+    }
+}

--- a/libtransmission/config-dir-lock.h
+++ b/libtransmission/config-dir-lock.h
@@ -1,0 +1,57 @@
+// This file Copyright © Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
+
+#pragma once
+
+#ifndef __TRANSMISSION__
+#error only libtransmission should #include this header.
+#endif
+
+#include <string_view>
+
+#include "libtransmission/file.h"
+
+/**
+ * Marks a config dir as in use for as long as this object is alive.
+ *
+ * A session's settings, resume files and stats are written as though they have
+ * a single owner, so two sessions sharing a config dir overwrite each other's
+ * state. Taking this lock lets the second one find out.
+ *
+ * The lock lives on an open file descriptor, so the kernel releases it however
+ * the process ends. A killed session leaves nothing behind to clean up.
+ *
+ * Failing to acquire the lock is not proof that another session is running:
+ * a read-only config dir, or one on a filesystem that does not support
+ * locking, cannot be locked either. Treat the failure as "unknown" rather
+ * than as "in use".
+ */
+class tr_config_dir_lock
+{
+public:
+    tr_config_dir_lock() = default;
+    tr_config_dir_lock(tr_config_dir_lock const&) = delete;
+    tr_config_dir_lock& operator=(tr_config_dir_lock const&) = delete;
+    tr_config_dir_lock(tr_config_dir_lock&& that) noexcept;
+    tr_config_dir_lock& operator=(tr_config_dir_lock&& that) noexcept;
+    ~tr_config_dir_lock();
+
+    [[nodiscard]] static tr_config_dir_lock create(std::string_view config_dir);
+
+    [[nodiscard]] bool is_held() const noexcept
+    {
+        return handle_ != TR_BAD_SYS_FILE;
+    }
+
+private:
+    explicit tr_config_dir_lock(tr_sys_file_t handle) noexcept
+        : handle_{ handle }
+    {
+    }
+
+    void close() noexcept;
+
+    tr_sys_file_t handle_ = TR_BAD_SYS_FILE;
+};

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -999,6 +999,13 @@ std::string tr_sessionGetConfigDir(tr_session const* session)
     return session->configDir();
 }
 
+bool tr_sessionOwnsConfigDir(tr_session const* session)
+{
+    TR_ASSERT(session != nullptr);
+
+    return session->ownsConfigDir();
+}
+
 // ---
 
 void tr_sessionSetIncompleteFileNamingEnabled(tr_session* session, bool enabled)
@@ -2164,6 +2171,7 @@ auto makeBlocklistDir(std::string_view config_dir)
 
 tr_session::tr_session(std::string_view config_dir, tr_variant const& settings_dict)
     : config_dir_{ config_dir }
+    , config_dir_lock_{ tr_config_dir_lock::create(config_dir) }
     , resume_dir_{ makeResumeDir(config_dir) }
     , torrent_dir_{ makeTorrentDir(config_dir) }
     , blocklist_dir_{ makeBlocklistDir(config_dir) }

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -42,6 +42,7 @@
 #include "libtransmission/announcer.h"
 #include "libtransmission/bandwidth.h"
 #include "libtransmission/blocklist.h"
+#include "libtransmission/config-dir-lock.h"
 #include "libtransmission/interned-string.h"
 #include "libtransmission/ip-cache.h"
 #include "libtransmission/local-data.h"
@@ -466,6 +467,14 @@ public:
     [[nodiscard]] constexpr std::string const& configDir() const noexcept
     {
         return config_dir_;
+    }
+
+    // False when the config dir could not be locked, which usually means another
+    // session is already using it. Callers that can present a choice -- attach to
+    // the running session, pick another dir, quit -- should do so before writing.
+    [[nodiscard]] bool ownsConfigDir() const noexcept
+    {
+        return config_dir_lock_.is_held();
     }
 
     [[nodiscard]] constexpr auto const& torrentDir() const noexcept
@@ -1199,6 +1208,11 @@ private:
     /// const fields
 
     std::string const config_dir_;
+
+    // Held for the session's lifetime so that a second session on this config
+    // dir can discover the first instead of overwriting its state.
+    tr_config_dir_lock const config_dir_lock_;
+
     std::string const resume_dir_;
     std::string const torrent_dir_;
     std::string const blocklist_dir_;

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -169,6 +169,18 @@ void tr_sessionClose(tr_session* session, double timeout_secs = 15.0);
 [[nodiscard]] std::string tr_sessionGetConfigDir(tr_session const* session);
 
 /**
+ * @brief Return whether this session holds the lock on its config dir.
+ *
+ * A session's settings, resume files and stats are written as though they
+ * have a single owner, so two sessions sharing a config dir overwrite each
+ * other's state. False usually means another session is already using it.
+ *
+ * False is not proof: a config dir on a read-only or lock-less filesystem
+ * cannot be locked either. Treat it as "unknown" and ask rather than refuse.
+ */
+[[nodiscard]] bool tr_sessionOwnsConfigDir(tr_session const* session);
+
+/**
  * @brief Get the default download folder for new torrents.
  *
  * This is set by `tr_sessionInit()` or `tr_sessionSetDownloadDir()`,

--- a/tests/libtransmission/CMakeLists.txt
+++ b/tests/libtransmission/CMakeLists.txt
@@ -15,6 +15,7 @@ target_sources(libtransmission-test
         buffer-test.cc
         clients-test.cc
         completion-test.cc
+        config-dir-lock-test.cc
         copy-test.cc
         crypto-test.cc
         dht-test.cc

--- a/tests/libtransmission/config-dir-lock-test.cc
+++ b/tests/libtransmission/config-dir-lock-test.cc
@@ -1,0 +1,82 @@
+// This file Copyright © Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
+
+#include <string>
+#include <utility>
+
+#include <gtest/gtest.h>
+
+#include <libtransmission/config-dir-lock.h>
+#include <libtransmission/file.h>
+
+#include "test-fixtures.h"
+
+namespace tr::test
+{
+
+using ConfigDirLockTest = SandboxedTest;
+
+TEST_F(ConfigDirLockTest, locksAConfigDirNoOneElseIsUsing)
+{
+    EXPECT_TRUE(tr_config_dir_lock::create(sandboxDir()).is_held());
+}
+
+TEST_F(ConfigDirLockTest, refusesAConfigDirAnotherLockHolds)
+{
+    auto const held = tr_config_dir_lock::create(sandboxDir());
+    ASSERT_TRUE(held.is_held());
+
+    EXPECT_FALSE(tr_config_dir_lock::create(sandboxDir()).is_held());
+
+    // A failed attempt closes the descriptor it opened. Ask a second time to
+    // confirm that closing it left the lock `held` owns in place.
+    EXPECT_FALSE(tr_config_dir_lock::create(sandboxDir()).is_held());
+}
+
+TEST_F(ConfigDirLockTest, releasesTheLockWhenDestroyed)
+{
+    {
+        auto const held = tr_config_dir_lock::create(sandboxDir());
+        ASSERT_TRUE(held.is_held());
+    }
+
+    EXPECT_TRUE(tr_config_dir_lock::create(sandboxDir()).is_held());
+}
+
+TEST_F(ConfigDirLockTest, movingKeepsTheLockHeld)
+{
+    auto held = tr_config_dir_lock{};
+
+    {
+        auto moved_from = tr_config_dir_lock::create(sandboxDir());
+        ASSERT_TRUE(moved_from.is_held());
+        held = std::move(moved_from);
+    }
+
+    EXPECT_TRUE(held.is_held());
+
+    // Destroying the moved-from lock must not have released the config dir.
+    EXPECT_FALSE(tr_config_dir_lock::create(sandboxDir()).is_held());
+}
+
+TEST_F(ConfigDirLockTest, oneLockedConfigDirDoesNotLockAnother)
+{
+    auto const other_dir = sandboxDir() + "/other";
+    ASSERT_TRUE(tr_sys_dir_create(other_dir, TR_SYS_DIR_CREATE_PARENTS, 0700));
+
+    auto const held = tr_config_dir_lock::create(sandboxDir());
+    ASSERT_TRUE(held.is_held());
+
+    EXPECT_TRUE(tr_config_dir_lock::create(other_dir).is_held());
+}
+
+TEST_F(ConfigDirLockTest, failsWhenTheConfigDirIsNotThere)
+{
+    auto const missing_dir = sandboxDir() + "/missing";
+
+    EXPECT_FALSE(tr_config_dir_lock::create(missing_dir).is_held());
+}
+
+} // namespace tr::test


### PR DESCRIPTION
## Description

Notes: transmission-daemon now warns on startup if it can detect another Transmission process running with the same config directory.

This matters because a session's settings, resume files and stats are written as though they have a single owner. Two sessions pointed at the same config dir can overwrite each other's state.

## Checklist

- [x] I have manually written or manually audited all changes in this PR and vouch for them.

