### PR TITLE
fix: false negative on `send(2)` error

### DIFF
--- a/libtransmission/tr-buffer.h
+++ b/libtransmission/tr-buffer.h
@@ -111,7 +111,7 @@ public:
             return {};
         }
 
-        if (auto const n_sent = send(sockfd, reinterpret_cast<char const*>(data()), n_bytes, 0); n_sent >= 0U)
+        if (auto const n_sent = send(sockfd, reinterpret_cast<char const*>(data()), n_bytes, 0); n_sent >= 0)
         {
             drain(n_sent);
             return n_sent;

--- a/libtransmission/tr-buffer.h
+++ b/libtransmission/tr-buffer.h
@@ -111,7 +111,12 @@ public:
             return {};
         }
 
-        if (auto const n_sent = send(sockfd, reinterpret_cast<char const*>(data()), n_bytes, 0); n_sent >= 0)
+        if (auto const n_sent = send(
+                sockfd,
+                reinterpret_cast<char const*>(data()),
+                TR_IF_WIN32(static_cast<int>(n_bytes), n_bytes),
+                0);
+            n_sent >= 0)
         {
             drain(n_sent);
             return n_sent;


### PR DESCRIPTION
## Description

Regression from #5533.
Already fixed by #7191 in main.

On Windows and 32-bit POSIX systems, `n_sent` is inadvertently getting promoted to `unsigned int` and `size_t` respectively during the comparison with `0U`. This causes a false negative when `send(2)` returns `-1`.

One observable consequence of this is that in encrypted BT connections, Transmission will continue to send data to the peer as if no error occurred, and the peer will read garbage data because it tries to decrypt the encrypted stream while missing a chunk in the middle.

Notes: Fixed error detection on outbound TCP data.

## Checklist

- [x] I have manually written or manually audited all changes in this PR and vouch for them.
