### PR TITLE
feat: detect when another Transmission is using the same config dir

### DIFF
--- a/Transmission.xcodeproj/project.pbxproj
+++ b/Transmission.xcodeproj/project.pbxproj
@@ -310,6 +310,7 @@
 		BEFC1E530C07861A00B0BB3C /* open-files.cc in Sources */ = {isa = PBXBuildFile; fileRef = BEFC1E1A0C07861A00B0BB3C /* open-files.cc */; };
 		BEFC1E550C07861A00B0BB3C /* completion.h in Headers */ = {isa = PBXBuildFile; fileRef = BEFC1E1C0C07861A00B0BB3C /* completion.h */; };
 		BEFC1E560C07861A00B0BB3C /* completion.cc in Sources */ = {isa = PBXBuildFile; fileRef = BEFC1E1D0C07861A00B0BB3C /* completion.cc */; };
+		ED0C0D1A2E5F400100112233 /* config-dir-lock.cc in Sources */ = {isa = PBXBuildFile; fileRef = ED0C0D1B2E5F400100112233 /* config-dir-lock.cc */; };
 		BEFC1E570C07861A00B0BB3C /* clients.h in Headers */ = {isa = PBXBuildFile; fileRef = BEFC1E1E0C07861A00B0BB3C /* clients.h */; };
 		BEFC1E580C07861A00B0BB3C /* clients.cc in Sources */ = {isa = PBXBuildFile; fileRef = BEFC1E1F0C07861A00B0BB3C /* clients.cc */; };
 		C1033E071A3279B800EF44D8 /* crypto-utils-fallback.cc in Sources */ = {isa = PBXBuildFile; fileRef = C1033E031A3279B800EF44D8 /* crypto-utils-fallback.cc */; };
@@ -1161,6 +1162,8 @@
 		BEFC1E1A0C07861A00B0BB3C /* open-files.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "open-files.cc"; sourceTree = "<group>"; };
 		BEFC1E1C0C07861A00B0BB3C /* completion.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; path = completion.h; sourceTree = "<group>"; };
 		BEFC1E1D0C07861A00B0BB3C /* completion.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = completion.cc; sourceTree = "<group>"; };
+		ED0C0D1B2E5F400100112233 /* config-dir-lock.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "config-dir-lock.cc"; sourceTree = "<group>"; };
+		ED0C0D1C2E5F400100112233 /* config-dir-lock.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; path = "config-dir-lock.h"; sourceTree = "<group>"; };
 		BEFC1E1E0C07861A00B0BB3C /* clients.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; path = clients.h; sourceTree = "<group>"; };
 		BEFC1E1F0C07861A00B0BB3C /* clients.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = clients.cc; sourceTree = "<group>"; };
 		C1033E031A3279B800EF44D8 /* crypto-utils-fallback.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "crypto-utils-fallback.cc"; sourceTree = "<group>"; };
@@ -1940,6 +1943,8 @@
 				BEFC1E1E0C07861A00B0BB3C /* clients.h */,
 				BEFC1E1D0C07861A00B0BB3C /* completion.cc */,
 				BEFC1E1C0C07861A00B0BB3C /* completion.h */,
+				ED0C0D1B2E5F400100112233 /* config-dir-lock.cc */,
+				ED0C0D1C2E5F400100112233 /* config-dir-lock.h */,
 				C1033E041A3279B800EF44D8 /* crypto-utils-ccrypto.cc */,
 				C1033E031A3279B800EF44D8 /* crypto-utils-fallback.cc */,
 				C1033E051A3279B800EF44D8 /* crypto-utils.cc */,
@@ -3410,6 +3415,7 @@
 				BEFC1E530C07861A00B0BB3C /* open-files.cc in Sources */,
 				C1FEE5781C3223CC00D62832 /* watchdir-generic.cc in Sources */,
 				BEFC1E560C07861A00B0BB3C /* completion.cc in Sources */,
+				ED0C0D1A2E5F400100112233 /* config-dir-lock.cc in Sources */,
 				BEFC1E580C07861A00B0BB3C /* clients.cc in Sources */,
 				C1425B381EE9C805001DB852 /* peer-socket.cc in Sources */,
 				A2BE9C520C1E4AF5002D16E6 /* makemeta.cc in Sources */,

--- a/daemon/daemon.cc
+++ b/daemon/daemon.cc
@@ -853,6 +853,19 @@ int tr_daemon::start([[maybe_unused]] bool foreground)
             return TR_RPC_OK;
         });
     tr_logAddInfo(fmt::format(fmt::runtime(_("Loading settings from '{path}'")), fmt::arg("path", config_dir_)));
