### PR TITLE
fix: report the error when an existing file can't be opened

### DIFF
--- a/libtransmission/inout.cc
+++ b/libtransmission/inout.cc
@@ -85,22 +85,20 @@ bool write_entire_buf(tr_sys_file_t const fd, uint64_t file_offset, std::span<ui
     }
 
     // does the file exist?
-    auto err = ENOENT;
     auto const file_size = tor.file_size(file_index);
     auto const prealloc = writable && tor.file_is_wanted(file_index) ? session.preallocationMode() :
                                                                        tr_file_preallocation::None;
     if (auto const found = tor.find_file(file_index); found)
     {
-        if (auto const fd = open_files.get(tor_id, file_index, writable, found->filename(), prealloc, file_size); fd)
+        if (auto const fd = open_files.get(tor_id, file_index, writable, found->filename(), prealloc, file_size, &error); fd)
         {
             return fd;
         }
 
         // The file exists but can't be opened, e.g. no file descriptors
-        // are left or its permissions changed. Fall through and set
-        // `error` so that the caller doesn't mistake this for success
-        // and discard the data it wanted to write.
-        err = errno != 0 ? errno : EIO;
+        // are left or its permissions changed. `error` is set so that
+        // the caller doesn't mistake this for success and discard the
+        // data it wanted to write.
     }
     // do we want to create it?
     else if (writable)
@@ -108,23 +106,24 @@ bool write_entire_buf(tr_sys_file_t const fd, uint64_t file_offset, std::span<ui
         auto const base = tor.current_dir();
         auto const suffix = session.isIncompleteFileNamingEnabled() ? tr_torrent_files::PartialFileSuffix : ""sv;
         auto const filename = tr_pathbuf{ base, '/', tor.file_subpath(file_index), suffix };
-        if (auto const fd = open_files.get(tor_id, file_index, writable, filename, prealloc, file_size); fd)
+        if (auto const fd = open_files.get(tor_id, file_index, writable, filename, prealloc, file_size, &error); fd)
         {
             // make a note that we just created a file
             session.add_file_created();
             return fd;
         }
-
-        err = errno;
     }
 
-    error.set(
-        err,
-        fmt::format(
-            fmt::runtime(_("Couldn't get '{path}': {error} ({error_code})")),
-            fmt::arg("path", tor.file_subpath(file_index)),
-            fmt::arg("error", tr_strerror(err)),
-            fmt::arg("error_code", err)));
+    if (!error) // the file doesn't exist, and we can't create it
+    {
+        error.set(
+            ENOENT,
+            fmt::format(
+                fmt::runtime(_("Couldn't get '{path}': {error} ({error_code})")),
+                fmt::arg("path", tor.file_subpath(file_index)),
+                fmt::arg("error", tr_strerror(ENOENT)),
+                fmt::arg("error_code", ENOENT)));
+    }
     return {};
 }
 
