### PR TITLE
fix: don't let expendable web tasks stall session shutdown

### DIFF
--- a/libtransmission/announcer-udp.cc
+++ b/libtransmission/announcer-udp.cc
@@ -512,6 +512,11 @@ struct tau_tracker
         return std::empty(announces) && std::empty(scrapes);
     }
 
+    void start_shutdown(time_t deadline)
+    {
+        shutdown_expires_at_ = deadline;
+    }
+
 private:
     using Sockaddr = std::pair<sockaddr_storage, socklen_t>;
     using MaybeSockaddr = std::optional<Sockaddr>;
@@ -546,6 +551,25 @@ private:
 
     void timeout_requests(time_t now)
     {
+        if (shutdown_expires_at_ != 0)
+        {
+            // During shutdown, a request that's been sent has served its
+            // purpose, e.g. an `event=stopped` announce is delivered even
+            // when we never see the response, so don't wait for one...
+            finish_sent_requests(announces);
+            finish_sent_requests(scrapes);
+
+            // ...and when the shutdown grace period is up, whatever is
+            // left has missed its chance
+            if (shutdown_expires_at_ <= now)
+            {
+                fail_all(false, true, "");
+                connecting_at = {};
+                connection_transaction_id = {};
+                return;
+            }
+        }
+
         for (ipp_t ipp = 0; ipp < NUM_TR_AF_INET_TYPES; ++ipp)
         {
             if (auto const conn_at = connecting_at[ipp]; conn_at != 0 && conn_at + ConnectionRequestTtl < now)
@@ -557,6 +581,23 @@ private:
 
         timeout_requests(announces, now, "announce"sv);
         timeout_requests(scrapes, now, "scrape"sv);
+    }
+
+    template<typename T>
+    void finish_sent_requests(std::list<T>& requests)
+    {
+        for (auto it = std::begin(requests); it != std::end(requests);)
+        {
+            if (auto& req = *it; req.sent_at != 0)
+            {
+                req.fail(true, true, "");
+                it = requests.erase(it);
+            }
+            else
+            {
+                ++it;
+            }
+        }
     }
 
     template<typename T>
@@ -667,6 +708,8 @@ private:
 
     static constexpr auto DnsRetryIntervalSecs = time_t{ 3600 };
     static constexpr auto ConnectionRequestTtl = time_t{ 30 };
+
+    time_t shutdown_expires_at_ = 0;
 };
 
 // --- SESSION
@@ -705,6 +748,15 @@ public:
 
         tracker->scrapes.emplace_back(request, std::move(on_response));
         tracker->upkeep(false);
+    }
+
+    void startShutdown() override
+    {
+        auto const deadline = tr_time() + TrShutdownAnnounceGraceSecs.count();
+        for (auto& tracker : trackers_)
+        {
+            tracker.start_shutdown(deadline);
+        }
     }
 
     void upkeep() override

--- a/libtransmission/announcer.h
+++ b/libtransmission/announcer.h
@@ -9,6 +9,7 @@
 #error only libtransmission should #include this header.
 #endif
 
+#include <chrono>
 #include <cstddef> // size_t
 #include <cstdint> // uint32_t
 #include <ctime>
@@ -127,6 +128,12 @@ struct tr_scrape_response;
 
 // --- UDP ANNOUNCER
 
+// How long shutdown waits for pending announces, e.g. `event=stopped`
+// messages to trackers. A tracker that can't accept a request within
+// this window won't get it from a longer wait either, so don't let
+// unresponsive trackers stall shutdown.
+inline constexpr auto TrShutdownAnnounceGraceSecs = std::chrono::seconds{ 5 };
+
 using tr_scrape_response_func = std::function<void(tr_scrape_response const&)>;
 using tr_announce_response_func = std::function<void(tr_announce_response const&)>;
 
@@ -155,6 +162,12 @@ public:
     virtual void scrape(tr_scrape_request const& request, tr_scrape_response_func on_response) = 0;
 
     virtual void upkeep() = 0;
+
+    // Tell the announcer that shutdown has begun: requests that have
+    // been sent are considered done without waiting for a response, and
+    // the rest get `TrShutdownAnnounceGraceSecs` to finish before they
+    // are failed so that `is_idle()` can come true.
+    virtual void startShutdown() = 0;
 
     // @brief process an incoming udp message if it's a tracker response.
     // @return true if msg was a tracker response; false otherwise

--- a/libtransmission/ip-cache.cc
+++ b/libtransmission/ip-cache.cc
@@ -266,6 +266,8 @@ void tr_ip_cache::update_global_addr(tr_address_type const type) noexcept
     options.ip_proto = IPProtocolMap[type];
     options.sndbuf = 4096;
     options.rcvbuf = 4096;
