### PR TITLE
fix: include active errors in macOS filter

### DIFF
--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -2989,7 +2989,15 @@ static void removeKeRangerRansomware()
     NSIndexSet* indexesOfNonFilteredTorrents = [self.fTorrents
         indexesOfObjectsWithOptions:NSEnumerationConcurrent passingTest:^BOOL(Torrent* torrent, NSUInteger /*torrentIdx*/, BOOL* /*stopTorrentsEnumeration*/) {
             //check status
-            if (torrent.active && !torrent.checkingWaiting)
+            if (torrent.error)
+            {
+                std::atomic_fetch_add_explicit(errorRef, 1, std::memory_order_relaxed);
+                if (filterStatus && !filterError)
+                {
+                    return NO;
+                }
+            }
+            else if (torrent.active && !torrent.checkingWaiting)
             {
                 BOOL const isActive = torrent.transmitting;
                 if (isActive)
@@ -3012,14 +3020,6 @@ static void removeKeRangerRansomware()
                     {
                         return NO;
                     }
-                }
-            }
-            else if (torrent.error)
-            {
-                std::atomic_fetch_add_explicit(errorRef, 1, std::memory_order_relaxed);
-                if (filterStatus && !filterError)
-                {
-                    return NO;
                 }
             }
             else


### PR DESCRIPTION
Fixes the macOS Error filter for torrents that are still active when their tracker reports an error.

The filter classification checked `torrent.active` before `torrent.error`. Active errored torrents therefore followed the downloading or seeding path and were omitted from the Error filter. Error state now takes precedence, so the count and filter include those torrents while the other status paths stay unchanged.

Validation:
- `git diff --check` passes.
- The macOS UI build cannot run in this Windows environment because it requires Xcode and macOS.

Notes: Fixed the macOS Error filter so active torrents with tracker errors appear in the Error view.

Closes #8311
