### PR TITLE
fix: FTBFS when including fmt on gcc 12...15 with -Wnull-dereference …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -709,6 +709,12 @@ else()
         list(APPEND WARNING_CANDIDATES -Wformat-security)
     endif()
 
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 12.0)
+        # fix non-Transmission fmt+gcc
+        # https://github.com/fmtlib/fmt/commit/6870e4b06bbf0a0ddd98534a393a561261b3153c
+        list(REMOVE_ITEM WARNING_CANDIDATES -Wnull-dereference)
+    endif()
+
     set(CMAKE_REQUIRED_FLAGS)
 
     foreach(FLAG -Werror /WX)


### PR DESCRIPTION
Fix a  FTBFS when building with gcc versions 12-15 with -Wnull-dereference -Werror enabled. This appears to be a false warning in {fmt} code. This PR copies the same workaround that was used in the upstream {fmt} repo at fmtlib/fmt@6870e4b

Cherry-pick of #9051 a78b2bc for 4.1.x.

Notes: Fixed build failure when compiling with `-Wnull-dereference -Werror` in gcc 12..15.