### PR TITLE
fix: keep failed disk writes from wedging the cache or passing silently

### DIFF
--- a/libtransmission/cache.cc
+++ b/libtransmission/cache.cc
@@ -23,6 +23,7 @@
 #include "libtransmission/torrent.h"
 #include "libtransmission/torrents.h"
 #include "libtransmission/tr-assert.h"
+#include "libtransmission/utils.h" // _()
 
 Cache::Key Cache::make_key(tr_torrent const& tor, tr_block_info::Location const loc) noexcept
 {
@@ -117,7 +118,7 @@ int Cache::set_limit(Memory const max_size)
     max_blocks_ = get_max_blocks(max_size);
     tr_logAddDebug(fmt::format("Maximum cache size set to {} ({} blocks)", max_size.to_string(), max_blocks_));
 
-    return cache_trim();
+    return cache_trim().first;
 }
 
 Cache::Cache(tr_torrents const& torrents, Memory const max_size)
@@ -154,7 +155,18 @@ int Cache::write_block(tr_torrent_id_t const tor_id, tr_block_index_t const bloc
     ++cache_writes_;
     cache_write_bytes_ += std::size(*iter->buf);
 
-    return cache_trim();
+    if (auto const [err, err_tor_id] = cache_trim(); err != 0)
+    {
+        // The error belongs to whichever torrent failed to flush.
+        // Report it here only if that torrent is the caller's, so that
+        // the caller doesn't mark this block as complete.
+        if (err_tor_id == tor_id || torrents_.get(tor_id) == nullptr)
+        {
+            return err;
+        }
+    }
+
+    return 0;
 }
 
 Cache::CIter Cache::get_block(tr_torrent const& tor, tr_block_info::Location const& loc) noexcept
@@ -185,21 +197,53 @@ int Cache::read_block(tr_torrent const& tor, tr_block_info::Location const& loc,
 
 // ---
 
-int Cache::flush_span(CIter const& begin, CIter const& end)
+Cache::FlushResult Cache::flush_span(CIter const& begin, CIter const& end)
 {
-    for (auto span_begin = begin; span_begin < end;)
+    if (begin == end)
     {
-        auto const span_end = find_span_end(span_begin, end);
+        return {};
+    }
+
+    // Extract the span from the cache before writing it, for two reasons:
+    //
+    // 1. A failed tr_ioWrite() stops the offending torrent with a local
+    //    error, which reentrantly flushes and erases that torrent's other
+    //    cached blocks, invalidating any iterator into `blocks_`.
+    //
+    // 2. A span that can't be written must be dropped, not kept. Keeping
+    //    unwritable blocks would wedge the cache and starve the torrents
+    //    that can still write.
+    //    https://github.com/transmission/transmission/issues/5747
+    auto const first = std::distance(std::cbegin(blocks_), begin);
+    auto const count = std::distance(begin, end);
+    auto pending = Blocks{};
+    pending.reserve(static_cast<size_t>(count));
+    std::move(std::begin(blocks_) + first, std::begin(blocks_) + first + count, std::back_inserter(pending));
+    blocks_.erase(begin, end);
+
+    // all blocks in [begin, end) belong to the same torrent
+    auto const tor_id = pending.front().key.first;
+
+    for (auto span_begin = std::cbegin(pending), pending_end = std::cend(pending); span_begin < pending_end;)
+    {
+        auto const span_end = find_span_end(span_begin, pending_end);
 
         if (auto const err = write_contiguous(span_begin, span_end); err != 0)
         {
-            return err;
+            // Stop at the first failure instead of writing the rest:
+            // a failed tr_ioWrite() has stopped the torrent and closed
+            // its files, and writing on would reopen them for a torrent
+            // that can no longer use them.
+            tr_logAddWarn(
+                fmt::format(
+                    fmt::runtime(_("Couldn't write {count} cached blocks to disk; verify local data to re-download them")),
+                    fmt::arg("count", std::distance(span_begin, pending_end))));
+            return { err, tor_id };
         }
 
         span_begin = span_end;
     }
 
-    blocks_.erase(begin, end);
     return {};
 }
 
@@ -209,44 +253,48 @@ int Cache::flush_file(tr_torrent const& tor, tr_file_index_t const file)
     auto const [block_begin, block_end] = tor.block_span_for_file(file);
 
     return flush_span(
-        std::lower_bound(std::begin(blocks_), std::end(blocks_), std::make_pair(tor_id, block_begin), CompareCacheBlockByKey),
-        std::lower_bound(std::begin(blocks_), std::end(blocks_), std::make_pair(tor_id, block_end), CompareCacheBlockByKey));
+               std::lower_bound(
+                   std::begin(blocks_),
+                   std::end(blocks_),
+                   std::make_pair(tor_id, block_begin),
+                   CompareCacheBlockByKey),
+               std::lower_bound(
+                   std::begin(blocks_),
+                   std::end(blocks_),
+                   std::make_pair(tor_id, block_end),
+                   CompareCacheBlockByKey))
+        .first;
 }
 
 int Cache::flush_torrent(tr_torrent_id_t const tor_id)
 {
     return flush_span(
-        std::lower_bound(std::begin(blocks_), std::end(blocks_), std::make_pair(tor_id, 0), CompareCacheBlockByKey),
-        std::lower_bound(std::begin(blocks_), std::end(blocks_), std::make_pair(tor_id + 1, 0), CompareCacheBlockByKey));
+               std::lower_bound(std::begin(blocks_), std::end(blocks_), std::make_pair(tor_id, 0), CompareCacheBlockByKey),
+               std::lower_bound(std::begin(blocks_), std::end(blocks_), std::make_pair(tor_id + 1, 0), CompareCacheBlockByKey))
+        .first;
 }
 
