### PR TITLE
fix: disappearing filterbar buttons

### DIFF
--- a/macosx/FilterBar.xib
+++ b/macosx/FilterBar.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="24412" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="24506" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="24412"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="24506"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -27,7 +27,7 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
             <subviews>
                 <popUpButton verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="4">
-                    <rect key="frame" x="5" y="6" width="26" height="12"/>
+                    <rect key="frame" x="5" y="4" width="26" height="15"/>
                     <popUpButtonCell key="cell" type="recessed" bezelStyle="recessed" imagePosition="left" alignment="left" controlSize="mini" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" tag="-999" imageScaling="proportionallyDown" inset="2" pullsDown="YES" arrowPosition="noArrow" selectedItem="57" id="16">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES" changeBackground="YES" changeGray="YES"/>
                         <font key="font" metaFont="miniSystem"/>
@@ -58,11 +58,11 @@
                         <constraint firstAttribute="width" constant="1" id="6ed-rN-3Je"/>
                     </constraints>
                 </box>
-                <stackView distribution="fillProportionally" orientation="horizontal" alignment="centerY" spacing="1" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" horizontalClippingResistancePriority="750" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="mzg-HE-ptV">
-                    <rect key="frame" x="42" y="4" width="341" height="16"/>
+                <stackView clipsToBounds="YES" autoresizesSubviews="NO" distribution="fillProportionally" orientation="horizontal" alignment="centerY" spacing="1" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="mzg-HE-ptV">
+                    <rect key="frame" x="42" y="5" width="329" height="14"/>
                     <subviews>
-                        <button verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="9" customClass="FilterButton">
-                            <rect key="frame" x="0.0" y="0.0" width="31" height="16"/>
+                        <button horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="249" translatesAutoresizingMaskIntoConstraints="NO" id="9" customClass="FilterButton">
+                            <rect key="frame" x="0.0" y="-1" width="29" height="15"/>
                             <buttonCell key="cell" type="recessed" title="All" bezelStyle="recessed" alignment="center" controlSize="mini" lineBreakMode="truncatingTail" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="12">
                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES" changeBackground="YES" changeGray="YES"/>
                                 <font key="font" metaFont="smallSystemBold"/>
@@ -71,57 +71,69 @@
                                 <action selector="setFilter:" target="-2" id="40"/>
                             </connections>
                         </button>
-                        <button verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="3" customClass="FilterButton">
-                            <rect key="frame" x="32" y="0.0" width="52" height="16"/>
+                        <button horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="249" translatesAutoresizingMaskIntoConstraints="NO" id="3" customClass="FilterButton">
+                            <rect key="frame" x="30" y="-1" width="50" height="15"/>
                             <buttonCell key="cell" type="recessed" title="Active" bezelStyle="recessed" alignment="center" controlSize="mini" lineBreakMode="truncatingTail" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="21">
                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES" changeBackground="YES" changeGray="YES"/>
                                 <font key="font" metaFont="smallSystemBold"/>
                             </buttonCell>
                             <connections>
                                 <action selector="setFilter:" target="-2" id="41"/>
+                                <outlet property="previousButton" destination="9" id="VXf-vQ-utg"/>
                             </connections>
                         </button>
-                        <button verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="8" customClass="FilterButton">
-                            <rect key="frame" x="85" y="0.0" width="89" height="16"/>
+                        <button horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="249" translatesAutoresizingMaskIntoConstraints="NO" id="8" customClass="FilterButton">
+                            <rect key="frame" x="81" y="-1" width="87" height="15"/>
                             <buttonCell key="cell" type="recessed" title="Downloading" bezelStyle="recessed" alignment="center" controlSize="mini" lineBreakMode="truncatingTail" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="13">
                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES" changeBackground="YES" changeGray="YES"/>
                                 <font key="font" metaFont="smallSystemBold"/>
                             </buttonCell>
                             <connections>
                                 <action selector="setFilter:" target="-2" id="42"/>
+                                <outlet property="previousButton" destination="3" id="WLH-Mm-HQb"/>
                             </connections>
                         </button>
-                        <button verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="7" customClass="FilterButton">
-                            <rect key="frame" x="175" y="0.0" width="62" height="16"/>
+                        <button horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="249" translatesAutoresizingMaskIntoConstraints="NO" id="7" customClass="FilterButton">
+                            <rect key="frame" x="169" y="-1" width="60" height="15"/>
                             <buttonCell key="cell" type="recessed" title="Seeding" bezelStyle="recessed" alignment="center" controlSize="mini" lineBreakMode="truncatingTail" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="14">
                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES" changeBackground="YES" changeGray="YES"/>
                                 <font key="font" metaFont="smallSystemBold"/>
                             </buttonCell>
                             <connections>
                                 <action selector="setFilter:" target="-2" id="43"/>
+                                <outlet property="previousButton" destination="8" id="NAz-QL-3mb"/>
                             </connections>
                         </button>
-                        <button verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="6" customClass="FilterButton">
-                            <rect key="frame" x="238" y="0.0" width="57" height="16"/>
+                        <button horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="249" translatesAutoresizingMaskIntoConstraints="NO" id="6" customClass="FilterButton">
+                            <rect key="frame" x="230" y="-1" width="55" height="15"/>
                             <buttonCell key="cell" type="recessed" title="Paused" bezelStyle="recessed" alignment="center" controlSize="mini" lineBreakMode="truncatingTail" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="15">
                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES" changeBackground="YES" changeGray="YES"/>
                                 <font key="font" metaFont="smallSystemBold"/>
                             </buttonCell>
                             <connections>
                                 <action selector="setFilter:" target="-2" id="44"/>
