### PR TITLE
fix: report the real error when a file can't be opened (4.1.x)

### DIFF
--- a/libtransmission/inout.cc
+++ b/libtransmission/inout.cc
@@ -92,7 +92,7 @@ bool write_entire_buf(tr_sys_file_t const fd, uint64_t file_offset, uint8_t cons
                                                                        tr_open_files::Preallocation::None;
     if (auto const found = tor.find_file(file_index); found)
     {
-        if (auto const fd = open_files.get(tor_id, file_index, writable, found->filename(), prealloc, file_size, &error); fd)
+        if (auto const fd = open_files.get(tor_id, file_index, writable, found->filename(), prealloc, file_size, error); fd)
         {
             return fd;
         }
@@ -108,7 +108,7 @@ bool write_entire_buf(tr_sys_file_t const fd, uint64_t file_offset, uint8_t cons
         auto const base = tor.current_dir();
         auto const suffix = session.isIncompleteFileNamingEnabled() ? tr_torrent_files::PartialFileSuffix : ""sv;
         auto const filename = tr_pathbuf{ base, '/', tor.file_subpath(file_index), suffix };
-        if (auto const fd = open_files.get(tor_id, file_index, writable, filename, prealloc, file_size, &error); fd)
+        if (auto const fd = open_files.get(tor_id, file_index, writable, filename, prealloc, file_size, error); fd)
         {
             // make a note that we just created a file
             session.add_file_created();

--- a/libtransmission/inout.cc
+++ b/libtransmission/inout.cc
@@ -92,33 +92,48 @@ bool write_entire_buf(tr_sys_file_t const fd, uint64_t file_offset, uint8_t cons
                                                                        tr_open_files::Preallocation::None;
     if (auto const found = tor.find_file(file_index); found)
     {
-        return open_files.get(tor_id, file_index, writable, found->filename(), prealloc, file_size);
-    }
+        if (auto const fd = open_files.get(tor_id, file_index, writable, found->filename(), prealloc, file_size, &error); fd)
+        {
+            return fd;
+        }
 
+        // The file exists but can't be opened, e.g. no file descriptors
+        // are left or its permissions changed. `error` is set so that
+        // the caller doesn't mistake this for success and discard the
+        // data it wanted to write.
+    }
     // do we want to create it?
-    auto err = ENOENT;
-    if (writable)
+    else if (writable)
     {
         auto const base = tor.current_dir();
         auto const suffix = session.isIncompleteFileNamingEnabled() ? tr_torrent_files::PartialFileSuffix : ""sv;
         auto const filename = tr_pathbuf{ base, '/', tor.file_subpath(file_index), suffix };
-        if (auto const fd = open_files.get(tor_id, file_index, writable, filename, prealloc, file_size); fd)
+        if (auto const fd = open_files.get(tor_id, file_index, writable, filename, prealloc, file_size, &error); fd)
         {
             // make a note that we just created a file
             session.add_file_created();
             return fd;
         }
-
-        err = errno;
     }
 
-    error.set(
-        err,
-        fmt::format(
-            fmt::runtime(_("Couldn't get '{path}': {error} ({error_code})")),
-            fmt::arg("path", tor.file_subpath(file_index)),
-            fmt::arg("error", tr_strerror(err)),
-            fmt::arg("error_code", err)));
+    if (error)
+    {
+        // open_files.get() reports why but not which file; the message
+        // reaches the user via the torrent's local error, so put the
+        // filename back in
+        error.prefix_message(
+            fmt::format(fmt::runtime(_("Couldn't get '{path}': ")), fmt::arg("path", tor.file_subpath(file_index))));
+    }
+    else // the file doesn't exist, and we can't create it
+    {
+        error.set(
+            ENOENT,
+            fmt::format(
+                fmt::runtime(_("Couldn't get '{path}': {error} ({error_code})")),
+                fmt::arg("path", tor.file_subpath(file_index)),
+                fmt::arg("error", tr_strerror(ENOENT)),
+                fmt::arg("error_code", ENOENT)));
+    }
     return {};
 }
 
@@ -145,6 +160,9 @@ void read_or_write_bytes(
     auto const fd = get_fd(session, open_files, tor, writable, file_index, error);
     if (!fd || error)
     {
+        // no logging needed here: open_files.get() has already logged
+        // the failure, and the write path also surfaces `error` via the
+        // torrent's local error
         return;
     }
 

--- a/libtransmission/open-files.cc
+++ b/libtransmission/open-files.cc
@@ -143,7 +143,8 @@ std::optional<tr_sys_file_t> tr_open_files::get(
     bool writable,
     std::string_view filename_in,
     Preallocation allocation,
-    uint64_t file_size)
+    uint64_t file_size,
+    tr_error* out_error)
 {
     // is there already an entry
     auto key = make_key(tor_id, file_num);
@@ -172,6 +173,10 @@ std::optional<tr_sys_file_t> tr_open_files::get(
                     fmt::arg("path", dir),
                     fmt::arg("error", error.message()),
                     fmt::arg("error_code", error.code())));
+            if (out_error != nullptr)
+            {
+                *out_error = std::move(error);
+            }
             return {};
         }
     }
@@ -195,6 +200,10 @@ std::optional<tr_sys_file_t> tr_open_files::get(
                 fmt::arg("path", filename),
                 fmt::arg("error", error.message()),
                 fmt::arg("error_code", error.code())));
