### PR TITLE
macOS: fix magnet links corrupted when pasted into main window

### DIFF
--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -1695,14 +1695,8 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
 
 - (void)openPasteboard
 {
-    // 1. Magnet links must be matched (and handled, see the early return below) before falling through
-    // to the plain-link NSDataDetector pass further down. NSDataDetector doesn't understand percent-encoding:
-    // scanning the raw text of a magnet link, it can spuriously match a substring inside a percent-encoded
-    // `tr=` tracker parameter as if it were an unrelated bare domain (e.g. matching "2Ftracker.opentrackr.org"
-    // out of "udp%3A%2F%2Ftracker.opentrackr.org"), and NSDataDetector fills in a default "http://" scheme for
-    // such matches. That spurious match was separately opened as a direct download URL alongside the correctly
-    // recognized magnet, producing a "Torrent download failed" error even though the magnet itself added fine.
-    // See https://github.com/transmission/transmission/issues/8736
+    // 1. If Pasteboard contains String objects, search them for both magnets and plain links.
+    // Magnets must be matched against the raw string, not an NSURL object read from the pasteboard (see step 2).
     NSArray<NSString*>* arrayOfStrings = [NSPasteboard.generalPasteboard readObjectsForClasses:@[ [NSString class] ] options:nil];
 
     // The magnet detector
@@ -1714,46 +1708,49 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
     // But for now, we'll keep the historical separator choice from 8392476b30491ffe7d8d64210f5cf3c3dd1d69ca, whitespaceAndNewlineCharacterSet, which is `[\p{Z}\v]`.
     NSRegularExpression* magnetDetector = [NSRegularExpression regularExpressionWithPattern:@"magnet:?([^\\p{Z}\\v])+" options:kNilOptions
                                                                                       error:nil];
-    BOOL foundMagnet = NO;
+    // The link detector (can't detect magnets). NSDataDetector doesn't understand percent-encoding, so scanning
+    // the raw text of a magnet link it can spuriously match a substring inside a percent-encoded `tr=` tracker
+    // parameter as if it were an unrelated bare domain (e.g. matching "2Ftracker.opentrackr.org" out of
+    // "udp%3A%2F%2Ftracker.opentrackr.org"), defaulting a bogus "http://" scheme onto it. Skipping any link match
+    // that overlaps a magnet match avoids that misfire while still opening a plain link genuinely pasted
+    // alongside a magnet. See https://github.com/transmission/transmission/issues/8736
+    NSDataDetector* linkDetector = [NSDataDetector dataDetectorWithTypes:NSTextCheckingTypeLink error:nil];
+
+    BOOL foundMagnetOrLink = NO;
     for (NSString* itemString in arrayOfStrings)
     {
-        for (NSTextCheckingResult* result in [magnetDetector matchesInString:itemString options:0
-                                                                       range:NSMakeRange(0, itemString.length)])
+        NSRange const fullRange = NSMakeRange(0, itemString.length);
+
+        NSArray<NSTextCheckingResult*>* magnetMatches = [magnetDetector matchesInString:itemString options:0 range:fullRange];
+        for (NSTextCheckingResult* result in magnetMatches)
         {
             [self openURL:[itemString substringWithRange:result.range]];
-            foundMagnet = YES;
+            foundMagnetOrLink = YES;
+        }
+
+        for (NSTextCheckingResult* result in [linkDetector matchesInString:itemString options:0 range:fullRange])
+        {
+            BOOL const overlapsMagnet = [magnetMatches
+                                            indexOfObjectPassingTest:^BOOL(NSTextCheckingResult* magnetResult, NSUInteger idx, BOOL* stop) {
+                                                return NSIntersectionRange(result.range, magnetResult.range).length > 0;
+                                            }] != NSNotFound;
+            if (!overlapsMagnet)
+            {
+                [self openURL:result.URL.absoluteString];
+                foundMagnetOrLink = YES;
+            }
         }
     }
-    if (foundMagnet)
+    if (foundMagnetOrLink)
     {
         return;
     }
 
-    // 2. If Pasteboard contains URL objects (and no magnets were found above), we treat those and only those
+    // 2. Otherwise, if Pasteboard contains URL objects, we treat those and only those
     NSArray<NSURL*>* arrayOfURLs = [NSPasteboard.generalPasteboard readObjectsForClasses:@[ [NSURL class] ] options:nil];
-
-    if (arrayOfURLs.count > 0)
+    for (NSURL* url in arrayOfURLs)
     {
-        for (NSURL* url in arrayOfURLs)
-        {
-            [self openURL:url.absoluteString];
-        }
-        return;
-    }
-
-    // 3. Otherwise, search the pasteboard strings for plain links (magnets were already handled above)
-    if (arrayOfStrings.count == 0)
-    {
-        return;
-    }
-    NSDataDetector* linkDetector = [NSDataDetector dataDetectorWithTypes:NSTextCheckingTypeLink error:nil];
-    for (NSString* itemString in arrayOfStrings)
-    {
-        for (NSTextCheckingResult* result in [linkDetector matchesInString:itemString options:0
-                                                                     range:NSMakeRange(0, itemString.length)])
-        {
-            [self openURL:result.URL.absoluteString];
-        }
+        [self openURL:url.absoluteString];
     }
 }
 