@@ -149,6 +148,11 @@ void read_bytes(
     auto const fd = get_fd(session, open_files, tor, false, file_index, error);
     if (!fd || error)
     {
+        if (error)
+        {
+            // get_fd()'s error message is already fully formatted
+            tr_logAddErrorTor(&tor, std::string{ error.message() });
+        }
         return;
     }
 
@@ -187,6 +191,12 @@ void write_bytes(
     auto const fd = get_fd(session, open_files, tor, true, file_index, error);
     if (!fd || error)
     {
+        if (error)
+        {
+            // get_fd()'s error message is already fully formatted;
+            // the caller also surfaces it via the torrent's local error
+            tr_logAddErrorTor(&tor, std::string{ error.message() });
+        }
         return;
     }
 

--- a/libtransmission/inout.cc
+++ b/libtransmission/inout.cc
@@ -85,17 +85,25 @@ bool write_entire_buf(tr_sys_file_t const fd, uint64_t file_offset, std::span<ui
     }
 
     // does the file exist?
+    auto err = ENOENT;
     auto const file_size = tor.file_size(file_index);
     auto const prealloc = writable && tor.file_is_wanted(file_index) ? session.preallocationMode() :
                                                                        tr_file_preallocation::None;
     if (auto const found = tor.find_file(file_index); found)
     {
-        return open_files.get(tor_id, file_index, writable, found->filename(), prealloc, file_size);
-    }
+        if (auto const fd = open_files.get(tor_id, file_index, writable, found->filename(), prealloc, file_size); fd)
+        {
+            return fd;
+        }
 
+        // The file exists but can't be opened, e.g. no file descriptors
+        // are left or its permissions changed. Fall through and set
+        // `error` so that the caller doesn't mistake this for success
+        // and discard the data it wanted to write.
+        err = errno != 0 ? errno : EIO;
+    }
     // do we want to create it?
-    auto err = ENOENT;
-    if (writable)
+    else if (writable)
     {
         auto const base = tor.current_dir();
         auto const suffix = session.isIncompleteFileNamingEnabled() ? tr_torrent_files::PartialFileSuffix : ""sv;

--- a/libtransmission/inout.cc
+++ b/libtransmission/inout.cc
@@ -114,7 +114,15 @@ bool write_entire_buf(tr_sys_file_t const fd, uint64_t file_offset, std::span<ui
         }
     }
 
-    if (!error) // the file doesn't exist, and we can't create it
+    if (error)
+    {
+        // open_files.get() reports why but not which file; the message
+        // reaches the user via the torrent's local error, so put the
+        // filename back in
+        error.prefix_message(
+            fmt::format(fmt::runtime(_("Couldn't get '{path}': ")), fmt::arg("path", tor.file_subpath(file_index))));
+    }
+    else // the file doesn't exist, and we can't create it
     {
         error.set(
             ENOENT,
@@ -148,11 +156,8 @@ void read_bytes(
     auto const fd = get_fd(session, open_files, tor, false, file_index, error);
     if (!fd || error)
     {
-        if (error)
-        {
-            // get_fd()'s error message is already fully formatted
-            tr_logAddErrorTor(&tor, std::string{ error.message() });
-        }
+        // no logging needed here: open_files.get() has already logged
+        // the failure
         return;
     }
 
@@ -191,12 +196,9 @@ void write_bytes(
     auto const fd = get_fd(session, open_files, tor, true, file_index, error);
     if (!fd || error)
     {
-        if (error)
-        {
-            // get_fd()'s error message is already fully formatted;
-            // the caller also surfaces it via the torrent's local error
-            tr_logAddErrorTor(&tor, std::string{ error.message() });
-        }
+        // no logging needed here: open_files.get() has already logged
+        // the failure, and the caller also surfaces `error` via the
+        // torrent's local error
         return;
     }
 

--- a/libtransmission/open-files.cc
+++ b/libtransmission/open-files.cc
@@ -144,7 +144,8 @@ std::optional<tr_sys_file_t> tr_open_files::get(
     bool writable,
     std::string_view const filename,
     tr_file_preallocation allocation,
-    uint64_t file_size)
+    uint64_t file_size,
+    tr_error* out_error)
 {
     // is there already an entry
     auto key = make_key(tor_id, file_num);
@@ -170,6 +171,10 @@ std::optional<tr_sys_file_t> tr_open_files::get(
                     fmt::arg("path", dir),
                     fmt::arg("error", error.message()),
                     fmt::arg("error_code", error.code())));
+            if (out_error != nullptr)
+            {
+                *out_error = std::move(error);
+            }
             return {};
         }
     }
@@ -193,6 +198,10 @@ std::optional<tr_sys_file_t> tr_open_files::get(
                 fmt::arg("path", filename),
                 fmt::arg("error", error.message()),
                 fmt::arg("error_code", error.code())));
+        if (out_error != nullptr)
+        {
+            *out_error = std::move(error);
+        }
         return {};
     }
 
@@ -223,6 +232,10 @@ std::optional<tr_sys_file_t> tr_open_files::get(
                     fmt::arg("error", error.message()),
                     fmt::arg("error_code", error.code())));
             tr_sys_file_close(fd);
+            if (out_error != nullptr)
+            {
+                *out_error = std::move(error);
+            }
             return {};
         }
 
@@ -243,6 +256,10 @@ std::optional<tr_sys_file_t> tr_open_files::get(
                 fmt::arg("error", error.message()),
                 fmt::arg("error_code", error.code())));
         tr_sys_file_close(fd);
+        if (out_error != nullptr)
+        {
+            *out_error = std::move(error);
+        }
         return {};
     }
 

