### PR TITLE
build: fix Qt5 system-zlib detection on Windows

### DIFF
--- a/release/windows/build-qt5.ps1
+++ b/release/windows/build-qt5.ps1
@@ -41,6 +41,9 @@ function global:Build-Qt5([string] $PrefixDir, [string] $Arch, [string] $DepsPre
         '-ssl'
         '-openssl'
         '-system-zlib'
+        # Qt5's MSVC probe looks only for zdll.lib and zlib.lib.
+        # zlib installs z.lib, so name the library explicitly.
+        'ZLIB_LIBS=-lz'
         '-qt-pcre'
         '-qt-libpng'
         '-qt-libjpeg'


### PR DESCRIPTION
## Description

Cherry-pick of #9061 into `4.1.x`, which fails identically.

Every Windows Qt5 CI job currently fails at configure:

```
Checking for zlib... no
ERROR: Feature 'system-zlib' was enabled, but the pre-condition 'libs.zlib' failed.
```

zlib's CMake build sets `OUTPUT_NAME z` on the shared target, so MSVC installs `z.lib`. Qt5's `libs.zlib` probe tries only `zdll.lib` and `zlib.lib` under MSVC — its `-lz` entry is gated on `!config.msvc` — so it never finds the library. Setting `ZLIB_LIBS=-lz` names it explicitly.

Qt6 needs no equivalent change. It finds zlib through the installed CMake package config, which does not depend on the library file name.

## Checklist

- [x] I have manually written or manually audited all changes in this PR and vouch for them.