--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -1695,7 +1695,38 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
 
 - (void)openPasteboard
 {
-    // 1. If Pasteboard contains URL objects, we treat those and only those
+    // 1. Magnet links must be matched against the raw pasteboard string, not an NSURL object.
+    // Reading the pasteboard as NSURL (below) round-trips the string through NSURL's parser/serializer,
+    // which can corrupt percent-encoded segments of a `magnet:` URI (an opaque, non-hierarchical scheme),
+    // e.g. turning "tr=udp%3A%2F%2Ftracker.opentrackr.org" into a broken tracker hostname.
+    // See https://github.com/transmission/transmission/issues/8736
+    NSArray<NSString*>* arrayOfStrings = [NSPasteboard.generalPasteboard readObjectsForClasses:@[ [NSString class] ] options:nil];
+
+    // The magnet detector
+    // https://www.bittorrent.org/beps/bep_0009.html defines the magnet URI format as `magnet:?query` where query is non-empty.
+    // https://datatracker.ietf.org/doc/html/rfc3986 defines the query format rigorously as `([!$\&-;=?-Z_a-z~]|%[0-9A-F]{2})*`.
+    // But `tr_urlParse` acknowledges that magnet links can be malformed by "not escaping text in the display name".
+    // Those malformed magnets aren't URI anymore, and since a display name can potentially contain any Unicode except '/' (see `isUnixReservedChar`), we may want to be liberal on what we accept.
+    // In practice, copy-pasted magnets might most often be separated by Horizontal tab, Line feed, Carriage Return, Space, XML delimiters '<' '>', JSON delimiter '"' and Markdown delimiter '`'.
+    // But for now, we'll keep the historical separator choice from 8392476b30491ffe7d8d64210f5cf3c3dd1d69ca, whitespaceAndNewlineCharacterSet, which is `[\p{Z}\v]`.
+    NSRegularExpression* magnetDetector = [NSRegularExpression regularExpressionWithPattern:@"magnet:?([^\\p{Z}\\v])+" options:kNilOptions
+                                                                                      error:nil];
+    BOOL foundMagnet = NO;
+    for (NSString* itemString in arrayOfStrings)
+    {
+        for (NSTextCheckingResult* result in [magnetDetector matchesInString:itemString options:0
+                                                                       range:NSMakeRange(0, itemString.length)])
+        {
+            [self openURL:[itemString substringWithRange:result.range]];
+            foundMagnet = YES;
+        }
+    }
+    if (foundMagnet)
+    {
+        return;
+    }
+
+    // 2. If Pasteboard contains URL objects (and no magnets were found above), we treat those and only those
     NSArray<NSURL*>* arrayOfURLs = [NSPasteboard.generalPasteboard readObjectsForClasses:@[ [NSURL class] ] options:nil];
 
     if (arrayOfURLs.count > 0)
@@ -1707,37 +1738,18 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
         return;
     }
 