--- a/libtransmission/open-files.cc
+++ b/libtransmission/open-files.cc
@@ -249,7 +249,7 @@ std::optional<tr_sys_file_t> tr_open_files::get(
     // https://bugs.launchpad.net/ubuntu/+source/transmission/+bug/318249
     if (resize_needed && !tr_sys_file_truncate(fd, file_size, &error))
     {
-        tr_logAddWarn(
+        tr_logAddError(
             fmt::format(
                 fmt::runtime(_("Couldn't truncate '{path}': {error} ({error_code})")),
                 fmt::arg("path", filename),

--- a/libtransmission/open-files.h
+++ b/libtransmission/open-files.h
@@ -31,7 +31,8 @@ public:
         bool writable,
         std::string_view filename,
         tr_file_preallocation allocation,
-        uint64_t file_size);
+        uint64_t file_size,
+        tr_error* out_error = nullptr);
 
     void close_all();
     void close_torrent(tr_torrent_id_t tor_id);

--- a/tests/libtransmission/CMakeLists.txt
+++ b/tests/libtransmission/CMakeLists.txt
@@ -27,6 +27,7 @@ target_sources(libtransmission-test
         getopt-test.cc
         handshake-test.cc
         history-test.cc
+        inout-test.cc
         ip-cache-test.cc
         json-test.cc
         local-data-test.cc

--- a/tests/libtransmission/inout-test.cc
+++ b/tests/libtransmission/inout-test.cc
@@ -1,0 +1,56 @@
+// This file Copyright © Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
+
+#include <string>
+#include <vector>
+
+#include <libtransmission/transmission.h>
+
+#include <libtransmission/block-info.h>
+#include <libtransmission/file.h>
+#include <libtransmission/inout.h>
+#include <libtransmission/torrent.h>
+
+#include <gtest/gtest.h>
+
+#include "test-fixtures.h"
+
+namespace tr::test
+{
+
+using InOutTest = SessionTest;
+
+TEST_F(InOutTest, writeFailsWhenExistingFileCannotBeOpened)
+{
+    auto* const tor = zeroTorrentInit(ZeroTorrentState::Complete);
+    auto constexpr MaxWaitMsec = 5000;
+
+    // make the torrent's first file unopenable by replacing it with a directory
+    auto const path = tr_torrentFindFile(tor, 0U);
+    ASSERT_FALSE(std::empty(path));
+    ASSERT_TRUE(tr_sys_path_remove(path.c_str()));
+    ASSERT_TRUE(tr_sys_dir_create(path.c_str(), 0, 0700));
+
+    // The write must fail: reporting success would make the caller
+    // discard the data, leaving pieces that later fail verification.
+    // (Run in the session thread; drop the file descriptors that verify
+    // left open first, so the write has to reopen the unopenable path.)
+    auto err = tr_error_code_t{};
+    auto done = false;
+    session_->run_in_session_thread(
+        [this, tor, &err, &done]()
+        {
+            session_->openFiles().close_torrent(tor->id());
+            auto const buf = std::vector<uint8_t>(tr_block_info::BlockSize);
+            err = tr_ioWrite(*tor, session_->openFiles(), tor->block_loc(0U), buf);
+            done = true;
+        });
+    ASSERT_TRUE(waitFor([&done]() { return done; }, MaxWaitMsec));
+
+    EXPECT_NE(0, err);
+    EXPECT_TRUE(waitFor([tor]() { return tr_torrentStat(tor).error == tr_stat::Error::LocalError; }, MaxWaitMsec));
+}
+
+} // namespace tr::test


### PR DESCRIPTION
When a file exists but can't be opened (fd exhaustion, changed permissions, path replaced), `get_fd()` returns nullopt without setting the caller's `tr_error`. `tr_ioWrite()` then reports success for a write that never happened, so the block's data is silently discarded while the block is marked complete; verification later finds the pieces corrupt and the torrent re-downloads them, endlessly while the open failures persist. One of the failure modes behind #5747 (see the macOS fd-limit report in https://github.com/transmission/transmission/issues/5747#issuecomment-2122645991), and the only one left on `main` now that #8669 removed the write cache. The 4.1.x variant of #5747 is addressed separately in #9049.

## Test plan

- New `inout-test.cc`: `tr_ioWrite()` to an existing-but-unopenable path must return an error and put the torrent into a local error state. Fails without the fix (write reports success), passes with it.
- Full libtransmission suite passes; `./code_style.sh --check` clean.

Notes: fixed: a disk write could silently discard downloaded data when the target file exists but can't be opened, leading to corrupt pieces and re-downloads
