### PR TITLE
fix: parse magnet links that carry an empty authority (#9020)

### DIFF
--- a/gtk/Session.cc
+++ b/gtk/Session.cc
@@ -49,6 +49,7 @@
 #include <cstring> // strstr
 #include <functional>
 #include <iostream>
+#include <iterator>
 #include <map>
 #include <memory>
 #include <optional>
@@ -144,7 +145,7 @@ private:
     void inc_busy();
     void dec_busy();
 
-    bool add(Glib::ustring const& name_in, bool do_start, bool do_prompt, bool do_notify);
+    bool add(Glib::ustring const& name, bool do_start, bool do_prompt, bool do_notify);
     void add_file_async_callback(
         Glib::RefPtr<Gio::File> const& file,
         Glib::RefPtr<Gio::AsyncResult>& result,
@@ -822,18 +823,8 @@ void Session::Impl::add_file_async_callback(
 }
 
 // Add `name,` which might be a local filename, a magnet link, or a URI.
-bool Session::Impl::add(Glib::ustring const& name_in, bool const do_start, bool const do_prompt, bool const do_notify)
+bool Session::Impl::add(Glib::ustring const& name, bool const do_start, bool const do_prompt, bool const do_notify)
 {
-    auto name = name_in;
-
-    // `gio::File` doesn't seem to know how to stringify magnet links correctly.
-    // Unfortunately there are some code paths that unavoidably use `gio::File`
-    // e.g. Gtk::Application::on_open() so we have to do this:
-    if (auto constexpr BrokenMagnetLinkPrefix = "magnet:///?"sv; tr_strv_starts_with(name.raw(), BrokenMagnetLinkPrefix))
-    {
-        name.replace(0, std::size(BrokenMagnetLinkPrefix), "magnet:?");
-    }
-
     auto* const session = get_session();
     if (session == nullptr)
     {

--- a/libtransmission/web-utils.cc
+++ b/libtransmission/web-utils.cc
@@ -305,14 +305,21 @@ std::optional<tr_url_parsed_t> tr_urlParse(std::string_view url)
     auto parsed = tr_url_parsed_t{};
     parsed.full = url;
 
-    // So many magnet links are malformed, e.g. not escaping text
-    // in the display name, that we're better off handling magnets
-    // as a special case before even scanning for invalid chars.
-    if (auto constexpr MagnetStart = "magnet:?"sv; tr_strv_starts_with(url, MagnetStart))
+    // So many magnet links are malformed, e.g. not escaping text in the display
+    // name, that we're better off handling magnets as a special case before even
+    // scanning for invalid chars. Any run of slashes between the scheme and the
+    // query is skipped in the same spirit: a magnet link has no authority, but a
+    // URI library that insists on one spells it empty, so GLib hands over
+    // "magnet:///?xt=..." for what was written "magnet:?xt=...".
+    if (auto constexpr Scheme = "magnet:"sv; tr_strv_starts_with(url, Scheme))
     {
-        parsed.scheme = "magnet"sv;
-        parsed.query = url.substr(std::size(MagnetStart));
-        return parsed;
+        auto const rest = url.substr(std::size(Scheme));
+        if (auto const pos = rest.find_first_not_of('/'); pos != std::string_view::npos && rest[pos] == '?')
+        {
+            parsed.scheme = "magnet"sv;
+            parsed.query = rest.substr(pos + 1U);
+            return parsed;
+        }
     }
 
     if (!urlCharsAreValid(url))

--- a/tests/libtransmission/magnet-metainfo-test.cc
+++ b/tests/libtransmission/magnet-metainfo-test.cc
@@ -61,11 +61,21 @@ TEST_F(MagnetMetainfoTest, magnetParse)
         "&ws=http%3A%2F%2Fserver.webseed.org%2Fpath%2Fto%2Ffile"
         "&tr=http%3A%2F%2Ftracker.opentracker.org%2Fannounce"sv;
 
-    for (auto const& uri : { UriHex, UriHexWithEmptyValue, UriHexWithJunkValues, UriBase32 })
+    // UriHex again, spelled the way a URI library that insists on an authority
+    // writes it.
+    auto constexpr UriHexEmptyAuthority =
+        "magnet:///?xt=urn:btih:"
+        "d2354010a3ca4ade5b7427bb093a62a3899ff381"
+        "&dn=Display%20Name"
+        "&tr=http%3A%2F%2Ftracker.openbittorrent.com%2Fannounce"
+        "&tr=http%3A%2F%2Ftracker.opentracker.org%2Fannounce"
+        "&ws=http%3A%2F%2Fserver.webseed.org%2Fpath%2Fto%2Ffile"sv;
+
+    for (auto const& uri : { UriHex, UriHexWithEmptyValue, UriHexWithJunkValues, UriBase32, UriHexEmptyAuthority })
     {
         auto mm = tr_magnet_metainfo{};
 
-        EXPECT_TRUE(mm.parseMagnet(uri));
+        ASSERT_TRUE(mm.parseMagnet(uri)) << uri;
         EXPECT_EQ(2U, std::size(mm.announce_list()));
         auto it = std::begin(mm.announce_list());
         EXPECT_EQ(0U, it->tier);

--- a/tests/libtransmission/web-utils-test.cc
+++ b/tests/libtransmission/web-utils-test.cc
@@ -166,6 +166,22 @@ TEST_F(WebUtilsTest, urlParse)
     EXPECT_EQ("2001:0db8:11a3:09d7:1f34:8a2e:07a0:765d"sv, parsed->host);
     EXPECT_EQ("/announce"sv, parsed->path);
     EXPECT_EQ(80, parsed->port);
+
+    // the same link, with and without an empty authority
+    for (auto const& magnet :
+         { "magnet:?xt=urn:btih:1&dn=A B"sv, "magnet://?xt=urn:btih:1&dn=A B"sv, "magnet:///?xt=urn:btih:1&dn=A B"sv })
+    {
+        parsed = tr_urlParse(magnet);
+        ASSERT_TRUE(parsed) << magnet;
+        EXPECT_EQ("magnet"sv, parsed->scheme) << magnet;
+        EXPECT_EQ("xt=urn:btih:1&dn=A B"sv, parsed->query) << magnet;
+    }
+
+    // a bare scheme carries no query
+    parsed = tr_urlParse("magnet:"sv);
+    EXPECT_TRUE(parsed);
+    EXPECT_EQ("magnet"sv, parsed->scheme);
+    EXPECT_EQ(""sv, parsed->query);
 }
 
 TEST_F(WebUtilsTest, urlParseFuzz)


### PR DESCRIPTION
## Description

Cherry-pick of #9020 .

A magnet link has no authority component, but a URI library that insists on one spells it empty: GLib turns "magnet:?xt=..." into "magnet:///?xt=...". Both name the same link, and only the first parsed.

The empty authority is the whole of the difference. Percent-encoding, "+", unescaped spaces, raw UTF-8 in the display name, repeated "tr=" parameters, base32 hashes and v2 "btmh" hashes all survive that round trip untouched.

The GTK client sees the second spelling for every magnet it is asked to open, because opening goes through Gio::File, and had been patching the link back into shape on arrival. Parsing it where every caller benefits lets that go.

The parse is left strict about everything else: a magnet link with no query still falls through to the general URL parser, as it did before.

## Checklist

- [x] I have manually written or manually audited all changes in this PR and vouch for them.