-    // 2. If Pasteboard contains String objects, we'll search for both links and magnets
-    NSArray<NSString*>* arrayOfStrings = [NSPasteboard.generalPasteboard readObjectsForClasses:@[ [NSString class] ] options:nil];
+    // 3. Otherwise, search the pasteboard strings for plain links (magnets were already handled above)
     if (arrayOfStrings.count == 0)
     {
         return;
     }
-    // The link detector (can't detect magnets)
     NSDataDetector* linkDetector = [NSDataDetector dataDetectorWithTypes:NSTextCheckingTypeLink error:nil];
-    // The magnet detector
-    // https://www.bittorrent.org/beps/bep_0009.html defines the magnet URI format as `magnet:?query` where query is non-empty.
-    // https://datatracker.ietf.org/doc/html/rfc3986 defines the query format rigorously as `([!$\&-;=?-Z_a-z~]|%[0-9A-F]{2})*`.
-    // But `tr_urlParse` acknowledges that magnet links can be malformed by "not escaping text in the display name".
-    // Those malformed magnets aren't URI anymore, and since a display name can potentially contain any Unicode except '/' (see `isUnixReservedChar`), we may want to be liberal on what we accept.
-    // In practice, copy-pasted magnets might most often be separated by Horizontal tab, Line feed, Carriage Return, Space, XML delimiters '<' '>', JSON delimiter '"' and Markdown delimiter '`'.
-    // But for now, we'll keep the historical separator choice from 8392476b30491ffe7d8d64210f5cf3c3dd1d69ca, whitespaceAndNewlineCharacterSet, which is `[\p{Z}\v]`.
-    NSRegularExpression* magnetDetector = [NSRegularExpression regularExpressionWithPattern:@"magnet:?([^\\p{Z}\\v])+" options:kNilOptions
-                                                                                      error:nil];
     for (NSString* itemString in arrayOfStrings)
     {
-        // We open all links
         for (NSTextCheckingResult* result in [linkDetector matchesInString:itemString options:0
                                                                      range:NSMakeRange(0, itemString.length)])
         {
             [self openURL:result.URL.absoluteString];
-        }
-
-        // We open all magnets
-        for (NSTextCheckingResult* result in [magnetDetector matchesInString:itemString options:0
-                                                                       range:NSMakeRange(0, itemString.length)])
-        {
-            [self openURL:[itemString substringWithRange:result.range]];
         }
     }
 }