-int Cache::flush_biggest()
+Cache::FlushResult Cache::flush_biggest()
 {
     auto const [begin, end] = find_biggest_span(std::begin(blocks_), std::end(blocks_));
 
     if (begin == end) // nothing to flush
     {
-        return 0;
+        return {};
     }
 
-    if (auto const err = write_contiguous(begin, end); err != 0)
-    {
-        return err;
-    }
-
-    blocks_.erase(begin, end);
-    return 0;
+    return flush_span(begin, end);
 }
 
-int Cache::cache_trim()
+Cache::FlushResult Cache::cache_trim()
 {
     while (std::size(blocks_) > max_blocks_)
     {
-        if (auto const err = flush_biggest(); err != 0)
+        if (auto const res = flush_biggest(); res.first != 0)
         {
-            return err;
+            return res;
         }
     }
 
-    return 0;
+    return {};
 }

--- a/libtransmission/cache.h
+++ b/libtransmission/cache.h
@@ -35,12 +35,13 @@ public:
 
     int set_limit(Memory max_size);
 
-    // @return any error code from cacheTrim()
-    int write_block(tr_torrent_id_t tor, tr_block_index_t block, std::unique_ptr<BlockData> writeme);
+    // @return an error code if this torrent's own blocks failed to flush;
+    // other torrents' flush errors are not reported to this caller.
+    [[nodiscard]] int write_block(tr_torrent_id_t tor, tr_block_index_t block, std::unique_ptr<BlockData> writeme);
 
     int read_block(tr_torrent const& tor, tr_block_info::Location const& loc, size_t len, uint8_t* setme);
-    int flush_torrent(tr_torrent_id_t tor_id);
-    int flush_file(tr_torrent const& tor, tr_file_index_t file);
+    [[nodiscard]] int flush_torrent(tr_torrent_id_t tor_id);
+    [[nodiscard]] int flush_file(tr_torrent const& tor, tr_file_index_t file);
 
 private:
     using Key = std::pair<tr_torrent_id_t, tr_block_index_t>;
@@ -60,17 +61,25 @@ private:
 
     [[nodiscard]] static CIter find_span_end(CIter const& span_begin, CIter const& end) noexcept;
 
