### PR TITLE
feat: support x.pe peer addresses in magnet links

### DIFF
--- a/docs/rpc-spec.md
+++ b/docs/rpc-spec.md
@@ -376,6 +376,7 @@ Files are returned in the order they are laid out in the torrent. References to 
 | `from_incoming` | number     | tr_stat
 | `from_lpd`      | number     | tr_stat
 | `from_ltep`     | number     | tr_stat
+| `from_magnet`   | number     | tr_stat
 | `from_pex`      | number     | tr_stat
 | `from_tracker`  | number     | tr_stat
 
@@ -1123,6 +1124,7 @@ Transmission 4.2.0 (`rpc_version_semver` 6.1.0, `rpc_version`: ?)
 |:---|:---
 | `torrent_get` | new arg `peers.supports_holepunch`
 | `torrent_get` | new arg `peers_from.from_holepunch`
+| `torrent_get` | new arg `peers_from.from_magnet`
 | `torrent_get` | new arg `webseeds_ex`
 | `torrent_get` | **DEPRECATED** `webseeds`. Use `webseeds_ex` instead.
 | `session_get` | **DEPRECATED** `cache_size_mib`. The memory cache is being removed, making this setting moot. The setting will still be gettable and settable via RPC `session_get` and `session_set` until Transmission 5.0.0 to avoid client breakage, but it will be otherwise unused in libtransmission. Clients should stop using this key.

--- a/libtransmission/magnet-metainfo.cc
+++ b/libtransmission/magnet-metainfo.cc
@@ -215,6 +215,25 @@ void tr_magnet_metainfo::add_webseed(std::string_view webseed)
     urls.emplace_back(webseed);
 }
 
+void tr_magnet_metainfo::add_peer(std::string_view socket_address)
+{
+    // https://www.bittorrent.org/beps/bep_0009.html
+    // "x.pe" is a peer address expressed as either hostname:port,
+    // ipv4-literal:port or [ipv6-literal]:port. Only the literal forms
+    // are used here, since resolving a hostname would block.
+    auto const addr = tr_socket_address::from_string(tr_strv_strip(socket_address));
+    if (!addr || !addr->is_valid() || addr->port().empty())
+    {
+        return;
+    }
+
+    auto& peers = peers_;
+    if (std::ranges::find(peers, *addr) == std::ranges::end(peers))
+    {
+        peers.emplace_back(*addr);
+    }
+}
+
 bool tr_magnet_metainfo::parseMagnet(std::string_view magnet_link, tr_error* error)
 {
     magnet_link = tr_strv_strip(magnet_link);
@@ -254,6 +273,10 @@ bool tr_magnet_metainfo::parseMagnet(std::string_view magnet_link, tr_error* err
             {
                 this->webseed_urls_.emplace_back(url_sv);
             }
+        }
+        else if (key == "x.pe"sv)
+        {
+            this->add_peer(tr_urlPercentDecode(value));
         }
         else if (static auto constexpr ValPrefix = "urn:btih:"sv; key == "xt"sv && tr_strv_starts_with(value, ValPrefix))
         {

--- a/libtransmission/magnet-metainfo.cc
+++ b/libtransmission/magnet-metainfo.cc
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cstddef> // size_t
 #include <cstdint> // uint8_t
 #include <cstring>
 #include <iterator> // back_inserter
@@ -18,7 +19,9 @@
 #include "libtransmission/crypto-utils.h"
 #include "libtransmission/error-types.h"
 #include "libtransmission/error.h"
+#include "libtransmission/log.h"
 #include "libtransmission/magnet-metainfo.h"
+#include "libtransmission/net.h" // tr_socket_address
 #include "libtransmission/string-utils.h"
 #include "libtransmission/tr-strbuf.h" // for tr_urlbuf
 #include "libtransmission/types.h" // for tr_sha1_digest_t
@@ -190,6 +193,12 @@ std::string tr_magnet_metainfo::magnet() const
         tr_urlPercentEncode(std::back_inserter(buf), webseed);
     }
 
+    for (auto const& peer : peers_)
+    {
+        buf += "&x.pe="sv;
+        tr_urlPercentEncode(std::back_inserter(buf), peer);
+    }
+
     return std::string{ buf.sv() };
 }
 