+    // an in-flight IP query must not delay session shutdown
+    options.cancel_on_shutdown = true;
     mediator_.fetch(std::move(options));
 }
 

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -1441,16 +1441,20 @@ void tr_session::closeImplPart1(std::promise<void>* closed_promise, std::chrono:
     // Tell the announcer to start shutdown, which sends out the stop
     // events and stops scraping.
     this->announcer_->startShutdown();
+    this->announcer_udp_->startShutdown();
     // ...since global_ip_cache_ relies on web_ to update global addresses,
     // we tell it to stop updating before web_ starts to refuse new requests.
     // But we keep it intact for now, so that udp_core_ can continue.
     this->ip_cache_->try_shutdown();
     // ...and now that those are done, tell web_ that we're shutting
     // down soon. This leaves the `event=stopped` going but refuses any
-    // new tasks.
+    // new tasks. The announces get at most `TrShutdownAnnounceGraceSecs`:
+    // a tracker that can't accept a request within that window won't
+    // get it from a longer wait either.
     auto const now = std::chrono::steady_clock::now();
     auto const remaining_ms = now < deadline ? std::chrono::duration_cast<std::chrono::milliseconds>(deadline - now) : 0ms;
-    this->web_->startShutdown(remaining_ms);
+    this->web_->startShutdown(
+        std::min(remaining_ms, std::chrono::duration_cast<std::chrono::milliseconds>(TrShutdownAnnounceGraceSecs)));
 
     // recycle the now-unused save_timer_ here to wait for UDP shutdown
     TR_ASSERT(!save_timer_);

--- a/libtransmission/web.cc
+++ b/libtransmission/web.cc
@@ -795,16 +795,27 @@ public:
                 }
             }
 
-            // if shutdown has begun, cancel the tasks that were flagged
+            // If shutdown has begun, cancel the tasks that were flagged
             // as not being worth waiting for, so that only tasks such as
-            // `event=stopped` announces can use the shutdown grace period
+            // `event=stopped` announces can use the shutdown grace period.
+            // And a task whose request has already reached the server has
+            // served its purpose: what remains during shutdown are
+            // notify-style messages whose responses aren't worth waiting
+            // for either.
             if (deadline_exists())
             {
                 for (auto it = std::begin(running_tasks_); it != std::end(running_tasks_);)
                 {
                     auto& task = *it++;
-                    if (task.cancelOnShutdown())
+
+                    auto pretransfer_secs = double{};
+                    auto const request_was_sent = task.easy() != nullptr &&
+                        curl_easy_getinfo(task.easy(), CURLINFO_PRETRANSFER_TIME, &pretransfer_secs) == CURLE_OK &&
+                        pretransfer_secs > 0.0;
+
+                    if (task.cancelOnShutdown() || request_was_sent)
                     {
+                        task.response.did_connect = task.response.did_connect || request_was_sent;
                         curl_multi_remove_handle(multi.get(), task.easy());
                         remove_task(task);
                     }

--- a/libtransmission/web.cc
+++ b/libtransmission/web.cc
@@ -243,6 +243,15 @@ public:
     {
         if (deadline_exists())
         {
+            // Shutdown has begun, so refuse the task. Send the caller
+            // an empty response so that it's still notified even when
+            // its request was never run.
+            if (options.done_func)
+            {
+                auto response = FetchResponse{};
+                response.user_data = options.done_func_user_data;
+                mediator.run(std::move(options.done_func), std::move(response));
+            }
             return;
         }
 
@@ -326,6 +335,11 @@ public:
         [[nodiscard]] constexpr auto const& timeoutSecs() const
         {
             return options_.timeout_secs;
+        }
+
+        [[nodiscard]] constexpr auto cancelOnShutdown() const
+        {
+            return options_.cancel_on_shutdown;
         }
 
         [[nodiscard]] constexpr auto ipProtocol() const
@@ -778,6 +792,22 @@ public:
                     }
 
                     running_tasks_.splice(std::end(running_tasks_), queued_tasks_);
+                }
+            }
+
+            // if shutdown has begun, cancel the tasks that were flagged
+            // as not being worth waiting for, so that only tasks such as
+            // `event=stopped` announces can use the shutdown grace period
+            if (deadline_exists())
+            {
+                for (auto it = std::begin(running_tasks_); it != std::end(running_tasks_);)
+                {
+                    auto& task = *it++;
+                    if (task.cancelOnShutdown())
+                    {
+                        curl_multi_remove_handle(multi.get(), task.easy());
+                        remove_task(task);
+                    }
                 }
             }
 

--- a/libtransmission/web.h
+++ b/libtransmission/web.h
@@ -83,6 +83,11 @@ public:
         // Maximum time to wait before timeout
         std::chrono::seconds timeout_secs = DefaultTimeoutSecs;
 