+    // (error code, id of the torrent that failed to flush).
+    // The id is only meaningful when the error code is nonzero.
+    using FlushResult = std::pair<int, tr_torrent_id_t>;
+
     // @return any error code from tr_ioWrite()
     [[nodiscard]] int write_contiguous(CIter const& begin, CIter const& end) const;
 
-    // @return any error code from writeContiguous()
-    [[nodiscard]] int flush_span(CIter const& begin, CIter const& end);
+    // Erases [begin, end) from the cache and writes it to disk.
+    // On failure the unwritten blocks are still erased: keeping blocks
+    // that can never be written would wedge the cache. The failed
+    // tr_ioWrite() has already stopped the torrent with a local error,
+    // and verifying local data re-downloads the dropped blocks.
+    [[nodiscard]] FlushResult flush_span(CIter const& begin, CIter const& end);
 
-    // @return any error code from writeContiguous()
-    [[nodiscard]] int flush_biggest();
+    // @return any error code from flush_span()
+    [[nodiscard]] FlushResult flush_biggest();
 
-    // @return any error code from writeContiguous()
-    [[nodiscard]] int cache_trim();
+    // @return any error code from flush_biggest()
+    [[nodiscard]] FlushResult cache_trim();
 
     [[nodiscard]] static constexpr size_t get_max_blocks(Memory const max_size) noexcept
     {

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -2170,18 +2170,21 @@ void tr_session::verify_add(tr_torrent* const tor)
 // ---
 void tr_session::flush_torrent_files(tr_torrent_id_t const tor_id) const noexcept
 {
-    this->cache->flush_torrent(tor_id);
+    // a failed flush is handled by the cache; see Cache::flush_span()
+    (void)this->cache->flush_torrent(tor_id);
 }
 
 void tr_session::close_torrent_files(tr_torrent_id_t const tor_id) noexcept
 {
-    this->cache->flush_torrent(tor_id);
+    // a failed flush is handled by the cache; see Cache::flush_span()
+    (void)this->cache->flush_torrent(tor_id);
     openFiles().close_torrent(tor_id);
 }
 
 void tr_session::close_torrent_file(tr_torrent const& tor, tr_file_index_t file_num) noexcept
 {
-    this->cache->flush_file(tor, file_num);
+    // a failed flush is handled by the cache; see Cache::flush_span()
+    (void)this->cache->flush_file(tor, file_num);
     openFiles().close_file(tor.id(), file_num);
 }
 

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -390,8 +390,12 @@ void tr_webseed_task::use_fetched_blocks()
                     if (auto const* const torrent = tr_torrentFindFromId(session, tor_id); torrent != nullptr)
                     {
                         webseed->active_requests.unset(block);
-                        session->cache->write_block(tor_id, block, std::move(data));
-                        webseed->publish(tr_peer_event::GotBlock(torrent->block_info(), block));
+                        if (session->cache->write_block(tor_id, block, std::move(data)) == 0)
+                        {
+                            // only publish if the write didn't fail,
+                            // so the block isn't marked as complete
+                            webseed->publish(tr_peer_event::GotBlock(torrent->block_info(), block));
+                        }
                     }
                 });
         }

