### PR TITLE
fix: lost wakeup that could hang tr_web shutdown (#9001)

### DIFF
--- a/libtransmission/web.cc
+++ b/libtransmission/web.cc
@@ -226,25 +226,32 @@ public:
 
     ~Impl()
     {
-        deadline_ = mediator.now();
-        queued_tasks_cv_.notify_one();
+        startShutdown(0ms);
         curl_thread->join();
     }
 
     void startShutdown(std::chrono::milliseconds deadline)
     {
-        deadline_ = mediator.now() + std::chrono::duration_cast<std::chrono::seconds>(deadline).count();
+        // Set the deadline under the mutex.
+        // curlThreadFunc() tests the deadline to decide whether to sleep.
+        // An unsynchronized store could land between that test and the
+        // sleep and go unnoticed.
+        {
+            auto const lock = std::unique_lock{ tasks_mutex_ };
+            deadline_ = mediator.now() + std::chrono::duration_cast<std::chrono::seconds>(deadline).count();
+        }
         queued_tasks_cv_.notify_one();
     }
 
     void fetch(FetchOptions&& options)
     {
-        if (deadline_exists())
+        auto const lock = std::unique_lock{ tasks_mutex_ };
+
+        if (deadline_exists()) // no new tasks once shutdown has begun
         {
             return;
         }
 
-        auto const lock = std::unique_lock{ tasks_mutex_ };
         queued_tasks_.emplace_back(*this, std::move(options));
         queued_tasks_cv_.notify_one();
     }
@@ -730,21 +737,26 @@ public:
                 }
             }
 
-            if (deadline_exists() && is_idle())
-            {
-                break;
-            }
-
             if (auto lock = std::unique_lock{ tasks_mutex_ }; lock.owns_lock())
             {
-                // sleep until there's something to do
                 auto const stop_waiting = [this]()
                 {
-                    return !is_idle() || !deadline_exists();
+                    return !is_idle() || deadline_exists();
                 };
+
+                // A pending shutdown ends the wait so that the loop reaches
+                // the exit check below.
+                // The timeout keeps libcurl's connection cache serviced
+                // while no tasks are running.
+                static auto constexpr IdleUpkeepInterval = std::chrono::seconds{ 1 };
                 if (!stop_waiting())
                 {
-                    queued_tasks_cv_.wait(lock, stop_waiting);
+                    queued_tasks_cv_.wait_for(lock, IdleUpkeepInterval, stop_waiting);
+                }
+
+                if (deadline_exists() && is_idle())
+                {
+                    break;
                 }
 
                 // add queued tasks
@@ -857,10 +869,9 @@ tr_web::tr_web(Mediator& mediator)
 {
 }
 
-tr_web::~tr_web()
-{
-    impl_->startShutdown(0ms);
-}
+// ~Impl() itself starts an immediate shutdown before joining the curl
+// thread, so there's nothing to do here beyond destroying the members
+tr_web::~tr_web() = default;
 
 std::unique_ptr<tr_web> tr_web::create(Mediator& mediator)
 {

--- a/tests/libtransmission/CMakeLists.txt
+++ b/tests/libtransmission/CMakeLists.txt
@@ -59,6 +59,7 @@ target_sources(libtransmission-test
         values-test.cc
         variant-test.cc
         watchdir-test.cc
+        web-test.cc
         web-utils-test.cc)
 
 set_property(

--- a/tests/libtransmission/web-test.cc
+++ b/tests/libtransmission/web-test.cc
@@ -1,0 +1,111 @@
+// This file Copyright © Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
+
+#include <atomic>
+#include <chrono>
+#include <cstdlib> // std::abort()
+#include <future>
+#include <iostream>
+#include <thread>
+#include <utility>
+
+#include <libtransmission/web.h>
+
+#include "test-fixtures.h"
+
+using namespace std::literals;
+
+class WebTest : public ::libtransmission::test::TransmissionTest
+{
+protected:
+    // A tr_web destructor asks its curl thread to stop and then joins it.
+    // The request races the thread's decision to sleep, and roughly one
+    // run in 1500 lands in the window where the request can be missed.
+    // Keep this high enough that a stuck curl thread fails every run.
+    static auto constexpr Reps = 10000;
+
+    // How long the reps get before the test calls the curl thread stuck.
+    // The slowest CI machines take thirty times longer than the fastest.
+    // This only has to be short enough to beat ctest's own timeout.
+    static auto constexpr StuckBudget = std::chrono::seconds{ 120 };
+
+    // Run func on a helper thread and end the process if it overruns.
+    // A curl thread that never notices the shutdown request leaves the
+    // helper blocked in join(), and that helper can't be cancelled.
+    // Aborting turns a stalled CI job into a reported failure.
+    // func counts the reps it finishes so that the message can tell a
+    // stuck curl thread apart from a slow machine.
+    template<typename Func>
+    static void runWithinBudget(Func&& func)
+    {
+        auto n_done = std::atomic<int>{};
+        auto promise = std::promise<void>{};
+        auto future = promise.get_future();
+        auto thread = std::thread{ [&n_done, promise = std::move(promise), func = std::forward<Func>(func)]() mutable
+                                   {
+                                       func(n_done);
+                                       promise.set_value();
+                                   } };
+
+        if (future.wait_for(StuckBudget) == std::future_status::timeout)
+        {
+            std::cerr << "tr_web did not finish within " << StuckBudget.count() << " seconds (" << n_done.load()
+                      << " reps done)\n";
+            thread.detach();
+            std::abort();
+        }
+
+        thread.join();
+    }
+};
+
+TEST_F(WebTest, destroyWhileIdleDoesNotHang)
+{
+    runWithinBudget(
+        [](std::atomic<int>& n_done)
+        {
+            auto mediator = tr_web::Mediator{};
+
+            for (auto i = 0; i < Reps; ++i)
+            {
+                auto const web = tr_web::create(mediator);
+                EXPECT_TRUE(web->is_idle());
+                ++n_done;
+            }
+        });
+}
+
+TEST_F(WebTest, startShutdownThenDestroyDoesNotHang)
+{
+    runWithinBudget(
+        [](std::atomic<int>& n_done)
+        {
+            auto mediator = tr_web::Mediator{};
+
+            for (auto i = 0; i < Reps; ++i)
+            {
+                auto const web = tr_web::create(mediator);
+                web->startShutdown(0ms);
+                ++n_done;
+            }
+        });
+}
+
+TEST_F(WebTest, destroyWithTaskInFlightDoesNotHang)
+{
+    // A tr_web with work in flight takes the other path out of the loop,
+    // where the curl thread cancels the task instead of waiting for one.
+    runWithinBudget(
+        [](std::atomic<int>& n_done)
+        {
+            auto mediator = tr_web::Mediator{};
+            auto const web = tr_web::create(mediator);
+
+            // TEST-NET-1 (RFC 5737) has no route, so this fetch is still
+            // in flight when the tr_web is destroyed.
+            web->fetch({ "http://192.0.2.1/"sv, [](tr_web::FetchResponse const&) {}, nullptr, 60s });
+            ++n_done;
+        });
+}


### PR DESCRIPTION
Cherry-pick  095d46b #9001 for 4.1.x.

Notes: Fixed a rare hang when quitting that could leave Transmission running after it was closed.