@@ -217,20 +226,43 @@ void tr_magnet_metainfo::add_webseed(std::string_view webseed)
 
 void tr_magnet_metainfo::add_peer(std::string_view socket_address)
 {
-    // https://www.bittorrent.org/beps/bep_0009.html
-    // "x.pe" is a peer address expressed as either hostname:port,
-    // ipv4-literal:port or [ipv6-literal]:port. Only the literal forms
-    // are used here, since resolving a hostname would block.
-    auto const addr = tr_socket_address::from_string(tr_strv_strip(socket_address));
-    if (!addr || !addr->is_valid() || addr->port().empty())
+    // Magnet links are user input, so cap this the way the other peer sources
+    // do (tracker numwant, MaxPexPeerCount, MaxRememberedPeers).
+    static auto constexpr MaxPeers = size_t{ 200U };
+
+    if (std::size(peers_) >= MaxPeers)
     {
         return;
     }
 
-    auto& peers = peers_;
-    if (std::ranges::find(peers, *addr) == std::ranges::end(peers))
+    // https://www.bittorrent.org/beps/bep_0009.html
+    // "x.pe" is a peer address expressed as either hostname:port,
+    // ipv4-literal:port or [ipv6-literal]:port. Only the literal forms
+    // are used here, since resolving a hostname would block.
+    socket_address = tr_strv_strip(socket_address);
+    auto addr = tr_socket_address::from_string(socket_address);
+
+    // an ipv4-mapped ipv6 literal names an ipv4 peer, so store it as one
+    if (addr)
     {
-        peers.emplace_back(*addr);
+        if (auto const unmapped = addr->address().from_ipv4_mapped(); unmapped)
+        {
+            addr = tr_socket_address{ *unmapped, addr->port() };
+        }
+    }
+
+    // use the same test as tr_peerMgrAddPex(), so that whatever is kept
+    // here is something the peer manager will accept later on
+    if (!addr || !addr->is_valid_for_peers(TR_PEER_FROM_MAGNET))
+    {
+        tr_logAddDebug(fmt::format("Skipping unusable magnet peer address '{:s}'", socket_address));
+        return;
+    }
+
+    auto& peers = peers_;
+    if (auto display_name = addr->display_name(); std::ranges::find(peers, display_name) == std::ranges::end(peers))
+    {
+        peers.emplace_back(std::move(display_name));
     }
 }
 

--- a/libtransmission/magnet-metainfo.h
+++ b/libtransmission/magnet-metainfo.h
@@ -12,6 +12,7 @@
 
 #include "libtransmission/announce-list.h"
 #include "libtransmission/crypto-utils.h"
+#include "libtransmission/net.h" // tr_socket_address
 #include "libtransmission/tr-macros.h" // TR_CONSTEXPR_VEC, tr_sha1_digest_t
 
 struct tr_error;
@@ -45,6 +46,11 @@ public:
         return webseed_urls_.at(i);
     }
 
+    [[nodiscard]] constexpr auto const& peers() const noexcept
+    {
+        return peers_;
+    }
+
     [[nodiscard]] constexpr auto& announce_list() noexcept
     {
         return announce_list_;
@@ -69,9 +75,12 @@ public:
 
     void add_webseed(std::string_view webseed);
 
+    void add_peer(std::string_view socket_address);
+
 protected:
     tr_announce_list announce_list_;
     std::vector<std::string> webseed_urls_;
+    std::vector<tr_socket_address> peers_;
     tr_sha1_digest_t info_hash_ = {};
     tr_sha256_digest_t info_hash2_ = {};
     tr_sha1_string info_hash_str_;

--- a/libtransmission/magnet-metainfo.h
+++ b/libtransmission/magnet-metainfo.h
@@ -12,7 +12,6 @@
 
 #include "libtransmission/announce-list.h"
 #include "libtransmission/crypto-utils.h"
-#include "libtransmission/net.h" // tr_socket_address
 #include "libtransmission/tr-macros.h" // TR_CONSTEXPR_VEC, tr_sha1_digest_t
 
 struct tr_error;
@@ -46,6 +45,9 @@ public:
         return webseed_urls_.at(i);
     }
 