--- a/tests/libtransmission/CMakeLists.txt
+++ b/tests/libtransmission/CMakeLists.txt
@@ -13,6 +13,7 @@ target_sources(libtransmission-test
         block-info-test.cc
         blocklist-test.cc
         buffer-test.cc
+        cache-test.cc
         clients-test.cc
         completion-test.cc
         config-dir-lock-test.cc

--- a/tests/libtransmission/cache-test.cc
+++ b/tests/libtransmission/cache-test.cc
@@ -1,0 +1,181 @@
+// This file Copyright © Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
+
+#include <chrono>
+#include <future>
+#include <memory>
+#include <string>
+
+#include <libtransmission/transmission.h>
+
+#include <libtransmission/block-info.h>
+#include <libtransmission/cache.h>
+#include <libtransmission/file.h>
+#include <libtransmission/torrent.h>
+
+#include "gtest/gtest.h"
+#include "test-fixtures.h"
+
+using namespace std::literals;
+
+namespace libtransmission::test
+{
+
+class CacheTest : public SessionTest
+{
+protected:
+    static auto constexpr MaxWaitMsec = 5000;
+
+    // the cache is not thread-safe, so all calls run in the session thread.
+    // the promise is shared so that a timed-out wait can't leave the queued
+    // lambda holding a dangling reference into this frame.
+
+    int blockingWriteBlock(tr_torrent_id_t const tor_id, tr_block_index_t const block)
+    {
+        auto const promise = std::make_shared<std::promise<int>>();
+        auto future = promise->get_future();
+        session_->run_in_session_thread(
+            [session = session_, tor_id, block, promise]()
+            {
+                auto buf = std::make_unique<Cache::BlockData>(tr_block_info::BlockSize);
+                promise->set_value(session->cache->write_block(tor_id, block, std::move(buf)));
+            });
+        if (future.wait_for(std::chrono::milliseconds{ MaxWaitMsec }) != std::future_status::ready)
+        {
+            ADD_FAILURE() << "timed out waiting for Cache::write_block()";
+            return -1;
+        }
+        return future.get();
+    }
+
+    int blockingFlushTorrent(tr_torrent_id_t const tor_id)
+    {
+        auto const promise = std::make_shared<std::promise<int>>();
+        auto future = promise->get_future();
+        session_->run_in_session_thread(
+            [session = session_, tor_id, promise]() { promise->set_value(session->cache->flush_torrent(tor_id)); });
+        if (future.wait_for(std::chrono::milliseconds{ MaxWaitMsec }) != std::future_status::ready)
+        {
+            ADD_FAILURE() << "timed out waiting for Cache::flush_torrent()";
+            return -1;
+        }
+        return future.get();
+    }
+
+    tr_stat_errtype blockingErrorType(tr_torrent const* const tor)
+    {
+        auto const promise = std::make_shared<std::promise<tr_stat_errtype>>();
+        auto future = promise->get_future();
+        session_->run_in_session_thread([tor, promise]() { promise->set_value(tor->error().error_type()); });
+        if (future.wait_for(std::chrono::milliseconds{ MaxWaitMsec }) != std::future_status::ready)
+        {
+            ADD_FAILURE() << "timed out waiting for the torrent's error state";
+            return TR_STAT_LOCAL_ERROR;
+        }
+        return future.get();
+    }
+
+    void setCacheLimitBlocks(size_t const n_blocks)
+    {
+        auto const promise = std::make_shared<std::promise<int>>();
+        auto future = promise->get_future();
+        session_->run_in_session_thread(
+            [session = session_, n_blocks, promise]()
+            {
+                promise->set_value(session->cache->set_limit(
+                    Cache::Memory{ n_blocks * tr_block_info::BlockSize, Cache::Memory::Units::Bytes }));
+            });
+        if (future.wait_for(std::chrono::milliseconds{ MaxWaitMsec }) != std::future_status::ready)
+        {
+            ADD_FAILURE() << "timed out waiting for Cache::set_limit()";
+        }
+    }
+};
+
+TEST_F(CacheTest, dropsBlocksOfRemovedTorrents)
+{
+    auto* const tor = zeroTorrentInit(ZeroTorrentState::Partial);
+    setCacheLimitBlocks(2U);
+
+    // Cache blocks whose torrent is gone from the session can never be
+    // flushed. Three of them overflow the two-block cache limit, so the
+    // cache must trim by dropping them.
+    auto const ghost_id = static_cast<tr_torrent_id_t>(tor->id() + 1000);
+    for (tr_block_index_t block = 0U; block < 3U; ++block)
+    {
+        (void)blockingWriteBlock(ghost_id, block);
+    }
+
+    // the unflushable blocks must be dropped, not kept:
+    // flushing the ghost torrent now finds nothing left to write
+    EXPECT_EQ(0, blockingFlushTorrent(ghost_id));
+
+    // and a torrent that can still write must not be starved by them
+    auto const [begin, end] = tor->block_span_for_piece(0U);
+    EXPECT_EQ(0, blockingWriteBlock(tor->id(), begin));
+    EXPECT_EQ(TR_STAT_OK, blockingErrorType(tor));
+}
+
+TEST_F(CacheTest, failedFlushErrorsOnlyItsOwnTorrent)
+{
+    auto* const tor_bad = zeroTorrentInit(ZeroTorrentState::Complete);
+    auto* const tor_ok = torrentInitFromFile("perfect-pieces.torrent", true /*paused*/);
+    ASSERT_NE(nullptr, tor_ok);
+    setCacheLimitBlocks(2U);
+
+    // Make tor_bad's files unwritable and uncreatable: remove them and
+    // replace their parent directory with a regular file, so that
+    // reopening and recreating them both fail on every platform.
+    auto const path = tr_torrentFindFile(tor_bad, 0U);
+    ASSERT_FALSE(std::empty(path));
+    auto const dir = std::string{ tr_sys_path_dirname(path) };
+    for (tr_file_index_t i = 0U, n = tor_bad->file_count(); i < n; ++i)
+    {
+        auto const filename = tr_torrentFindFile(tor_bad, i);
+        ASSERT_FALSE(std::empty(filename));
+        ASSERT_TRUE(tr_sys_path_remove(filename.c_str()));
+    }
+    ASSERT_TRUE(tr_sys_path_remove(dir.c_str()));
+    createFileWithContents(dir, "not a directory");
+
+    // drop the file descriptors that verify left open, so that the next
+    // write has to reopen the now-unwritable path
+    {
+        auto const promise = std::make_shared<std::promise<void>>();
+        auto future = promise->get_future();
+        session_->run_in_session_thread(
+            [session = session_, tor_id = tor_bad->id(), promise]()
+            {
+                session->openFiles().close_torrent(tor_id);
+                promise->set_value();
+            });
+        ASSERT_EQ(std::future_status::ready, future.wait_for(std::chrono::milliseconds{ MaxWaitMsec }));
+    }
+
+    // Three blocks overflow the two-block limit, forcing a flush that
+    // fails. The error must be reported to the torrent that owns the
+    // blocks, and the failed write must stop it with a local error.
+    auto const [begin, end] = tor_bad->block_span_for_file(0U);
+    auto last_err = int{};
+    for (tr_block_index_t block = begin; block < begin + 3U; ++block)
+    {
+        last_err = blockingWriteBlock(tor_bad->id(), block);
+    }
+    EXPECT_NE(0, last_err);
+    EXPECT_EQ(TR_STAT_LOCAL_ERROR, blockingErrorType(tor_bad));
+
+    // the unwritable blocks must be dropped, not kept:
+    // flushing tor_bad again now finds nothing left to write
+    EXPECT_EQ(0, blockingFlushTorrent(tor_bad->id()));
+
+    // and other torrents keep writing unharmed instead of being
+    // starved by tor_bad's unflushable blocks
+    EXPECT_EQ(0, blockingWriteBlock(tor_ok->id(), 0U));
+    EXPECT_EQ(0, blockingWriteBlock(tor_ok->id(), 1U));
+    EXPECT_EQ(0, blockingWriteBlock(tor_ok->id(), 2U));
+    EXPECT_EQ(TR_STAT_OK, blockingErrorType(tor_ok));
+}
+
+} // namespace libtransmission::test

--- a/tests/libtransmission/move-test.cc
+++ b/tests/libtransmission/move-test.cc
@@ -89,7 +89,7 @@ TEST_P(IncompleteDirTest, incompleteDir)
 
     auto const test_incomplete_dir_threadfunc = [](TestIncompleteDirData* data) noexcept
     {
-        data->session->cache->write_block(data->tor->id(), data->block, std::move(data->buf));
+        EXPECT_EQ(0, data->session->cache->write_block(data->tor->id(), data->block, std::move(data->buf)));
         data->tor->on_block_received(data->block);
         data->done = true;
     };

--- a/tests/libtransmission/test-fixtures.h
+++ b/tests/libtransmission/test-fixtures.h
@@ -459,12 +459,16 @@ protected:
         return tor;
     }
 
