### PR TITLE
fix: correct swapped width and height in NSImage initialization

### DIFF
--- a/macosx/TorrentTableView.mm
+++ b/macosx/TorrentTableView.mm
@@ -289,7 +289,7 @@ static NSTimeInterval const kToggleProgressSeconds = 0.175;
             if (error)
             {
                 NSRect frame = torrentCell.fIconView.frame;
-                NSImage* resultImage = [[NSImage alloc] initWithSize:NSMakeSize(frame.size.height, frame.size.width)];
+                NSImage* resultImage = [[NSImage alloc] initWithSize:frame.size];
                 [resultImage lockFocus];
 
                 // draw fileImage


### PR DESCRIPTION
Backport of #9071 to `4.1.x`.