--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -1695,10 +1695,13 @@ void onTorrentCompletenessChanged(tr_torrent* tor, tr_completeness status, bool 
 
 - (void)openPasteboard
 {
-    // 1. Magnet links must be matched against the raw pasteboard string, not an NSURL object.
-    // Reading the pasteboard as NSURL (below) round-trips the string through NSURL's parser/serializer,
-    // which can corrupt percent-encoded segments of a `magnet:` URI (an opaque, non-hierarchical scheme),
-    // e.g. turning "tr=udp%3A%2F%2Ftracker.opentrackr.org" into a broken tracker hostname.
+    // 1. Magnet links must be matched (and handled, see the early return below) before falling through
+    // to the plain-link NSDataDetector pass further down. NSDataDetector doesn't understand percent-encoding:
+    // scanning the raw text of a magnet link, it can spuriously match a substring inside a percent-encoded
+    // `tr=` tracker parameter as if it were an unrelated bare domain (e.g. matching "2Ftracker.opentrackr.org"
+    // out of "udp%3A%2F%2Ftracker.opentrackr.org"), and NSDataDetector fills in a default "http://" scheme for
+    // such matches. That spurious match was separately opened as a direct download URL alongside the correctly
+    // recognized magnet, producing a "Torrent download failed" error even though the magnet itself added fine.
     // See https://github.com/transmission/transmission/issues/8736
     NSArray<NSString*>* arrayOfStrings = [NSPasteboard.generalPasteboard readObjectsForClasses:@[ [NSString class] ] options:nil];
 


### PR DESCRIPTION
## Summary
- Pasting a magnet link directly into the main Transmission window (Edit ▸ Paste / Cmd+V) could add the torrent successfully but *also* throw a spurious error like "Torrent download failed - The torrent could not be downloaded from http://2Ftracker.opentrackr.org: A server with the specified hostname could not be found," when the link contained percent-encoded tracker URLs (e.g. `tr=udp%3A%2F%2Ftracker.opentrackr.org`).
- `openPasteboard` ran two detectors unconditionally on every pasted string: a magnet-matching regex, and `NSDataDetector`'s plain-link scan (`linkDetector`), used to catch ordinary http(s) links pasted alongside torrents/magnets.
- `NSDataDetector` doesn't understand percent-encoding — it pattern-matches on literal text. Scanning the raw magnet string, it can spuriously lock onto a substring *inside* a percent-encoded `tr=` tracker parameter as if it were an unrelated bare domain (e.g. matching `2Ftracker.opentrackr.org` out of `udp%3A%2F%2Ftracker.opentrackr.org`, apparently skipping past the `%` it doesn't recognize). For a schemeless/bare-domain match like this, `NSDataDetector` fills in a default `http://` scheme on `.URL`. That spurious match got opened as a direct-download URL for a `.torrent` file, alongside the correctly-recognized magnet — hence the torrent still added, but a bogus HTTP download error also fired.
- The "Open URL…" sheet (Cmd+U) never runs `NSDataDetector` at all — it just passes the raw text field string straight to `openURL:` — which is why pasting there worked and was the reported workaround.
- **Fix**: `openPasteboard` now matches magnets and plain links in a single pass per pasted string, and discards a link match only when its range overlaps a magnet match — which is what happens when `NSDataDetector` misfires inside a magnet's percent-encoded tracker parameter. A plain link genuinely separate from any magnet in the same paste (e.g. pasting a sentence containing both a magnet URI and an unrelated URL) still opens normally, unlike an earlier version of this fix that returned immediately on any magnet match and would have silently dropped a co-pasted plain link.

Fixes #8736

## Test plan
Verified locally with a debug build (`xcodebuild -target Transmission -configuration Debug build`).

1. Magnet with percent-encoded trackers, pasted alone:
   ```
   magnet:?xt=urn:btih:08ada5a7a6183aae1e09d831df6748d566095a10&dn=Sintel&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337%2Fannounce&tr=udp%3A%2F%2Ftracker.openbittorrent.com%3A6969%2Fannounce
   ```
   - [x] Before this change: pasting into the main window (Cmd+V) added the torrent, but also threw "could not be downloaded from http://2Ftracker.opentrackr.org..." and, on a second run, "...http://2Ftracker.openbittorrent.com: Could not connect to the server" — confirming the spurious-match theory (the mangled hostname tracked whichever tracker parameter the data detector happened to latch onto).
   - [x] After this change: pasting the same link into the main window adds the torrent cleanly with no error.

2. Magnet and a genuinely separate plain link pasted together, to check for regressions from the fix itself:
   ```
   Check out this torrent: magnet:?xt=urn:btih:08ada5a7a6183aae1e09d831df6748d566095a10&dn=Sintel&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337%2Fannounce also see https://www.debian.org for a real download
   ```
   - [x] Sintel torrent added from the magnet, **and** a separate "[www.debian.org.html] is not a torrent file" error fired for the debian.org link — confirming both the magnet and the unrelated plain link are still handled from a single paste (i.e. the overlap check isn't over-broad and doesn't swallow legitimate separate links).

3. Plain http(s) link pasted alone (no magnet in the same paste):
   - [x] Same "not a valid torrent file" behavior as stock, unaffected by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