-    [[nodiscard]] tr_torrent* torrentInitFromFile(std::string_view filename)
+    [[nodiscard]] tr_torrent* torrentInitFromFile(std::string_view filename, bool const paused = false)
     {
         auto* const ctor = tr_ctorNew(session_);
 
         auto const path = tr_pathbuf{ LIBTRANSMISSION_TEST_ASSETS_DIR, '/', filename };
         EXPECT_TRUE(ctor->set_metainfo_from_file(path));
+        if (paused)
+        {
+            tr_ctorSetPaused(ctor, TR_FORCE, true);
+        }
 
         auto* const tor = createTorrentAndWaitForVerifyDone(ctor);
         tr_ctorFree(ctor);


### PR DESCRIPTION
Torrents on 4.1.x can get stuck downloading forever without progressing, and completed data can turn up corrupt on verify (#5747). Two defects in the write path cause it; this fixes both on the `4.1.x` branch.

## Summary

**1. A failed flush wedges the cache permanently.** `Cache::flush_span()` and `flush_biggest()` only erase blocks when every write succeeds. But blocks whose writes fail can never be flushed: `tr_ioWrite()` has already stopped their torrent with a local error, or the torrent is gone from the session (`write_contiguous()` returns EINVAL). Once that happens, every subsequent `write_block()` from any healthy torrent runs `cache_trim()`, retries the same doomed span (it is the biggest), fails, and returns the error to the *healthy* torrent's `client_got_block()`. That torrent then never marks its blocks complete and re-requests them endlessly: download counter climbs, zero progress, zero disk writes. Restarting clears the cache, which matches the "restart fixes it for a while" reports in #5747. This is exactly the two-torrent quota reproduction from https://github.com/transmission/transmission/issues/5747#issuecomment-3962268590: the errored torrent's blocks starve the healthy one.

Spans are now extracted from the cache before writing and dropped on failure. Extraction also fixes a reentrancy hazard this exposed: a failed `tr_ioWrite()` stops the offending torrent, which reentrantly flushes and erases that torrent's remaining blocks mid-iteration, invalidating the iterators `flush_biggest()` was holding. `write_block()` also no longer reports a flush error to its caller unless the caller's own torrent is the one that errored.

**2. Writes to an unopenable existing file silently "succeed".** When a file exists but can't be opened (fd exhaustion, changed permissions, path replaced), `get_fd()` returns nullopt without setting the caller's `tr_error`. `tr_ioWrite()` then reports success, the cache discards the blocks as flushed, and the data vanishes; verification later finds the pieces corrupt and the torrent re-downloads them, endlessly while the open failures persist. This matches the macOS fd-limit report in https://github.com/transmission/transmission/issues/5747#issuecomment-2122645991. The open failure is now reported like every other failure in `get_fd()`.

`main` is a different story: #8669 removed the write cache, so defect 1 doesn't exist there, but defect 2 does; #9050 fixes it on `main` with the same change.

## Test plan

- New `cache-test.cc`: a healthy torrent keeps writing after another torrent's blocks become unflushable (torrent removed, and file replaced by a directory); the failed torrent gets a local error, the healthy one stays clean. Both tests fail on unpatched 4.1.x: reverting only the cache change fails both, reverting only the inout change fails the flush-error test, so each fix is independently required.
- Full libtransmission suite passes on the `4.1.x` branch; `./code_style.sh --check` clean.

Notes: fixed: a failed or impossible disk write could make other torrents download endlessly without progressing, and could silently discard downloaded data