+
+    // A warning, not a failure: see tr_sessionOwnsConfigDir() for why this is
+    // not proof of a second session.
+    if (!tr_sessionOwnsConfigDir(session))
+    {
+        tr_logAddWarn(
+            fmt::format(
+                fmt::runtime(
+                    _("Couldn't claim '{path}'. If another Transmission session is using it, the two will "
+                      "overwrite each other's settings, resume files and stats.")),
+                fmt::arg("path", config_dir_)));
+    }
+
     tr_sessionSaveSettings(session, config_dir_, settings_);
 
     auto const* const settings_map = settings_.get_if<tr_variant::Map>();

--- a/docs/Configuration-Files.md
+++ b/docs/Configuration-Files.md
@@ -44,6 +44,9 @@ This is a JSON-encoded file that holds all the client's settings and preferences
 ### stats.json
 This is a JSON-encoded file that holds session statistics such as running upload and download byte counts.
 
+### lock
+This empty file is kept locked by a running session to mark the configuration folder as in use to safeguard against a second session from running with the same files and accidentally overwriting each other's settings. The OS always releases the lock when the session ends.
+
 ### torrents/
 This subfolder holds the .torrent files that have been added to Transmission. The files in this folder are named with a combination of the torrent's name (to make it human-readable) and a portion of the torrent's SHA1 hash (to avoid filename collisions from similarly-named torrents).
 

--- a/libtransmission/CMakeLists.txt
+++ b/libtransmission/CMakeLists.txt
@@ -45,6 +45,8 @@ target_sources(${TR_NAME}
         clients.h
         completion.cc
         completion.h
+        config-dir-lock.cc
+        config-dir-lock.h
         constants.h
         crypto-utils-ccrypto.cc
         crypto-utils-fallback.cc

--- a/libtransmission/config-dir-lock.cc
+++ b/libtransmission/config-dir-lock.cc
@@ -1,0 +1,46 @@
+// This file Copyright © Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
+
+#include <string_view>
+
+#include "libtransmission/config-dir-lock.h"
+#include "libtransmission/file.h"
+#include "libtransmission/tr-strbuf.h"
+
+using namespace std::literals;
+
+namespace
+{
+// Sessions find each other by this name, so every version has to agree on it.
+auto constexpr LockFilename = "lock"sv;
+} // namespace
+
+tr_config_dir_lock::tr_config_dir_lock(std::string_view config_dir)
+{
+    auto const filename = tr_pathbuf{ config_dir, '/', LockFilename };
+
+    auto const handle = tr_sys_file_open(filename, TR_SYS_FILE_READ | TR_SYS_FILE_WRITE | TR_SYS_FILE_CREATE, 0600);
+    if (handle == TR_BAD_SYS_FILE)
+    {
+        return;
+    }
+
+    if (!tr_sys_file_lock(handle, TR_SYS_FILE_LOCK_EX | TR_SYS_FILE_LOCK_NB))
+    {
+        tr_sys_file_close(handle);
+        return;
+    }
+
+    handle_ = handle;
+}
+
+tr_config_dir_lock::~tr_config_dir_lock()
+{
+    if (handle_ != TR_BAD_SYS_FILE)
+    {
+        // Closing the descriptor releases the lock.
+        tr_sys_file_close(handle_);
+    }
+}

--- a/libtransmission/config-dir-lock.h
+++ b/libtransmission/config-dir-lock.h
@@ -1,0 +1,49 @@
+// This file Copyright © Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
+
+#pragma once
+
+#ifndef __TRANSMISSION__
+#error only libtransmission should #include this header.
+#endif
+
+#include <string_view>
+
+#include "libtransmission/file.h"
+
+/**
+ * Marks a config dir as in use for as long as this object is alive.
+ *
+ * A session's settings, resume files and stats are written as though they have
+ * a single owner, so two sessions sharing a config dir overwrite each other's
+ * state. Taking this lock lets the second one find out.
+ *
+ * The lock lives on an open file descriptor, so the kernel releases it however
+ * the process ends. A killed session leaves nothing behind to clean up.
+ *
+ * is_held() is false for two causes that cannot be told apart: another session
+ * holds the dir, or it could not be locked at all -- a read-only config dir, or
+ * one on a filesystem without locking.
+ */
+class tr_config_dir_lock
+{
+public:
+    explicit tr_config_dir_lock(std::string_view config_dir);
+    tr_config_dir_lock(tr_config_dir_lock const&) = delete;
+    tr_config_dir_lock& operator=(tr_config_dir_lock const&) = delete;
+    tr_config_dir_lock(tr_config_dir_lock&&) = delete;
+    tr_config_dir_lock& operator=(tr_config_dir_lock&&) = delete;
+    ~tr_config_dir_lock();
+
+    // Not constexpr: on Windows TR_BAD_SYS_FILE is a cast that no constant
+    // expression may perform.
+    [[nodiscard]] bool is_held() const noexcept
+    {
+        return handle_ != TR_BAD_SYS_FILE;
+    }
+
+private:
+    tr_sys_file_t handle_ = TR_BAD_SYS_FILE;
+};

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -999,6 +999,13 @@ std::string tr_sessionGetConfigDir(tr_session const* session)
     return session->configDir();
 }
 