+        // If set, the request is not worth delaying shutdown for:
+        // startShutdown() cancels it right away instead of giving it
+        // time to finish the way it does e.g. `event=stopped` announces.
+        bool cancel_on_shutdown = false;
+
         // Called periodically by the web internals when data is received.
         // Used by webseeds to report to tr_bandwidth for data xfer stats
         std::function<void(size_t /*n_bytes*/)> on_data_received;

--- a/tests/libtransmission/CMakeLists.txt
+++ b/tests/libtransmission/CMakeLists.txt
@@ -65,6 +65,7 @@ target_sources(libtransmission-test
         values-test.cc
         variant-test.cc
         watchdir-test.cc
+        web-test.cc
         web-utils-test.cc)
 
 if(APPLE)

--- a/tests/libtransmission/announcer-udp-test.cc
+++ b/tests/libtransmission/announcer-udp-test.cc
@@ -1269,3 +1269,63 @@ TEST_F(AnnouncerUdpTest, announceDualStackNoneSuccessful)
         }
     }
 }
+
+TEST_F(AnnouncerUdpTest, shutdownDoesNotWaitForUnresponsiveTracker)
+{
+    auto mediator = MockMediator{};
+    auto announcer = tr_announcer_udp::create(mediator);
+    auto upkeep_timer = createUpkeepTimer(mediator, announcer);
+
+    // tell announcer to scrape, but never let the "tracker" respond,
+    // as if the tracker were unreachable
+    auto [request, expected_response] = buildSimpleScrapeRequestAndResponse();
+    auto response = std::optional<tr_scrape_response>{};
+    announcer->scrape(request, [&response](tr_scrape_response const& resp) { response = resp; });
+
+    // the announcer sent a connection request that will never be answered
+    (void)parseConnectionRequest(waitForAnnouncerToSendMessage(mediator));
+    EXPECT_FALSE(announcer->is_idle());
+
+    // Shutdown must not wait out the full request TTL for a tracker
+    // that isn't responding: once the grace period is up, the pending
+    // requests are failed so that is_idle() can come true.
+    announcer->startShutdown();
+    tr_timeUpdate(tr_time() + TrShutdownAnnounceGraceSecs.count() + 1);
+    announcer->upkeep();
+
+    EXPECT_TRUE(announcer->is_idle());
+    ASSERT_TRUE(response.has_value());
+    EXPECT_TRUE(response->did_timeout);
+}
+
+TEST_F(AnnouncerUdpTest, shutdownDoesNotWaitForResponsesToSentRequests)
+{
+    auto mediator = MockMediator{};
+    auto announcer = tr_announcer_udp::create(mediator);
+    auto upkeep_timer = createUpkeepTimer(mediator, announcer);
+
+    // tell announcer to scrape
+    auto [request, expected_response] = buildSimpleScrapeRequestAndResponse();
+    auto response = std::optional<tr_scrape_response>{};
+    announcer->scrape(request, [&response](tr_scrape_response const& resp) { response = resp; });
+
+    auto from = sockaddr_storage{};
+    auto* const from_ptr = reinterpret_cast<struct sockaddr*>(&from);
+    auto fromlen = socklen_t{};
+
+    // let the connection handshake finish so the scrape request goes out
+    auto const connect_transaction_id = parseConnectionRequest(waitForAnnouncerToSendMessage(mediator, from_ptr, &fromlen));
+    auto const connection_id = sendConnectionResponse(*announcer, connect_transaction_id, from_ptr, fromlen);
+    (void)parseScrapeRequest(waitForAnnouncerToSendMessage(mediator), connection_id);
+    EXPECT_FALSE(announcer->is_idle());
+
+    // A request that has been sent has served its purpose. Shutdown
+    // must not wait for its response, without needing any grace period
+    // to pass.
+    announcer->startShutdown();
+    announcer->upkeep();
+
+    EXPECT_TRUE(announcer->is_idle());
+    ASSERT_TRUE(response.has_value());
+    EXPECT_TRUE(response->did_timeout);
+}

