### PR TITLE
feat(web): add a color scheme option to appearance settings

### DIFF
--- a/web/assets/css/transmission-app.scss
+++ b/web/assets/css/transmission-app.scss
@@ -18,6 +18,143 @@
   }
 }
 
+@mixin color-scheme-dark {
+  --color-bg-hover: var(--grey-40);
+  --color-bg-odd: var(--black);
+  --color-bg-popup: var(--black);
+  --color-bg-primary: var(--black);
+  --color-bg-selected: var(--default-accent-color-strong);
+  --color-bg-warn: #cf6679;
+  --color-border-default: var(--default-border-dark);
+  --color-border-stark: var(--dark-mode-white);
+  --color-border-starkest: var(--grey-500);
+  --color-fg-disabled: var(--grey);
+  --color-fg-on-popup: var(--nice-grey);
+  --color-fg-primary: var(--dark-mode-white);
+  --color-fg-secondary: var(--nice-grey);
+  --color-fg-selected: #404040;
+  --color-fg-tertiary: var(--grey-500);
+  --color-fg-warn: var(--dark-mode-black);
+  --color-progressbar-fg-1: #edefff;
+  --color-progressbar-fg-2: #edefff;
+  --color-progressbar-fg-3: #edefff;
+  --color-progressbar-paused: var(--grey-500);
+  --color-progressbar-seed-1: var(--green-100);
+  --color-progressbar-seed-2: var(--green-400);
+  --color-progressbar-seed-paused: var(--grey-500);
+  --progress-bar-shadow-1: 1px 1px #000;
+  --progress-bar-shadow-2: 1px 1px #000;
+  --progress-bar-shadow-3: 1px 1px #000;
+
+  .contrast-more {
+    --color-bg-even: var(--black);
+    --color-bg-hover: var(--grey-40);
+    --color-bg-tabs: var(--black);
+    --color-bg-warn: #cf6679;
+    --color-border-default: var(--white);
+    --color-border-stark: var(--white);
+    --color-border-starkest: var(--white);
+    --color-fg-disabled: var(--white);
+    --color-fg-error: var(--red-500);
+    --color-fg-on-popup: var(--white);
+    --color-fg-port-closed: var(--red-500);
+    --color-fg-port-open: var(--green-100);
+    --color-fg-primary: var(--white);
+    --color-fg-secondary: var(--white);
+    --color-fg-selected: var(--black);
+    --color-fg-tabs: var(--white);
+    --color-fg-tertiary: var(--white);
+    --color-fg-warn: var(--black);
+    --color-progressbar-fg-1: #fff;
+    --color-progressbar-fg-2: #fff;
+    --color-progressbar-fg-3: #000;
+    --color-progressbar-background-2: var(--white);
+    --color-progressbar-magnet: var(--yellow-300);
+    --color-progressbar-paused: var(--grey-500);
+    --color-progressbar-queued: var(--blue-400);
+    --color-progressbar-seed-1: var(--black);
+    --color-progressbar-seed-2: var(--white);
+    --color-progressbar-seed-paused: var(--grey-500);
+    --color-progressbar-verify: var(--yellow-300);
+    --color-toolbar-background: var(--black);
+    --progress-bar-shadow-3: 0;
+  }
+}
+
+@mixin color-scheme-light {
+  --color-bg-hover: var(--nice-grey);
+  --color-bg-odd: var(--white);
+  --color-bg-popup: var(--white);
+  --color-bg-primary: var(--white);
+  --color-bg-selected: var(--default-accent-color);
+  --color-bg-warn: #e4606d5b;
+  --color-border-default: var(--default-border-light);
+  --color-border-stark: var(--grey-500);
+  --color-border-starkest: #d0d7de;
+  --color-dialog-border: var(--nice-grey);
+  --color-fg-disabled: var(--grey);
+  --color-fg-error: var(--red-500);
+  --color-fg-on-popup: var(--grey-900);
+  --color-fg-port-closed: var(--red-500);
+  --color-fg-port-open: var(--green-400);
+  --color-fg-primary: #404040;
+  --color-fg-secondary: var(--grey-500);
+  --color-fg-selected: #404040;
+  --color-fg-tertiary: var(--grey-500);
+  --color-fg-warn: #cf212e;
+  --color-progressbar-fg-1: #303030;
+  --color-progressbar-fg-2: #edefff;
+  --color-progressbar-fg-3: #edefff;
+  --color-progressbar-leech: var(--blue-100);
+  --color-progressbar-magnet: var(--yellow-300);
+  --color-progressbar-paused: var(--grey-200);
+  --color-progressbar-queued: var(--blue-400);
+  --color-progressbar-seed-1: var(--green-500);
+  --color-progressbar-seed-2: var(--green-300);
+  --color-progressbar-seed-paused: var(--grey-200);
+  --color-progressbar-verify: var(--yellow-300);
+  --progress-bar-shadow-1: 0;
+  --progress-bar-shadow-2: 1px 1px #000;
+  --progress-bar-shadow-3: 1px 1px #000;
+
+  .contrast-more {
+    --color-bg-even: var(--white);
+    --color-bg-hover: var(--grey-40);
+    --color-bg-selected: var(--default-accent-color-strong);
+    --color-bg-tabs: var(--white);
+    --color-bg-warn: #cf6679;
+    --color-border-default: var(--black);
+    --color-border-stark: var(--black);
+    --color-border-starkest: var(--black);
+    --color-fg-disabled: var(--black);
+    --color-fg-error: var(--red-500);
+    --color-fg-on-popup: var(--black);
+    --color-fg-port-closed: var(--red-500);
+    --color-fg-port-open: var(--green-400);
+    --color-fg-primary: var(--black);
+    --color-fg-secondary: var(--black);
+    --color-fg-selected: var(--black);
+    --color-fg-tabs: var(--black);
+    --color-fg-tertiary: var(--black);
+    --color-fg-warn: var(--white);
+    --color-progressbar-background-2: var(--white);
+    --color-progressbar-fg-1: #fff;
+    --color-progressbar-fg-2: #fff;
+    --color-progressbar-fg-3: #000;
+    --color-progressbar-leech: var(--blue-200);
+    --color-progressbar-magnet: var(--yellow-300);
+    --color-progressbar-paused: var(--grey-500);
+    --color-progressbar-queued: var(--blue-400);
+    --color-progressbar-seed-1: var(--black);
+    --color-progressbar-seed-2: var(--white);
+    --color-progressbar-seed-paused: var(--grey-500);
+    --color-progressbar-verify: var(--yellow-300);
+    --color-toolbar-background: var(--white);
+    --progress-bar-shadow-1: 1px 1px #000;
+    --progress-bar-shadow-3: 0;
+  }
+}
+
 :root {
   /* z-index enum */
   --z-index-popup: 2;
@@ -87,140 +224,28 @@
 
   color-scheme: light dark;
 
-  @media (prefers-color-scheme: dark) {
-    --color-bg-hover: var(--grey-40);
-    --color-bg-odd: var(--black);
-    --color-bg-popup: var(--black);
-    --color-bg-primary: var(--black);
-    --color-bg-selected: var(--default-accent-color-strong);
-    --color-bg-warn: #cf6679;
-    --color-border-default: var(--default-border-dark);
-    --color-border-stark: var(--dark-mode-white);
-    --color-border-starkest: var(--grey-500);
-    --color-fg-disabled: var(--grey);
-    --color-fg-on-popup: var(--nice-grey);
-    --color-fg-primary: var(--dark-mode-white);
-    --color-fg-secondary: var(--nice-grey);
-    --color-fg-selected: #404040;
-    --color-fg-tertiary: var(--grey-500);
-    --color-fg-warn: var(--dark-mode-black);
-    --color-progressbar-fg-1: #edefff;
-    --color-progressbar-fg-2: #edefff;
-    --color-progressbar-fg-3: #edefff;
-    --color-progressbar-paused: var(--grey-500);
-    --color-progressbar-seed-1: var(--green-100);
-    --color-progressbar-seed-2: var(--green-400);
-    --color-progressbar-seed-paused: var(--grey-500);
-    --progress-bar-shadow-1: 1px 1px #000;
-    --progress-bar-shadow-2: 1px 1px #000;
-    --progress-bar-shadow-3: 1px 1px #000;
+  /* Follow the browser (and therefore the OS) preference by default, but let
+     the user override it from Appearance > Color scheme. */
+  &:not([data-color-scheme]) {
+    @media (prefers-color-scheme: dark) {
+      @include color-scheme-dark;
+    }
 
-    .contrast-more {
-      --color-bg-even: var(--black);
-      --color-bg-hover: var(--grey-40);
-      --color-bg-tabs: var(--black);
-      --color-bg-warn: #cf6679;
-      --color-border-default: var(--white);
-      --color-border-stark: var(--white);
-      --color-border-starkest: var(--white);
-      --color-fg-disabled: var(--white);
-      --color-fg-error: var(--red-500);
-      --color-fg-on-popup: var(--white);
-      --color-fg-port-closed: var(--red-500);
-      --color-fg-port-open: var(--green-100);
-      --color-fg-primary: var(--white);
-      --color-fg-secondary: var(--white);
-      --color-fg-selected: var(--black);
-      --color-fg-tabs: var(--white);
-      --color-fg-tertiary: var(--white);
-      --color-fg-warn: var(--black);
-      --color-progressbar-fg-1: #fff;
-      --color-progressbar-fg-2: #fff;
-      --color-progressbar-fg-3: #000;
-      --color-progressbar-background-2: var(--white);
-      --color-progressbar-magnet: var(--yellow-300);
-      --color-progressbar-paused: var(--grey-500);
-      --color-progressbar-queued: var(--blue-400);
-      --color-progressbar-seed-1: var(--black);
-      --color-progressbar-seed-2: var(--white);
-      --color-progressbar-seed-paused: var(--grey-500);
-      --color-progressbar-verify: var(--yellow-300);
-      --color-toolbar-background: var(--black);
-      --progress-bar-shadow-3: 0;
+    @media (prefers-color-scheme: light) {
+      @include color-scheme-light;
     }
   }
-  @media (prefers-color-scheme: light) {
-    --color-bg-hover: var(--nice-grey);
-    --color-bg-odd: var(--white);
-    --color-bg-popup: var(--white);
-    --color-bg-primary: var(--white);
-    --color-bg-selected: var(--default-accent-color);
-    --color-bg-warn: #e4606d5b;
-    --color-border-default: var(--default-border-light);
-    --color-border-stark: var(--grey-500);
-    --color-border-starkest: #d0d7de;
-    --color-dialog-border: var(--nice-grey);
-    --color-fg-disabled: var(--grey);
-    --color-fg-error: var(--red-500);
-    --color-fg-on-popup: var(--grey-900);
-    --color-fg-port-closed: var(--red-500);
-    --color-fg-port-open: var(--green-400);
-    --color-fg-primary: #404040;
-    --color-fg-secondary: var(--grey-500);
-    --color-fg-selected: #404040;
-    --color-fg-tertiary: var(--grey-500);
-    --color-fg-warn: #cf212e;
-    --color-progressbar-fg-1: #303030;
-    --color-progressbar-fg-2: #edefff;
-    --color-progressbar-fg-3: #edefff;
-    --color-progressbar-leech: var(--blue-100);
-    --color-progressbar-magnet: var(--yellow-300);
-    --color-progressbar-paused: var(--grey-200);
-    --color-progressbar-queued: var(--blue-400);
-    --color-progressbar-seed-1: var(--green-500);
-    --color-progressbar-seed-2: var(--green-300);
-    --color-progressbar-seed-paused: var(--grey-200);
-    --color-progressbar-verify: var(--yellow-300);
-    --progress-bar-shadow-1: 0;
-    --progress-bar-shadow-2: 1px 1px #000;
-    --progress-bar-shadow-3: 1px 1px #000;
 
-    .contrast-more {
-      --color-bg-even: var(--white);
-      --color-bg-hover: var(--grey-40);
-      --color-bg-selected: var(--default-accent-color-strong);
-      --color-bg-tabs: var(--white);
-      --color-bg-warn: #cf6679;
-      --color-border-default: var(--black);
-      --color-border-stark: var(--black);
-      --color-border-starkest: var(--black);
-      --color-fg-disabled: var(--black);
-      --color-fg-error: var(--red-500);
-      --color-fg-on-popup: var(--black);
-      --color-fg-port-closed: var(--red-500);
-      --color-fg-port-open: var(--green-400);
-      --color-fg-primary: var(--black);
-      --color-fg-secondary: var(--black);
-      --color-fg-selected: var(--black);
-      --color-fg-tabs: var(--black);
-      --color-fg-tertiary: var(--black);
-      --color-fg-warn: var(--white);
-      --color-progressbar-background-2: var(--white);
-      --color-progressbar-fg-1: #fff;
-      --color-progressbar-fg-2: #fff;
-      --color-progressbar-fg-3: #000;
-      --color-progressbar-leech: var(--blue-200);
-      --color-progressbar-magnet: var(--yellow-300);
-      --color-progressbar-paused: var(--grey-500);
-      --color-progressbar-queued: var(--blue-400);
-      --color-progressbar-seed-1: var(--black);
-      --color-progressbar-seed-2: var(--white);
-      --color-progressbar-seed-paused: var(--grey-500);
-      --color-progressbar-verify: var(--yellow-300);
-      --color-toolbar-background: var(--white);
-      --progress-bar-shadow-1: 1px 1px #000;
-      --progress-bar-shadow-3: 0;
-    }
+  &[data-color-scheme='dark'] {
+    color-scheme: dark;
+
+    @include color-scheme-dark;
+  }
+
+  &[data-color-scheme='light'] {
+    color-scheme: light;
+
+    @include color-scheme-light;
   }
 }
 

--- a/web/src/appearance-settings.js
+++ b/web/src/appearance-settings.js
@@ -98,6 +98,33 @@ export class Appearance extends EventTarget {
 
     add_check(this.action_manager.text('toggle-contrast'), listener);
 
+    // color scheme
+
+    legend = document.createElement('h4');
+    message.append(legend);
+    legend.textContent = 'Color scheme';
+
+    div = document.createElement('div');
+    div.classList.add('table-row');
+    message.append(div);
+
+    listener = (e) => {
+      e.checked = this.prefs.color_scheme === e.value;
+      e.addEventListener('change', (event_) => {
+        this.prefs.color_scheme = event_.target.value;
+      });
+    };
+
+    add_radio(
+      'color-scheme',
+      'Match system',
+      null,
+      Prefs.ColorSchemeSystem,
+      listener,
+    );
+    add_radio('color-scheme', 'Light', null, Prefs.ColorSchemeLight, listener);
+    add_radio('color-scheme', 'Dark', null, Prefs.ColorSchemeDark, listener);
+
     // highlight color
 
     legend = document.createElement('h4');

--- a/web/src/prefs.js
+++ b/web/src/prefs.js
@@ -103,6 +103,10 @@ Prefs.DisplayMode = 'display-mode';
 Prefs.ContrastLess = 'less';
 Prefs.ContrastMore = 'more';
 Prefs.ContrastMode = 'contrast-mode';
+Prefs.ColorScheme = 'color-scheme';
+Prefs.ColorSchemeSystem = 'system';
+Prefs.ColorSchemeLight = 'light';
+Prefs.ColorSchemeDark = 'dark';
 Prefs.FilterActive = 'active';
 Prefs.FilterAll = 'all';
 Prefs.FilterDownloading = 'downloading';
@@ -132,6 +136,7 @@ Prefs.SortMode = 'sort-mode';
 Prefs._Defaults = {
   [Prefs.AltSpeedEnabled]: false,
   [Prefs.DisplayMode]: Prefs.DisplayFull,
+  [Prefs.ColorScheme]: Prefs.ColorSchemeSystem,
   [Prefs.ContrastMode]: globalThis.matchMedia('(prefers-contrast: more)')
     .matches
     ? Prefs.ContrastMore

--- a/web/src/transmission.js
+++ b/web/src/transmission.js
@@ -469,6 +469,21 @@ export class Transmission extends EventTarget {
         this.refilterAllSoon();
         break;
       }
+      case Prefs.ColorScheme: {
+        // Pin the color scheme to the user's choice. When it's left up to the
+        // system, drop the attribute so the prefers-color-scheme media queries
+        // take over again.
+        if (
+          value === Prefs.ColorSchemeLight ||
+          value === Prefs.ColorSchemeDark
+        ) {
+          document.documentElement.dataset.colorScheme = value;
+        } else {
+          delete document.documentElement.dataset.colorScheme;
+        }
+        break;
+      }
+
       case Prefs.ContrastMode: {
         // Add custom class to the body/html element to get the appropriate contrast color scheme
         document.body.classList.remove('contrast-more', 'contrast-less');


### PR DESCRIPTION
## Description

Fixes #8138.

The web client picked its colours from `prefers-color-scheme` only, so there was no way to run the UI in dark mode from a light-mode desktop (or the reverse) — which is what the issue asks for, and what Sonarr/Radarr/etc. offer.

**CSS** — the light and dark custom-property blocks are moved verbatim into `@mixin color-scheme-light` / `@mixin color-scheme-dark` (including their nested `.contrast-more` overrides). `:root` then includes them either from the existing media queries, guarded by `:not([data-color-scheme])`, or directly from `[data-color-scheme='light'|'dark']`. `color-scheme` is narrowed to match when a scheme is pinned, so form controls and scrollbars follow too.

Because the media-query rules no longer match once the attribute is set, there is no specificity fight between the two paths — and with no attribute set, the generated CSS is identical to before.

**JS** — new `Prefs.ColorScheme` (`system` / `light` / `dark`, defaulting to `system`, persisted like the other appearance prefs), applied in `_onPrefChanged` by setting or removing `data-color-scheme` on `<html>`. A "Color scheme" radio group (Match system / Light / Dark) sits in the Appearance dialog next to the existing contrast and highlight-colour controls.

Default behaviour is unchanged for anyone who doesn't touch the new setting.

`npm run build` and `npm run lint` (eslint + stylelint + prettier) both pass. Generated files under `web/public_html/` are intentionally left out, since those are refreshed separately in the "chore: update generated transmission-web files" commits.

## Checklist

- [x] I have manually written or manually audited all changes in this PR and vouch for them.
