### PR TITLE
ci: stop rebuilding the web assets on NetBSD

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1600,7 +1600,6 @@ jobs:
               libpsl \
               miniupnpc \
               ninja-build \
-              `[ '${{ needs.what-to-make.outputs.make-web }}' = 'true' ] && echo nodejs` \
               pkgconf \
               `[ '${{ needs.what-to-make.outputs.make-qt }}' = 'true' ] && echo qt6-qtsvg qt6-qttools` \
               rapidjson \
@@ -1627,7 +1626,7 @@ jobs:
               -DENABLE_QT=${{ (needs.what-to-make.outputs.make-qt == 'true') && 'ON' || 'OFF' }} \
               -DENABLE_TESTS=${{ (needs.what-to-make.outputs.make-tests == 'true') && 'ON' || 'OFF' }} \
               -DENABLE_UTILS=${{ (needs.what-to-make.outputs.make-utils == 'true') && 'ON' || 'OFF' }} \
-              -DREBUILD_WEB=${{ (needs.what-to-make.outputs.make-web == 'true') && 'ON' || 'OFF' }} \
+              -DREBUILD_WEB=OFF `# nodejs is not packaged in NetBSD; the source tarball ships prebuilt web assets` \
               -DENABLE_WERROR=ON \
               -DRUN_CLANG_TIDY=OFF \
               -DUSE_SYSTEM_DEFAULT=ON \


### PR DESCRIPTION
## Description

The netbsd job fails before it compiles anything:

```
pkg_add: no pkg found for 'nodejs', sorry.
pkg_add: 1 package addition failed
##[error]ssh exited with code 1
```

`PKG_PATH` asks the CDN for `.../NetBSD/x86_64/10.1/All`, which 302-redirects to the current quarterly bulk build. That is now `10.0_2026Q2`, which shipped no `nodejs` package at all — `10.0_2026Q1` had `nodejs-20.20.2`, `22.22.2`, `24.14.1` and `25.8.2`. Since `prepare` runs under `set -ex`, the failed `pkg_add` aborts the step.

`nodejs` is only requested to rebuild the web assets, which is little benefit on NetBSD: the generated assets are checked in under `web/public_html/`, and the Linux, macOS and Windows jobs already exercise the rebuild. So drop the package and pin `REBUILD_WEB=OFF`, the same thing the sibling DragonFlyBSD job does for its own reason.

## Checklist

- [x] I have reviewed and vouch for all changes in this PR