+        if (out_error != nullptr)
+        {
+            *out_error = std::move(error);
+        }
         return {};
     }
 
@@ -225,6 +234,10 @@ std::optional<tr_sys_file_t> tr_open_files::get(
                     fmt::arg("error", error.message()),
                     fmt::arg("error_code", error.code())));
             tr_sys_file_close(fd);
+            if (out_error != nullptr)
+            {
+                *out_error = std::move(error);
+            }
             return {};
         }
 
@@ -238,13 +251,17 @@ std::optional<tr_sys_file_t> tr_open_files::get(
     // https://bugs.launchpad.net/ubuntu/+source/transmission/+bug/318249
     if (resize_needed && !tr_sys_file_truncate(fd, file_size, &error))
     {
-        tr_logAddWarn(
+        tr_logAddError(
             fmt::format(
                 fmt::runtime(_("Couldn't truncate '{path}': {error} ({error_code})")),
                 fmt::arg("path", filename),
                 fmt::arg("error", error.message()),
                 fmt::arg("error_code", error.code())));
         tr_sys_file_close(fd);
+        if (out_error != nullptr)
+        {
+            *out_error = std::move(error);
+        }
         return {};
     }
 

--- a/libtransmission/open-files.cc
+++ b/libtransmission/open-files.cc
@@ -144,7 +144,7 @@ std::optional<tr_sys_file_t> tr_open_files::get(
     std::string_view filename_in,
     Preallocation allocation,
     uint64_t file_size,
-    tr_error* out_error)
+    tr_error& error)
 {
     // is there already an entry
     auto key = make_key(tor_id, file_num);
@@ -160,7 +160,6 @@ std::optional<tr_sys_file_t> tr_open_files::get(
 
     // create subfolders, if any
     auto const filename = tr_pathbuf{ filename_in };
-    auto error = tr_error{};
     if (writable)
     {
         auto dir = tr_pathbuf{ filename.sv() };
@@ -173,10 +172,6 @@ std::optional<tr_sys_file_t> tr_open_files::get(
                     fmt::arg("path", dir),
                     fmt::arg("error", error.message()),
                     fmt::arg("error_code", error.code())));
-            if (out_error != nullptr)
-            {
-                *out_error = std::move(error);
-            }
             return {};
         }
     }
@@ -200,10 +195,6 @@ std::optional<tr_sys_file_t> tr_open_files::get(
                 fmt::arg("path", filename),
                 fmt::arg("error", error.message()),
                 fmt::arg("error_code", error.code())));