+bool tr_sessionOwnsConfigDir(tr_session const* session)
+{
+    TR_ASSERT(session != nullptr);
+
+    return session->ownsConfigDir();
+}
+
 // ---
 
 void tr_sessionSetIncompleteFileNamingEnabled(tr_session* session, bool enabled)
@@ -2160,10 +2167,20 @@ auto makeBlocklistDir(std::string_view config_dir)
 {
     return makeSubdir(config_dir, "blocklists"sv);
 }
+
+auto makeConfigDirLock(std::string_view config_dir)
+{
+    // A dir has to exist before it can be locked, and the subdirs below are the
+    // first things written into it, so a session on a new config dir claims it
+    // too.
+    tr_sys_dir_create(config_dir, TR_SYS_DIR_CREATE_PARENTS, 0777);
+    return tr_config_dir_lock{ config_dir };
+}
 } // namespace
 
 tr_session::tr_session(std::string_view config_dir, tr_variant const& settings_dict)
     : config_dir_{ config_dir }
+    , config_dir_lock_{ makeConfigDirLock(config_dir) }
     , resume_dir_{ makeResumeDir(config_dir) }
     , torrent_dir_{ makeTorrentDir(config_dir) }
     , blocklist_dir_{ makeBlocklistDir(config_dir) }

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -42,6 +42,7 @@
 #include "libtransmission/announcer.h"
 #include "libtransmission/bandwidth.h"
 #include "libtransmission/blocklist.h"
+#include "libtransmission/config-dir-lock.h"
 #include "libtransmission/interned-string.h"
 #include "libtransmission/ip-cache.h"
 #include "libtransmission/local-data.h"
@@ -466,6 +467,12 @@ public:
     [[nodiscard]] constexpr std::string const& configDir() const noexcept
     {
         return config_dir_;
+    }
+
+    // See tr_sessionOwnsConfigDir().
+    [[nodiscard]] bool ownsConfigDir() const noexcept
+    {
+        return config_dir_lock_.is_held();
     }
 
     [[nodiscard]] constexpr auto const& torrentDir() const noexcept
@@ -1199,6 +1206,10 @@ private:
     /// const fields
 
     std::string const config_dir_;