+                                <outlet property="previousButton" destination="7" id="ae1-kG-s1r"/>
                             </connections>
                         </button>
-                        <button verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="nvH-xy-86S" customClass="FilterButton">
-                            <rect key="frame" x="296" y="0.0" width="45" height="16"/>
+                        <button horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="249" translatesAutoresizingMaskIntoConstraints="NO" id="nvH-xy-86S" customClass="FilterButton">
+                            <rect key="frame" x="286" y="-1" width="43" height="15"/>
                             <buttonCell key="cell" type="recessed" title="Error" bezelStyle="recessed" alignment="center" controlSize="mini" lineBreakMode="truncatingTail" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="AtX-O4-Mqp">
                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES" changeBackground="YES" changeGray="YES"/>
                                 <font key="font" metaFont="smallSystemBold"/>
                             </buttonCell>
                             <connections>
                                 <action selector="setFilter:" target="-2" id="Rm7-FG-rfe"/>
+                                <outlet property="previousButton" destination="6" id="th6-wR-Nhb"/>
                             </connections>
                         </button>
                     </subviews>
+                    <constraints>
+                        <constraint firstItem="3" firstAttribute="leading" secondItem="9" secondAttribute="trailing" constant="1" id="86O-T4-8xk"/>
+                        <constraint firstItem="7" firstAttribute="leading" secondItem="8" secondAttribute="trailing" constant="1" id="9ZT-xd-N83"/>
+                        <constraint firstItem="6" firstAttribute="leading" secondItem="7" secondAttribute="trailing" constant="1" id="gVb-4B-gyV"/>
+                        <constraint firstItem="8" firstAttribute="leading" secondItem="3" secondAttribute="trailing" constant="1" id="lAR-UE-cBm"/>
+                        <constraint firstItem="nvH-xy-86S" firstAttribute="leading" secondItem="6" secondAttribute="trailing" constant="1" id="lPY-fk-DHL"/>
+                    </constraints>
                     <visibilityPriorities>
                         <integer value="1000"/>
                         <integer value="1000"/>
@@ -139,10 +151,10 @@
                         <real value="3.4028234663852886e+38"/>
                     </customSpacing>
                 </stackView>
-                <searchField wantsLayer="YES" focusRingType="none" verticalHuggingPriority="750" verticalCompressionResistancePriority="1000" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="10">
-                    <rect key="frame" x="400" y="4" width="95" height="16"/>
+                <searchField wantsLayer="YES" focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="1000" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="10">
+                    <rect key="frame" x="400" y="4" width="95" height="17"/>
                     <constraints>
-                        <constraint firstAttribute="width" constant="95" placeholder="YES" id="RUH-hb-Ldl"/>
+                        <constraint firstAttribute="width" priority="1" constant="95" placeholder="YES" id="RUH-hb-Ldl"/>
                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="48" id="Ven-bt-DjP"/>
                         <constraint firstAttribute="width" relation="lessThanOrEqual" constant="95" id="b6y-sO-sUo"/>
                     </constraints>

--- a/macosx/FilterButton.mm
+++ b/macosx/FilterButton.mm
@@ -5,6 +5,13 @@
 #import "FilterButton.h"
 #import "NSStringAdditions.h"
 
+@interface FilterButton ()
+
+/// Button on its left.
+@property(nonatomic) IBOutlet FilterButton* previousButton;
+
+@end
+
 @implementation FilterButton
 
 - (instancetype)initWithCoder:(NSCoder*)coder
@@ -14,6 +21,26 @@
         _count = NSNotFound;
     }
     return self;
+}
+
+- (void)setFrame:(NSRect)frame
+{
+    // The native NSButtonTextField is removed from the view hierarchy at unpredictable times by `[NSButtonAppearanceBasedVisualProvider removeTextField]`.
+    // That removal is later followed by the re-addition of a new textfield.
+    // But the containing NSStackView is also misframing the buttons, ignoring layout constraints.
+    // Apple switched development to SwiftUI and will probably not fix this, so we override the frame ourselves.
+
+    if (frame.size.width < 20)
+    {
+        // Prevent buttons from disappearing
+        frame.size.width = 20;
+    }
+    if (self.previousButton)
+    {
+        // Prevents the NSStackView superposing the buttons
+        frame.origin.x = NSMaxX(self.previousButton.frame) + 1;
+    }
+    [super setFrame:frame];
 }
 
 - (void)setCount:(NSUInteger)count


### PR DESCRIPTION
## Description

Fix #3400

It took me 4 years to find an approximate solution. It may not be perfect, but it's the best I achieved so far.

Notes: Fix the disappearing filterbar buttons

Problem: NSStackView and NSButton have undocumented, or poorly documented, or buggy behaviours which make them lose their content in a couple of ways:
- NSButton will sometimes remove its textfield and may or not re-add a new one later.
- When that happens, NSStackView ignores layout constraints and set the frame of the buttons to unpredictable arbitrary values.

Solution:
- Set a minimum width for each button in `setFrame:`. Width 20 is observed to be the proper minimum in regular behaviour.
- Set a proper horizontal position next to their left neighbour.
- Add `<stackView clipsToBounds="YES">` to prevent seeing the buttons under the search field.
- Remove `detachesHiddenViews="YES"`: no effects in practice, but we don't want to leave this as a potential cause of missing buttons.

Testing:
Resize the Transmission window violently for a few seconds to trigger the NSButton replacing its TextViews and the NSStackView going wild.

## Checklist

- [x] I have manually written or manually audited all changes in this PR and vouch for them.
