### PR TITLE
fix: FTBFS when including fmt on [gcc 12...gcc 15]  with `-Wnull-dereference -Werror` enabled

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1588,6 +1588,16 @@ jobs:
             uname -a
             export PATH="/usr/pkg/bin:/usr/pkg/sbin${PATH:+:${PATH}}"
             export PKG_PATH="https://cdn.NetBSD.org/pub/pkgsrc/packages/NetBSD/`uname -p`/`uname -r`/All"
+            # cairo, dbus, gtkmm4 and qt6-qtbase check for X11 shared libraries
+            # as they install, so the sets have to go in before pkg_add adds
+            # those packages.
+            # curl is added first because the sets are fetched with it.
+            if [ '${{ needs.what-to-make.outputs.make-gtk }}' = 'true' ] || [ '${{ needs.what-to-make.outputs.make-qt }}' = 'true' ]; then
+              /usr/sbin/pkg_add -u curl
+              for set in xbase xcomp; do
+                curl -sL "https://cdn.netbsd.org/pub/NetBSD/NetBSD-`uname -r`/amd64/binary/sets/$set.tar.xz" | tar xJpf - -C /
+              done
+            fi
             /usr/sbin/pkg_add -u \
               curl \
               cmake \
@@ -1604,11 +1614,6 @@ jobs:
               `[ '${{ needs.what-to-make.outputs.make-qt }}' = 'true' ] && echo qt6-qtsvg qt6-qttools` \
               rapidjson \
               utf8-cpp
-            if [ '${{ needs.what-to-make.outputs.make-gtk }}' = 'true' ] || [ '${{ needs.what-to-make.outputs.make-qt }}' = 'true' ]; then
-              for set in xbase xcomp; do
-                curl -sL "https://cdn.netbsd.org/pub/NetBSD/NetBSD-`uname -r`/amd64/binary/sets/$set.tar.xz" | tar xJpf - -C /
-              done
-            fi
           run: |
             set -ex
             export PATH="/usr/pkg/bin:/usr/pkg/sbin${PATH:+:${PATH}}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -798,6 +798,12 @@ else()
         list(APPEND WARNING_CANDIDATES -Wformat-security)
     endif()
 
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 12.0)
+        # fix non-Transmission fmt+gcc
+        # https://github.com/fmtlib/fmt/commit/6870e4b06bbf0a0ddd98534a393a561261b3153c
+        list(REMOVE_ITEM WARNING_CANDIDATES -Wnull-dereference)
+    endif()
+
     set(CMAKE_REQUIRED_FLAGS)
 
     foreach(FLAG -Werror /WX)


### PR DESCRIPTION
Fix two issues that were breaking the NetBSD build.

1. Fix a genuine FTBFS when building with gcc versions 12-15 with `-Wnull-dereference -Werror` enabled. This appears to be a false warning in {fmt} code. This PR copies the same workaround that was used in the upstream {fmt} repo at https://github.com/fmtlib/fmt/commit/6870e4b06bbf0a0ddd98534a393a561261b3153c

2. Also fix a CI-specific NetBSD build failure: install the X sets before `pkg_add`. This fixes the actions error:
`pkg_add: cairo-1.18.4nb3: missing required library: /usr/X11R7/lib/libX11.so.7`

Notes: Fixes FTBFS when using [gcc 12 ... gcc 15]  and compiling with `-Wnull-dereference -Werror`,

🤖 Generated with [Claude Code](https://claude.com/claude-code)