-        if (out_error != nullptr)
-        {
-            *out_error = std::move(error);
-        }
         return {};
     }
 
@@ -234,10 +225,6 @@ std::optional<tr_sys_file_t> tr_open_files::get(
                     fmt::arg("error", error.message()),
                     fmt::arg("error_code", error.code())));
             tr_sys_file_close(fd);
-            if (out_error != nullptr)
-            {
-                *out_error = std::move(error);
-            }
             return {};
         }
 
@@ -258,10 +245,6 @@ std::optional<tr_sys_file_t> tr_open_files::get(
                 fmt::arg("error", error.message()),
                 fmt::arg("error_code", error.code())));
         tr_sys_file_close(fd);
-        if (out_error != nullptr)
-        {
-            *out_error = std::move(error);
-        }
         return {};
     }
 

--- a/libtransmission/open-files.h
+++ b/libtransmission/open-files.h
@@ -39,7 +39,8 @@ public:
         bool writable,
         std::string_view filename,
         Preallocation allocation,
-        uint64_t file_size);
+        uint64_t file_size,
+        tr_error* out_error = nullptr);
 
     void close_all();
     void close_torrent(tr_torrent_id_t tor_id);

--- a/libtransmission/open-files.h
+++ b/libtransmission/open-files.h
@@ -40,7 +40,7 @@ public:
         std::string_view filename,
         Preallocation allocation,
         uint64_t file_size,
-        tr_error* out_error = nullptr);
+        tr_error& error);
 
     void close_all();
     void close_torrent(tr_torrent_id_t tor_id);