+
+    // Held for the session's lifetime. See tr_sessionOwnsConfigDir().
+    tr_config_dir_lock const config_dir_lock_;
+
     std::string const resume_dir_;
     std::string const torrent_dir_;
     std::string const blocklist_dir_;

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -169,6 +169,16 @@ void tr_sessionClose(tr_session* session, double timeout_secs = 15.0);
 [[nodiscard]] std::string tr_sessionGetConfigDir(tr_session const* session);
 
 /**
+ * @brief Return whether this session holds the lock on its config dir.
+ *
+ * False has two causes a caller cannot tell apart: another session holds the
+ * dir, or the lock could not be taken at all -- a read-only config dir, or one
+ * on a filesystem without locking. So false is grounds for warning that another
+ * session may be using the dir, not for concluding that one is.
+ */
+[[nodiscard]] bool tr_sessionOwnsConfigDir(tr_session const* session);
+
+/**
  * @brief Get the default download folder for new torrents.
  *
  * This is set by `tr_sessionInit()` or `tr_sessionSetDownloadDir()`,

--- a/tests/libtransmission/CMakeLists.txt
+++ b/tests/libtransmission/CMakeLists.txt
@@ -15,6 +15,7 @@ target_sources(libtransmission-test
         buffer-test.cc
         clients-test.cc
         completion-test.cc
+        config-dir-lock-test.cc
         copy-test.cc
         crypto-test.cc
         dht-test.cc

--- a/tests/libtransmission/config-dir-lock-test.cc
+++ b/tests/libtransmission/config-dir-lock-test.cc
@@ -1,0 +1,63 @@
+// This file Copyright © Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
+
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include <libtransmission/config-dir-lock.h>
+#include <libtransmission/file.h>
+
+#include "test-fixtures.h"
+
+namespace tr::test
+{
+
+using ConfigDirLockTest = SandboxedTest;
+
+TEST_F(ConfigDirLockTest, locksAConfigDirNoOneElseIsUsing)
+{
+    EXPECT_TRUE(tr_config_dir_lock(sandboxDir()).is_held());
+}
+
+TEST_F(ConfigDirLockTest, doesNotLockAConfigDirAnotherLockHolds)
+{
+    auto const held = tr_config_dir_lock(sandboxDir());
+    ASSERT_TRUE(held.is_held());
+
+    EXPECT_FALSE(tr_config_dir_lock(sandboxDir()).is_held());
+
+    // A failed attempt closes the descriptor it opened. Ask a second time to
+    // confirm that closing it left the lock `held` owns in place.
+    EXPECT_FALSE(tr_config_dir_lock(sandboxDir()).is_held());
+}
+
+TEST_F(ConfigDirLockTest, doesNotLockAConfigDirItCannotOpen)
+{
+    EXPECT_FALSE(tr_config_dir_lock(sandboxDir() + "/missing").is_held());
+}
+
+TEST_F(ConfigDirLockTest, releasesTheLockWhenDestroyed)
+{
+    {
+        auto const held = tr_config_dir_lock(sandboxDir());
+        ASSERT_TRUE(held.is_held());
+    }
+
+    EXPECT_TRUE(tr_config_dir_lock(sandboxDir()).is_held());
+}
+
+TEST_F(ConfigDirLockTest, oneLockedConfigDirDoesNotLockAnother)
+{
+    auto const other_dir = sandboxDir() + "/other";
+    ASSERT_TRUE(tr_sys_dir_create(other_dir, TR_SYS_DIR_CREATE_PARENTS, 0700));
+
+    auto const held = tr_config_dir_lock(sandboxDir());
+    ASSERT_TRUE(held.is_held());
+
+    EXPECT_TRUE(tr_config_dir_lock(other_dir).is_held());
+}
+
+} // namespace tr::test

--- a/tests/libtransmission/session-test.cc
+++ b/tests/libtransmission/session-test.cc
@@ -357,4 +357,47 @@ TEST_F(SessionTest, loadTorrentsThenMagnets)
     EXPECT_TRUE(tor->has_metainfo());
 }
 
+namespace
+{
+// Starts a session on `config_dir` and reports whether it claimed the dir.
+[[nodiscard]] bool startsOwningConfigDir(std::string_view config_dir, tr_variant const& settings)
+{
+    auto* const session = tr_sessionInit(config_dir, false, settings);
+    auto const owns = tr_sessionOwnsConfigDir(session);
+    tr_sessionClose(session, 0.5);
+    return owns;
+}
+} // namespace
+
+// Two sessions on one config dir overwrite each other's settings, resume files
+// and stats. The second still starts; all it can do is report. `session_`
+// already holds this dir.
+TEST_F(SessionTest, doesNotOwnAConfigDirAnotherSessionHolds)
+{
+    EXPECT_FALSE(startsOwningConfigDir(sandboxDir(), quietSettings()));
+}
+
+TEST_F(SessionTest, releasesTheConfigDirWhenItCloses)
+{
+    closeSession();
+
+    EXPECT_TRUE(startsOwningConfigDir(sandboxDir(), quietSettings()));
+}
+
+TEST_F(SessionTest, claimsAConfigDirItHadToCreate)
+{
+    EXPECT_TRUE(startsOwningConfigDir(sandboxDir() + "/brand-new", quietSettings()));
+}
+
+TEST_F(SessionTest, startsOnAConfigDirItCannotLock)
+{
+    // A lock that is a directory can never be opened as a file, which is the
+    // shape of every "could not be locked at all" a real filesystem produces.
+    auto const dir = sandboxDir() + "/unlockable";
+    ASSERT_TRUE(tr_sys_dir_create(dir, TR_SYS_DIR_CREATE_PARENTS, 0700));
+    ASSERT_TRUE(tr_sys_dir_create(dir + "/lock", TR_SYS_DIR_CREATE_PARENTS, 0700));
+
+    EXPECT_FALSE(startsOwningConfigDir(dir, quietSettings()));
+}
+
 } // namespace tr::test

--- a/tests/libtransmission/test-fixtures.h
+++ b/tests/libtransmission/test-fixtures.h
@@ -339,23 +339,9 @@ private:
         // blocklists
         tr_sys_dir_create(tr_pathbuf{ sandboxDir(), "/blocklists" }, TR_SYS_DIR_CREATE_PARENTS, 0700);
 
-        // fill in any missing settings
-        settings_map->try_emplace(TR_KEY_port_forwarding_enabled, false);
-        settings_map->try_emplace(TR_KEY_dht_enabled, false);
-        settings_map->try_emplace(TR_KEY_message_level, verbose_ ? TR_LOG_DEBUG : TR_LOG_ERROR);
-
-        // disable ip query
-        settings_map->insert_or_assign(TR_KEY_ip_endpoints_ipv4, tr_variant::Vector{});
-        settings_map->insert_or_assign(TR_KEY_ip_endpoints_ipv6, tr_variant::Vector{});
+        applyQuietDefaults(*settings_map);
 
         return tr_sessionInit(sandboxDir(), !verbose_, settings);
-    }
-
-    static void sessionClose(tr_session* session)
-    {
-        static auto constexpr DeadlineSecs = 0.1;
-        tr_sessionClose(session, DeadlineSecs);
-        tr_logClearQueue();
     }
 
 protected:
@@ -519,6 +505,45 @@ protected:
         return settings_.get();
     }
 
+    // Fills in any missing setting with one that keeps a session quiet and off
+    // the network. Tests that start one of their own want the same treatment.
+    void applyQuietDefaults(tr_variant::Map& settings_map) const
+    {
+        settings_map.try_emplace(TR_KEY_port_forwarding_enabled, false);
+        settings_map.try_emplace(TR_KEY_dht_enabled, false);
+        settings_map.try_emplace(TR_KEY_message_level, verbose_ ? TR_LOG_DEBUG : TR_LOG_ERROR);
+        settings_map.insert_or_assign(TR_KEY_ip_endpoints_ipv4, tr_variant::Vector{});
+        settings_map.insert_or_assign(TR_KEY_ip_endpoints_ipv6, tr_variant::Vector{});
+    }
+
+    // Settings for a test that starts a second session, quieted the same way the
+    // fixture's own session is. Only the settings named here are set, so that
+    // the quiet ones are the ones missing for applyQuietDefaults() to fill in;
+    // tr_sessionInit() supplies the rest. The port is randomized so the two
+    // sessions do not contend for one.
+    [[nodiscard]] tr_variant quietSettings() const
+    {
+        auto settings = tr_variant::make_map();
+        auto* const settings_map = settings.get_if<tr_variant::Map>();
+        settings_map->insert_or_assign(TR_KEY_peer_port_random_on_start, true);
+        applyQuietDefaults(*settings_map);
+        return settings;
+    }
+
+    // Ends the fixture's session, releasing its hold on the config dir.
+    void closeSession()
+    {
+        static auto constexpr DeadlineSecs = 0.1;
+
+        if (session_ != nullptr)
+        {
+            tr_sessionClose(session_, DeadlineSecs);
+            session_ = nullptr;
+        }
+
+        tr_logClearQueue();
+    }
+
     void SetUp() override
     {
         SandboxedTest::SetUp();
@@ -528,8 +553,7 @@ protected:
 
     void TearDown() override
     {
-        sessionClose(session_);
-        session_ = nullptr;
+        closeSession();
         settings_.reset();
 
         SandboxedTest::TearDown();


### PR DESCRIPTION
## Description

Sessions now take an advisory lock on their config dir, and `tr_sessionOwnsConfigDir()` reports whether they got it. `transmission-daemon` warns when the dir is already in use.

Settings, resume files and stats are written as though they have one owner, so two sessions on a config dir overwrite each other and nothing notices. In #255 that shows up as copies launched from the Start menu all announcing the same torrents to the same trackers. Hand-off can't catch it — a daemon and a GUI client never exchange messages. #9016 covers the other half of #255, where opening a torrent starts a second client instead of handing off to the running one.

It warns rather than refusing because failing to lock is a weaker signal than holding it: a read-only or lock-less filesystem fails exactly like real contention. What a GUI should do instead — surfacing the session the user already has — is left to its own PR, since that needs an override flag so a second instance can still be started deliberately.

Notes: transmission-daemon now warns at startup if another Transmission session is already using the same configuration directory. This is to safeguard against multiple sessions accidentally overwriting each others' settings.

## Checklist

- [x] I have manually written or manually audited all changes in this PR and vouch for them.
