### PR TITLE
Fix swapped width and height dimensions in NSImage allocation

### DIFF
--- a/macosx/TorrentTableView.mm
+++ b/macosx/TorrentTableView.mm
@@ -289,7 +289,7 @@ static NSTimeInterval const kToggleProgressSeconds = 0.175;
             if (error)
             {
                 NSRect frame = torrentCell.fIconView.frame;
-                NSImage* resultImage = [[NSImage alloc] initWithSize:NSMakeSize(frame.size.height, frame.size.width)];
+                NSImage* resultImage = [[NSImage alloc] initWithSize:frame.size];
                 [resultImage lockFocus];
 
                 // draw fileImage


### PR DESCRIPTION
### Summary
Fixes a bug where `NSImage` was initialized with swapped dimensions (`height` passed as width, and `width` passed as height).

### Changes
* Updated `NSImage initWithSize:` to use `frame.size.width` for width and `frame.size.height` for height.