--- a/tests/libtransmission/CMakeLists.txt
+++ b/tests/libtransmission/CMakeLists.txt
@@ -25,6 +25,7 @@ target_sources(libtransmission-test
         getopt-test.cc
         handshake-test.cc
         history-test.cc
+        inout-test.cc
         ip-cache-test.cc
         json-test.cc
         lpd-test.cc

--- a/tests/libtransmission/inout-test.cc
+++ b/tests/libtransmission/inout-test.cc
@@ -49,7 +49,7 @@ TEST_F(InOutTest, writeFailsWhenExistingFileCannotBeOpened)
 
     auto err = int{};
     auto error_type = TR_STAT_OK;
-    auto const write_block = [session = session_, tor, &err, &error_type]()
+    auto const write_block = [tor, &err, &error_type]()
     {
         auto const buf = std::vector<uint8_t>(tr_block_info::BlockSize);
         err = tr_ioWrite(*tor, tor->block_loc(0U), std::size(buf), std::data(buf));

--- a/tests/libtransmission/inout-test.cc
+++ b/tests/libtransmission/inout-test.cc
@@ -4,6 +4,7 @@
 // License text can be found in the licenses/ folder.
 
 #include <chrono>
+#include <functional>
 #include <future>
 #include <memory>
 #include <utility>
@@ -29,29 +30,49 @@ TEST_F(InOutTest, writeFailsWhenExistingFileCannotBeOpened)
     auto* const tor = zeroTorrentInit(ZeroTorrentState::Complete);
     auto constexpr MaxWaitMsec = 5000;
 
-    // make the torrent's first file unopenable by replacing it with a directory
     auto const path = tr_torrentFindFile(tor, 0U);
     ASSERT_FALSE(std::empty(path));
+
+    // tr_ioWrite() must run in the session thread; block until it's done
+    auto const run_in_session_thread = [this, MaxWaitMsec](std::function<void()> fn)
+    {
+        auto const promise = std::make_shared<std::promise<void>>();
+        auto future = promise->get_future();
+        session_->run_in_session_thread(
+            [fn = std::move(fn), promise]()
+            {
+                fn();
+                promise->set_value();
+            });
+        ASSERT_EQ(std::future_status::ready, future.wait_for(std::chrono::milliseconds{ MaxWaitMsec }));
+    };
+
+    auto err = int{};
+    auto error_type = TR_STAT_OK;
+    auto const write_block = [session = session_, tor, &err, &error_type]()
+    {
+        auto const buf = std::vector<uint8_t>(tr_block_info::BlockSize);
+        err = tr_ioWrite(*tor, tor->block_loc(0U), std::size(buf), std::data(buf));
+        error_type = tor->error().error_type();
+    };
+
+    // Neither the fixture nor verify go through the fd pool, so warm it
+    // with a write that succeeds: this is the steady state of a torrent
+    // that's been receiving blocks from peers.
+    run_in_session_thread(write_block);
+    ASSERT_EQ(0, err);
+    ASSERT_EQ(TR_STAT_OK, error_type);
+
+    // Evict the pooled fd, then make the path unopenable by replacing
+    // the file with a directory.
+    run_in_session_thread([session = session_, tor]() { session->openFiles().close_torrent(tor->id()); });
     ASSERT_TRUE(tr_sys_path_remove(path.c_str()));
     ASSERT_TRUE(tr_sys_dir_create(path.c_str(), 0, 0700));
 
-    // The write must fail: reporting success would make the caller
-    // discard the data, leaving pieces that later fail verification.
-    // (Run in the session thread; drop the file descriptors that verify
-    // left open first, so the write has to reopen the unopenable path.)
-    auto const promise = std::make_shared<std::promise<std::pair<int, tr_stat_errtype>>>();
-    auto future = promise->get_future();
-    session_->run_in_session_thread(
-        [session = session_, tor, promise]()
-        {
-            session->openFiles().close_torrent(tor->id());
-            auto const buf = std::vector<uint8_t>(tr_block_info::BlockSize);
-            auto const err = tr_ioWrite(*tor, tor->block_loc(0U), std::size(buf), std::data(buf));
-            promise->set_value({ err, tor->error().error_type() });
-        });
-    ASSERT_EQ(std::future_status::ready, future.wait_for(std::chrono::milliseconds{ MaxWaitMsec }));
-
-    auto const [err, error_type] = future.get();
+    // The next write has to reopen the path. It must fail and set a
+    // local error: reporting success would make the caller discard the
+    // data, leaving pieces that later fail verification.
+    run_in_session_thread(write_block);
     EXPECT_NE(0, err);
     EXPECT_EQ(TR_STAT_LOCAL_ERROR, error_type);
 }

--- a/tests/libtransmission/inout-test.cc
+++ b/tests/libtransmission/inout-test.cc
@@ -1,0 +1,59 @@
+// This file Copyright © Mnemosyne LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
+// or any future license endorsed by Mnemosyne LLC.
+// License text can be found in the licenses/ folder.
+
+#include <chrono>
+#include <future>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include <libtransmission/transmission.h>
+
+#include <libtransmission/block-info.h>
+#include <libtransmission/file.h>
+#include <libtransmission/inout.h>
+#include <libtransmission/torrent.h>
+
+#include "gtest/gtest.h"
+#include "test-fixtures.h"
+
+namespace libtransmission::test
+{
+
+using InOutTest = SessionTest;
+
+TEST_F(InOutTest, writeFailsWhenExistingFileCannotBeOpened)
+{
+    auto* const tor = zeroTorrentInit(ZeroTorrentState::Complete);
+    auto constexpr MaxWaitMsec = 5000;
+
+    // make the torrent's first file unopenable by replacing it with a directory
+    auto const path = tr_torrentFindFile(tor, 0U);
+    ASSERT_FALSE(std::empty(path));
+    ASSERT_TRUE(tr_sys_path_remove(path.c_str()));
+    ASSERT_TRUE(tr_sys_dir_create(path.c_str(), 0, 0700));
+
+    // The write must fail: reporting success would make the caller
+    // discard the data, leaving pieces that later fail verification.
+    // (Run in the session thread; drop the file descriptors that verify
+    // left open first, so the write has to reopen the unopenable path.)
+    auto const promise = std::make_shared<std::promise<std::pair<int, tr_stat_errtype>>>();
+    auto future = promise->get_future();
+    session_->run_in_session_thread(
+        [session = session_, tor, promise]()
+        {
+            session->openFiles().close_torrent(tor->id());
+            auto const buf = std::vector<uint8_t>(tr_block_info::BlockSize);
+            auto const err = tr_ioWrite(*tor, tor->block_loc(0U), std::size(buf), std::data(buf));
+            promise->set_value({ err, tor->error().error_type() });
+        });
+    ASSERT_EQ(std::future_status::ready, future.wait_for(std::chrono::milliseconds{ MaxWaitMsec }));
+
+    auto const [err, error_type] = future.get();
+    EXPECT_NE(0, err);
+    EXPECT_EQ(TR_STAT_LOCAL_ERROR, error_type);
+}
+
+} // namespace libtransmission::test

--- a/tests/libtransmission/open-files-test.cc
+++ b/tests/libtransmission/open-files-test.cc
@@ -36,6 +36,7 @@ TEST_F(OpenFilesTest, getCachedFailsIfNotCached)
 
 TEST_F(OpenFilesTest, getOpensIfNotCached)
 {
+    auto error = tr_error{};
     static auto constexpr Contents = "Hello, World!\n"sv;
     auto filename = tr_pathbuf{ sandboxDir(), "/test-file.txt" };
     createFileWithContents(filename, Contents);
@@ -44,7 +45,7 @@ TEST_F(OpenFilesTest, getOpensIfNotCached)
     EXPECT_FALSE(session_->openFiles().get(0, 0, false));
 
     // confirm that we can cache the file
-    auto fd = session_->openFiles().get(0, 0, false, filename, PreallocateFull, std::size(Contents));
+    auto fd = session_->openFiles().get(0, 0, false, filename, PreallocateFull, std::size(Contents), error);
     EXPECT_TRUE(fd.has_value());
     assert(fd.has_value());
     EXPECT_NE(TR_BAD_SYS_FILE, *fd);
@@ -59,23 +60,25 @@ TEST_F(OpenFilesTest, getOpensIfNotCached)
 
 TEST_F(OpenFilesTest, getCacheSucceedsIfCached)
 {
+    auto error = tr_error{};
     static auto constexpr Contents = "Hello, World!\n"sv;
     auto filename = tr_pathbuf{ sandboxDir(), "/test-file.txt" };
     createFileWithContents(filename, Contents);
 
     EXPECT_FALSE(session_->openFiles().get(0, 0, false));
-    EXPECT_TRUE(session_->openFiles().get(0, 0, false, filename, PreallocateFull, std::size(Contents)));
+    EXPECT_TRUE(session_->openFiles().get(0, 0, false, filename, PreallocateFull, std::size(Contents), error));
     EXPECT_TRUE(session_->openFiles().get(0, 0, false));
 }
 
 TEST_F(OpenFilesTest, getCachedReturnsTheSameFd)
 {
+    auto error = tr_error{};
     static auto constexpr Contents = "Hello, World!\n"sv;
     auto filename = tr_pathbuf{ sandboxDir(), "/test-file.txt" };
     createFileWithContents(filename, Contents);
 
     EXPECT_FALSE(session_->openFiles().get(0, 0, false));
-    auto const fd1 = session_->openFiles().get(0, 0, false, filename, PreallocateFull, std::size(Contents));
+    auto const fd1 = session_->openFiles().get(0, 0, false, filename, PreallocateFull, std::size(Contents), error);
     auto const fd2 = session_->openFiles().get(0, 0, false);
     EXPECT_TRUE(fd1.has_value());
     EXPECT_TRUE(fd2.has_value());
@@ -86,13 +89,14 @@ TEST_F(OpenFilesTest, getCachedReturnsTheSameFd)
 
 TEST_F(OpenFilesTest, getCachedFailsIfWrongPermissions)
 {
+    auto error = tr_error{};
     static auto constexpr Contents = "Hello, World!\n"sv;
     auto filename = tr_pathbuf{ sandboxDir(), "/test-file.txt" };
     createFileWithContents(filename, Contents);
 
     // cache it in ro mode
     EXPECT_FALSE(session_->openFiles().get(0, 0, false));
-    EXPECT_TRUE(session_->openFiles().get(0, 0, false, filename, PreallocateFull, std::size(Contents)));
+    EXPECT_TRUE(session_->openFiles().get(0, 0, false, filename, PreallocateFull, std::size(Contents), error));
 
     // now try to get it in r/w mode
     EXPECT_TRUE(session_->openFiles().get(0, 0, false));
@@ -101,23 +105,24 @@ TEST_F(OpenFilesTest, getCachedFailsIfWrongPermissions)
 
 TEST_F(OpenFilesTest, opensInReadOnlyUnlessWritableIsRequested)
 {
+    auto error = tr_error{};
     static auto constexpr Contents = "Hello, World!\n"sv;
     auto filename = tr_pathbuf{ sandboxDir(), "/test-file.txt" };
     createFileWithContents(filename, Contents);
 
     // cache a file read-only mode
-    auto fd = session_->openFiles().get(0, 0, false, filename, PreallocateFull, std::size(Contents));
+    auto fd = session_->openFiles().get(0, 0, false, filename, PreallocateFull, std::size(Contents), error);
     EXPECT_TRUE(fd.has_value());
     assert(fd.has_value());
 
     // confirm that writing to it fails
-    auto error = tr_error{};
     EXPECT_FALSE(tr_sys_file_write(*fd, std::data(Contents), std::size(Contents), nullptr, &error));
     EXPECT_TRUE(error);
 }
 
 TEST_F(OpenFilesTest, createsMissingFileIfWriteRequested)
 {
+    auto error = tr_error{};
     static auto constexpr Contents = "Hello, World!\n"sv;
     auto filename = tr_pathbuf{ sandboxDir(), "/test-file.txt" };
     EXPECT_FALSE(tr_sys_path_exists(filename));
@@ -126,7 +131,7 @@ TEST_F(OpenFilesTest, createsMissingFileIfWriteRequested)
     EXPECT_FALSE(fd);
     EXPECT_FALSE(tr_sys_path_exists(filename));
 
-    fd = session_->openFiles().get(0, 0, true, filename, PreallocateFull, std::size(Contents));
+    fd = session_->openFiles().get(0, 0, true, filename, PreallocateFull, std::size(Contents), error);
     EXPECT_TRUE(fd.has_value());
     assert(fd.has_value());
     EXPECT_NE(TR_BAD_SYS_FILE, *fd);
@@ -135,12 +140,13 @@ TEST_F(OpenFilesTest, createsMissingFileIfWriteRequested)
 
 TEST_F(OpenFilesTest, closeFileClosesTheFile)
 {
+    auto error = tr_error{};
     static auto constexpr Contents = "Hello, World!\n"sv;
     auto filename = tr_pathbuf{ sandboxDir(), "/test-file.txt" };
     createFileWithContents(filename, Contents);
 
     // cache a file read-only mode
-    EXPECT_TRUE(session_->openFiles().get(0, 0, false, filename, PreallocateFull, std::size(Contents)));
+    EXPECT_TRUE(session_->openFiles().get(0, 0, false, filename, PreallocateFull, std::size(Contents), error));
     EXPECT_TRUE(session_->openFiles().get(0, 0, false));
 
     // close the file
@@ -152,16 +158,17 @@ TEST_F(OpenFilesTest, closeFileClosesTheFile)
 
 TEST_F(OpenFilesTest, closeTorrentClosesTheTorrentFiles)
 {
+    auto error = tr_error{};
     static auto constexpr Contents = "Hello, World!\n"sv;
     static auto constexpr TorId = tr_torrent_id_t{ 0 };
 
     auto filename = tr_pathbuf{ sandboxDir(), "/a.txt" };
     createFileWithContents(filename, Contents);
-    EXPECT_TRUE(session_->openFiles().get(TorId, 1, false, filename, PreallocateFull, std::size(Contents)));
+    EXPECT_TRUE(session_->openFiles().get(TorId, 1, false, filename, PreallocateFull, std::size(Contents), error));
 
     filename.assign(sandboxDir(), "/b.txt");
     createFileWithContents(filename, Contents);
-    EXPECT_TRUE(session_->openFiles().get(TorId, 3, false, filename, PreallocateFull, std::size(Contents)));
+    EXPECT_TRUE(session_->openFiles().get(TorId, 3, false, filename, PreallocateFull, std::size(Contents), error));
 
     // confirm that closing a different torrent does not affect these files
     session_->openFiles().close_torrent(TorId + 1);
@@ -176,6 +183,7 @@ TEST_F(OpenFilesTest, closeTorrentClosesTheTorrentFiles)
 
 TEST_F(OpenFilesTest, closesLeastRecentlyUsedFile)
 {
+    auto error = tr_error{};
     static auto constexpr Contents = "Hello, World!\n"sv;
     static auto constexpr TorId = tr_torrent_id_t{ 0 };
     static auto constexpr LargerThanCacheLimit = 100;
@@ -186,7 +194,7 @@ TEST_F(OpenFilesTest, closesLeastRecentlyUsedFile)
     for (int i = 0; i < LargerThanCacheLimit; ++i)
     {
         auto filename = tr_pathbuf{ sandboxDir(), fmt::format("/file-{:d}.txt"sv, i) };
-        EXPECT_TRUE(session_->openFiles().get(TorId, i, true, filename, PreallocateFull, std::size(Contents)));
+        EXPECT_TRUE(session_->openFiles().get(TorId, i, true, filename, PreallocateFull, std::size(Contents), error));
     }
 
     // Do a lookup-only for the files again *in the same order*. By following the


### PR DESCRIPTION
Backport of #9050 to 4.1.x, split out of #9049 to keep that one focused on the cache fix.

### The bug

`tr_open_files::get()` builds a `tr_error` for every failure branch, logs it, and throws it away. `get_fd()` couldn't tell an unopenable existing file from a missing one: it returned the empty optional without setting the caller's error, so `read_or_write_bytes()` treated the failed open as success and silently discarded the data it was asked to write. The create branch guessed at the cause via `errno`, which `get()` never sets, so it reported whatever unrelated call last set it.

### The fix

- `tr_open_files::get()` grows a `tr_error` out-param and reports the real failure from all four branches (dir-create, open, preallocate, truncate).
- `get_fd()` uses it for both the open-existing and the create branches, and prefixes the message with the filename via `tr_error::prefix_message()` so the torrent's local error still names the file (review finding 6 on #9049).
- The duplicate bare log line in `read_or_write_bytes()` is gone; `get()` already logs the fully formatted message once.
- The truncate branch's log line moves from warn to error to match its behavior: failing there has always aborted the open, so warn-only understated it (review finding 7 on #9049; keeping it warn-only would have kept the silent data pass).

### Tests

New `inout-test.cc` regression test: replace a torrent's file with a directory, drop the pooled file descriptors, write a block through `tr_ioWrite`. The write must fail and set a local error; on unfixed 4.1.x it reports success and the data is gone. Verified the test fails with the fix reverted, and the libtransmission suite is green with it applied.

The error state is read inside the session thread, so the test doesn't poll `tr_torrentStat` from the test thread (review finding 12 on #9049).