--- a/tests/libtransmission/web-test.cc
+++ b/tests/libtransmission/web-test.cc
@@ -1,0 +1,69 @@
+// This file Copyright © Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
+
+#include <atomic>
+#include <chrono>
+#include <cstddef> // size_t
+#include <utility>
+
+#include <libtransmission/web.h>
+
+#include <gtest/gtest.h>
+
+#include "test-fixtures.h"
+
+using namespace std::literals;
+
+using WebTest = ::testing::Test;
+
+TEST_F(WebTest, fetchAfterShutdownStartedStillInvokesCallback)
+{
+    auto mediator = tr_web::Mediator{};
+    auto web = tr_web::create(mediator);
+    web->startShutdown(15s);
+
+    auto n_responses = size_t{};
+    auto status = long{ -1 };
+    void* user_data = nullptr;
+    auto marker = int{};
+    web->fetch(
+        { "http://127.0.0.1/"sv,
+          [&](tr_web::FetchResponse const& response)
+          {
+              status = response.status;
+              user_data = response.user_data;
+              ++n_responses;
+          },
+          &marker });
+
+    // the callers of a refused fetch must still be sent a response,
+    // otherwise ones that hold state until their callback is invoked
+    // (e.g. tr_ip_cache) block shutdown until the deadline expires.
+    // the default Mediator::run() is synchronous, so no need to wait
+    EXPECT_EQ(1U, n_responses);
+    EXPECT_EQ(0L, status);
+    EXPECT_EQ(&marker, user_data);
+}
+
+TEST_F(WebTest, startShutdownCancelsFlaggedTasksPromptly)
+{
+    auto mediator = tr_web::Mediator{};
+    auto web = tr_web::create(mediator);
+
+    auto n_responses = std::atomic<size_t>{};
+    // 192.0.2.1 is TEST-NET-1 (RFC 5737): the connection attempt can
+    // neither succeed nor finish quickly, like a black-holed endpoint
+    auto options = tr_web::FetchOptions{ "http://192.0.2.1/"sv,
+                                         [&n_responses](tr_web::FetchResponse const& /*response*/) { ++n_responses; },
+                                         nullptr };
+    options.cancel_on_shutdown = true;
+    web->fetch(std::move(options));
+
+    web->startShutdown(30s);
+
+    // the flagged task must be canceled as soon as shutdown starts
+    // instead of using up the 30s shutdown grace period
+    EXPECT_TRUE(tr::test::waitFor([&]() { return n_responses > 0U && web->is_idle(); }, 10s));
+}


### PR DESCRIPTION
Quitting takes the full 15-second shutdown deadline even with an empty queue (#8997), and again after removing a torrent whose tracker is unresponsive. Two commits, one per cause.

## Summary

**Commit 1: expendable web tasks.** `tr_sessionClose()` polls `closeImplPart2()` until `web_->is_idle() && announcer_udp_->is_idle() && ip_cache_->try_shutdown()`, or until the deadline (15s by default) expires. Two defects hold that condition false:

- `tr_web::fetch()` silently drops new tasks once shutdown has begun. The IP cache retry path (`on_response_ip_query` -> `update_global_addr` -> `fetch`) then never receives a response, so `is_updating_` stays `Yes` and `try_shutdown()` returns false until the deadline.
- Running tasks are only killed once the deadline is *reached*. The IP cache queries `ip4`/`ip6.transmissionbt.com` at session start with a 120s fetch timeout and a 30s retry interval, so an endpoint that hangs (firewalled, black-holed route, broken IPv6 connectivity) keeps a query in flight most of the wall-clock time, holding `web_->is_idle()` false for the entire grace period.

Fix: a refused `fetch()` now responds with an empty `FetchResponse` instead of dropping the task, and `tr_web::FetchOptions` gains a `cancel_on_shutdown` flag; flagged tasks are canceled as soon as `startShutdown()` is called. The IP cache queries set it.

**Commit 2: unresponsive trackers.** The `event=stopped` announces carry a 45s timeout, so removing a torrent with a dead tracker and quitting burned the full deadline again. Waiting that long buys nothing: an announce that has reached the server is delivered whether or not a response arrives, and a tracker that can't accept a request within a few seconds of shutdown won't accept it later either. So during shutdown, `tr_web` cancels tasks whose request is already on the wire (`CURLINFO_PRETRANSFER_TIME > 0`), the session caps the web deadline at a new `TrShutdownAnnounceGraceSecs` (5s) to bound the tasks that can't even connect, and the UDP announcer gains `startShutdown()` with the same semantics (sent requests are done; the rest get the grace period instead of idling out their 45s TTL).

## Test plan

- New `web-test.cc`: a refused fetch still invokes its callback, and a flagged in-flight task is canceled promptly at `startShutdown()`. Both fail without the libtransmission changes.
- New `announcer-udp-test.cc` cases: after `startShutdown()`, a sent-but-unanswered request finishes immediately, and an unreachable tracker's requests are failed once the grace period is up so `is_idle()` comes true.
- Full libtransmission suite passes; `./code_style.sh --check` clean.
- Manual, transmission-daemon against a local tracker that accepts the TCP connection but never responds:
  - empty session, IP query in flight, SIGTERM: 15.25s -> 0.16s
  - add torrent, remove it, SIGTERM right after: 15.54s -> 0.26s

Notes: fixed: quitting could take 15 seconds when a public IP query was hanging or when a removed torrent's tracker was unresponsive
