### PR TITLE
build: fix Qt5 system-zlib detection on Windows

### DIFF
--- a/release/windows/build-qt5.ps1
+++ b/release/windows/build-qt5.ps1
@@ -41,6 +41,9 @@ function global:Build-Qt5([string] $PrefixDir, [string] $Arch, [string] $DepsPre
         '-ssl'
         '-openssl'
         '-system-zlib'
+        # Qt5's MSVC probe looks only for zdll.lib and zlib.lib.
+        # zlib installs z.lib, so name the library explicitly.
+        'ZLIB_LIBS=-lz'
         '-qt-pcre'
         '-qt-libpng'
         '-qt-libjpeg'


### PR DESCRIPTION
## Description

Every Windows Qt5 CI job currently fails at configure:

```
Checking for zlib... no
ERROR: Feature 'system-zlib' was enabled, but the pre-condition 'libs.zlib' failed.
```

zlib's CMake build sets `OUTPUT_NAME z` on the shared target, so MSVC installs `z.lib`. Qt5's `libs.zlib` probe tries only `zdll.lib` and `zlib.lib` under MSVC — its `-lz` entry is gated on `!config.msvc` — so it never finds the library. Setting `ZLIB_LIBS=-lz` names it explicitly.

Qt6 needs no equivalent change. It finds zlib through the installed CMake package config, which does not depend on the library file name.

### Testing

Needs a green AppVeyor run here to confirm. Note that the Qt5 cache is already cold — its archive key includes zlib's token — so this run rebuilds Qt5 from scratch against the 60-minute job cap. A timeout on the first attempt would be the cold cache, not this change.

Once this is green, the same fix should be cherry-picked to `4.1.x`, which fails identically.

## Checklist

- [ ] I have manually written or manually audited all changes in this PR and vouch for them.