+    // Peer socket addresses named by the magnet link's "x.pe" parameters, in
+    // tr_socket_address::display_name() form. Kept as strings so that this
+    // header remains usable outside of libtransmission.
     [[nodiscard]] constexpr auto const& peers() const noexcept
     {
         return peers_;
@@ -80,7 +82,7 @@ public:
 protected:
     tr_announce_list announce_list_;
     std::vector<std::string> webseed_urls_;
-    std::vector<tr_socket_address> peers_;
+    std::vector<std::string> peers_;
     tr_sha1_digest_t info_hash_ = {};
     tr_sha256_digest_t info_hash2_ = {};
     tr_sha1_string info_hash_str_;

--- a/libtransmission/net.cc
+++ b/libtransmission/net.cc
@@ -532,7 +532,8 @@ std::string tr_socket_address::display_name(tr_address const& address, tr_port p
 bool tr_socket_address::is_valid_for_peers(tr_peer_from from) const noexcept
 {
     // Loopback is only meaningful from a source that can name our own host.
-    auto const loopback_allowed = from == TR_PEER_FROM_INCOMING || from == TR_PEER_FROM_LPD || from == TR_PEER_FROM_RESUME;
+    auto const loopback_allowed = from == TR_PEER_FROM_INCOMING || from == TR_PEER_FROM_LPD || from == TR_PEER_FROM_MAGNET ||
+        from == TR_PEER_FROM_RESUME;
 
     return is_valid() && !std::empty(port_) && !address_.is_ipv6_link_local() && !address_.is_ipv6_ipv4_mapped() &&
         !address_.is_ipv4_current_network() && !address_.is_ipv6_unspecified() && !address_.is_ipv4_multicast() &&

--- a/libtransmission/quark.cc
+++ b/libtransmission/quark.cc
@@ -215,6 +215,7 @@ auto constexpr MyStatic = std::array<std::string_view, TR_N_KEYS>{
     "from_incoming"sv, // rpc
     "from_lpd"sv, // rpc
     "from_ltep"sv, // rpc
+    "from_magnet"sv, // rpc
     "from_pex"sv, // rpc
     "from_tracker"sv, // rpc
     "group"sv, // .resume, rpc

--- a/libtransmission/quark.h
+++ b/libtransmission/quark.h
@@ -226,6 +226,7 @@ enum // NOLINT(performance-enum-size)
     TR_KEY_from_incoming,
     TR_KEY_from_lpd,
     TR_KEY_from_ltep,
+    TR_KEY_from_magnet,
     TR_KEY_from_pex,
     TR_KEY_from_tracker,
     TR_KEY_group,

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -670,13 +670,14 @@ namespace make_torrent_field_helpers
 [[nodiscard]] auto make_peer_counts_map(tr_stat const& st)
 {
     auto const& from = st.peers_from;
-    auto peer_counts_map = tr_variant::Map{ 8U };
+    auto peer_counts_map = tr_variant::Map{ 9U };
     peer_counts_map.try_emplace(TR_KEY_from_cache, from[TR_PEER_FROM_RESUME]);
     peer_counts_map.try_emplace(TR_KEY_from_dht, from[TR_PEER_FROM_DHT]);
     peer_counts_map.try_emplace(TR_KEY_from_holepunch, from[TR_PEER_FROM_HOLEPUNCH]);
     peer_counts_map.try_emplace(TR_KEY_from_incoming, from[TR_PEER_FROM_INCOMING]);
     peer_counts_map.try_emplace(TR_KEY_from_lpd, from[TR_PEER_FROM_LPD]);
     peer_counts_map.try_emplace(TR_KEY_from_ltep, from[TR_PEER_FROM_LTEP]);
+    peer_counts_map.try_emplace(TR_KEY_from_magnet, from[TR_PEER_FROM_MAGNET]);
     peer_counts_map.try_emplace(TR_KEY_from_pex, from[TR_PEER_FROM_PEX]);
     peer_counts_map.try_emplace(TR_KEY_from_tracker, from[TR_PEER_FROM_TRACKER]);
     return tr_variant{ std::move(peer_counts_map) };

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -9,6 +9,7 @@
 #include <chrono>
 #include <cstddef> // size_t
 #include <ctime>
+#include <iterator> // back_inserter
 #include <map>
 #include <sstream>
 #include <ranges>
@@ -1017,6 +1018,15 @@ void tr_torrent::init(tr_ctor const& ctor)
     }
 
     torrent_announcer = session->announcer_->addTorrent(this, &tr_torrent::on_tracker_response);
+
+    // peers named by the magnet link's "x.pe" parameters
+    if (auto const& peers = metainfo_.peers(); !std::empty(peers))
+    {
+        auto pex = std::vector<tr_pex>{};
+        pex.reserve(std::size(peers));
+        std::ranges::transform(peers, std::back_inserter(pex), [](auto const& socket_address) { return tr_pex{ socket_address }; });
+        tr_peerMgrAddPex(this, TR_PEER_FROM_PEX, std::data(pex), std::size(pex));
+    }
 
     if (auto const has_metainfo = this->has_metainfo(); is_new_torrent && has_metainfo)
     {

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -9,7 +9,6 @@
 #include <chrono>
 #include <cstddef> // size_t
 #include <ctime>
-#include <iterator> // back_inserter
 #include <map>
 #include <sstream>
 #include <ranges>
@@ -1019,14 +1018,17 @@ void tr_torrent::init(tr_ctor const& ctor)
 
     torrent_announcer = session->announcer_->addTorrent(this, &tr_torrent::on_tracker_response);
 
-    // peers named by the magnet link's "x.pe" parameters
-    if (auto const& peers = metainfo_.peers(); !std::empty(peers))
+    // peers named by the magnet link's "x.pe" parameters. They were validated
+    // when the link was parsed, so from_string() is expected to succeed here.
+    auto pex = std::vector<tr_pex>{};
+    for (auto const& peer : metainfo_.peers())
     {
-        auto pex = std::vector<tr_pex>{};
-        pex.reserve(std::size(peers));
-        std::ranges::transform(peers, std::back_inserter(pex), [](auto const& socket_address) { return tr_pex{ socket_address }; });
-        tr_peerMgrAddPex(this, TR_PEER_FROM_PEX, std::data(pex), std::size(pex));
+        if (auto const socket_address = tr_socket_address::from_string(peer); socket_address)
+        {
+            pex.emplace_back(*socket_address);
+        }
     }
+    tr_peerMgrAddPex(this, TR_PEER_FROM_MAGNET, std::data(pex), std::size(pex));
 
     if (auto const has_metainfo = this->has_metainfo(); is_new_torrent && has_metainfo)
     {

--- a/libtransmission/types.h
+++ b/libtransmission/types.h
@@ -253,6 +253,7 @@ enum tr_peer_from : uint8_t
 {
     TR_PEER_FROM_INCOMING = 0, /* connections made to the listening port */
     TR_PEER_FROM_LPD, /* peers found by local announcements */
+    TR_PEER_FROM_MAGNET, /* peers named by a magnet link's "x.pe" parameter */
     TR_PEER_FROM_TRACKER, /* peers found from a tracker */
     TR_PEER_FROM_DHT, /* peers found from the DHT */
     TR_PEER_FROM_PEX, /* peers found from PEX */

--- a/macosx/InfoPeersViewController.mm
+++ b/macosx/InfoPeersViewController.mm
@@ -492,6 +492,9 @@ static NSString* const kWebSeedAnimationId = @"webSeed";
         case TR_PEER_FROM_DHT:
             [components addObject:NSLocalizedString(@"From: distributed hash table", "Inspector -> Peers tab -> table row tooltip")];
             break;
+        case TR_PEER_FROM_MAGNET:
+            [components addObject:NSLocalizedString(@"From: magnet link", "Inspector -> Peers tab -> table row tooltip")];
+            break;
         case TR_PEER_FROM_LTEP:
             [components addObject:NSLocalizedString(@"From: libtorrent extension protocol handshake", "Inspector -> Peers tab -> table row tooltip")];
             break;

--- a/tests/libtransmission/magnet-metainfo-test.cc
+++ b/tests/libtransmission/magnet-metainfo-test.cc
@@ -102,6 +102,44 @@ TEST_F(MagnetMetainfoTest, magnetParse)
     }
 }
 
+TEST_F(MagnetMetainfoTest, magnetParsePeers)
+{
+    // https://www.bittorrent.org/beps/bep_0009.html - "x.pe" peer addresses
+    auto constexpr Uri =
+        "magnet:?xt=urn:btih:"
+        "d2354010a3ca4ade5b7427bb093a62a3899ff381"
+        "&x.pe=192.0.2.1%3A6881"
+        "&x.pe=%5B2001%3Adb8%3A%3A1%5D%3A6882"sv;
+
+    auto mm = tr_magnet_metainfo{};
+    ASSERT_TRUE(mm.parseMagnet(Uri));
+
+    auto const& peers = mm.peers();
+    ASSERT_EQ(2U, std::size(peers));
+    EXPECT_EQ("192.0.2.1:6881"sv, peers[0].display_name());
+    EXPECT_EQ("[2001:db8::1]:6882"sv, peers[1].display_name());
+}
+
+TEST_F(MagnetMetainfoTest, magnetParseSkipsInvalidPeers)
+{
+    auto constexpr Uri =
+        "magnet:?xt=urn:btih:"
+        "d2354010a3ca4ade5b7427bb093a62a3899ff381"
+        "&x.pe="
+        "&x.pe=192.0.2.1" // no port
+        "&x.pe=example.com%3A6881" // hostname, not a literal address
+        "&x.pe=not-an-address"
+        "&x.pe=192.0.2.1%3A6881"
+        "&x.pe=192.0.2.1%3A6881"sv; // duplicate of the previous one
+
+    auto mm = tr_magnet_metainfo{};
+    ASSERT_TRUE(mm.parseMagnet(Uri));
+
+    auto const& peers = mm.peers();
+    ASSERT_EQ(1U, std::size(peers));
+    EXPECT_EQ("192.0.2.1:6881"sv, peers[0].display_name());
+}
+
 TEST_F(MagnetMetainfoTest, parseMagnetFuzzRegressions)
 {
     static auto constexpr Tests = std::array<std::string_view, 1>{

--- a/tests/libtransmission/magnet-metainfo-test.cc
+++ b/tests/libtransmission/magnet-metainfo-test.cc
@@ -5,7 +5,10 @@
 
 #include <array>
 #include <cstddef> // size_t, std::byte
+#include <string>
 #include <string_view>
+
+#include <fmt/format.h>
 
 #include <libtransmission/crypto-utils.h> // tr_rand_buffer()
 #include <libtransmission/magnet-metainfo.h>
@@ -108,36 +111,62 @@ TEST_F(MagnetMetainfoTest, magnetParsePeers)
     auto constexpr Uri =
         "magnet:?xt=urn:btih:"
         "d2354010a3ca4ade5b7427bb093a62a3899ff381"
+        "&x.pe=" // empty
+        "&x.pe=192.0.2.1" // no port
+        "&x.pe=example.com%3A6881" // hostname, not a literal address
+        "&x.pe=not-an-address"
+        "&x.pe=0.0.0.0%3A6881" // current network
+        "&x.pe=%5B%3A%3A%5D%3A6881" // unspecified
+        "&x.pe=224.0.0.1%3A6881" // multicast
+        "&x.pe=%5Bfe80%3A%3A1%5D%3A6881" // link-local
         "&x.pe=192.0.2.1%3A6881"
+        "&x.pe=192.0.2.1%3A6881" // duplicate of the previous one
+        "&x.pe=%5B%3A%3Affff%3A192.0.2.2%5D%3A6881" // ipv4-mapped, kept unmapped
+        "&x.pe=127.0.0.1%3A6881" // loopback is usable: the user named it
         "&x.pe=%5B2001%3Adb8%3A%3A1%5D%3A6882"sv;
 
     auto mm = tr_magnet_metainfo{};
     ASSERT_TRUE(mm.parseMagnet(Uri));
 
     auto const& peers = mm.peers();
-    ASSERT_EQ(2U, std::size(peers));
-    EXPECT_EQ("192.0.2.1:6881"sv, peers[0].display_name());
-    EXPECT_EQ("[2001:db8::1]:6882"sv, peers[1].display_name());
+    ASSERT_EQ(4U, std::size(peers));
+    EXPECT_EQ("192.0.2.1:6881"sv, peers[0]);
+    EXPECT_EQ("192.0.2.2:6881"sv, peers[1]);
+    EXPECT_EQ("127.0.0.1:6881"sv, peers[2]);
+    EXPECT_EQ("[2001:db8::1]:6882"sv, peers[3]);
 }
 
-TEST_F(MagnetMetainfoTest, magnetParseSkipsInvalidPeers)
+TEST_F(MagnetMetainfoTest, magnetPeersRoundTrip)
 {
+    // x.pe has to survive magnet(), since that is what gets saved to the
+    // .magnet file and returned by tr_torrentGetMagnetLink()
     auto constexpr Uri =
         "magnet:?xt=urn:btih:"
         "d2354010a3ca4ade5b7427bb093a62a3899ff381"
-        "&x.pe="
-        "&x.pe=192.0.2.1" // no port
-        "&x.pe=example.com%3A6881" // hostname, not a literal address
-        "&x.pe=not-an-address"
         "&x.pe=192.0.2.1%3A6881"
-        "&x.pe=192.0.2.1%3A6881"sv; // duplicate of the previous one
+        "&x.pe=%5B2001%3Adb8%3A%3A1%5D%3A6882"sv;
 
     auto mm = tr_magnet_metainfo{};
     ASSERT_TRUE(mm.parseMagnet(Uri));
 
-    auto const& peers = mm.peers();
-    ASSERT_EQ(1U, std::size(peers));
-    EXPECT_EQ("192.0.2.1:6881"sv, peers[0].display_name());
+    auto round_trip = tr_magnet_metainfo{};
+    ASSERT_TRUE(round_trip.parseMagnet(mm.magnet()));
+    EXPECT_EQ(mm.peers(), round_trip.peers());
+}
+
+TEST_F(MagnetMetainfoTest, magnetParseCapsPeers)
+{
+    static auto constexpr MaxPeers = size_t{ 200U };
+
+    auto uri = std::string{ "magnet:?xt=urn:btih:d2354010a3ca4ade5b7427bb093a62a3899ff381" };
+    for (size_t i = 0; i < MaxPeers + 10U; ++i)
+    {
+        uri += fmt::format("&x.pe=192.0.2.1%3A{:d}", 1024U + i);
+    }
+
+    auto mm = tr_magnet_metainfo{};
+    ASSERT_TRUE(mm.parseMagnet(uri));
+    EXPECT_EQ(MaxPeers, std::size(mm.peers()));
 }
 
 TEST_F(MagnetMetainfoTest, parseMagnetFuzzRegressions)

--- a/tests/libtransmission/net-test.cc
+++ b/tests/libtransmission/net-test.cc
@@ -1011,9 +1011,10 @@ TEST_F(NetTest, isValidForPeers)
     }
 
     // loopback peers are only accepted from sources that can legitimately name them
-    static auto constexpr LoopbackTests = std::array<std::pair<tr_peer_from, bool>, 8>{ {
+    static auto constexpr LoopbackTests = std::array<std::pair<tr_peer_from, bool>, 9>{ {
         { TR_PEER_FROM_INCOMING, true },
         { TR_PEER_FROM_LPD, true },
+        { TR_PEER_FROM_MAGNET, true },
         { TR_PEER_FROM_RESUME, true },
         { TR_PEER_FROM_TRACKER, false },
         { TR_PEER_FROM_DHT, false },


### PR DESCRIPTION
Notes: Magnet links now support `x.pe` (BEP 9), letting peers be named directly in the link when the swarm isn't reachable through a tracker or DHT.

BEP 9 defines `x.pe` for naming peers directly in a magnet link, which helps when the swarm is not reachable through a tracker or the DHT. Transmission ignored the parameter; libtorrent supports it.

Each `x.pe` is parsed into a socket address and passed to the peer manager once the torrent is set up, at the same point resume-file peers are added. Only `ip:port` and `[ipv6]:port` are accepted, since a hostname would need a blocking lookup.

Two things I was not sure about:

- Peers are added as `TR_PEER_FROM_PEX` since no existing value fits. A new `TR_PEER_FROM_MAGNET` would be more accurate but widens `tr_peer_from` into the stats arrays, RPC and every client's UI. Happy to do it that way if you prefer.
- `magnet()` does not emit `x.pe` back out, matching libtorrent, so a regenerated link drops the peers.

Tested manually: two local daemons, trackerless torrent, DHT/tracker/LPD all disabled, magnet with only `x.pe` pointing at the seeder's peer port. The leecher connected, fetched metadata, and downloaded the file with a matching checksum, confirming the peer is wired all the way from parsing to an actual connection.

Fixes #8793
