### PR TITLE
refactor: collapse is_martian_addr() into is_valid_for_peers()

### DIFF
--- a/libtransmission/net.cc
+++ b/libtransmission/net.cc
@@ -271,26 +271,6 @@ void tr_net_close_socket(tr_socket_t sockfd)
     evutil_closesocket(static_cast<evutil_socket_t>(sockfd));
 }
 
-// ---
-
-namespace
-{
-namespace is_valid_for_peers_helpers
-{
-
-/* isMartianAddr was written by Juliusz Chroboczek,
-   and is covered under the same license as third-party/dht/dht.c. */
-[[nodiscard]] auto is_martian_addr(tr_address const& addr, tr_peer_from from)
-{
-    auto const loopback_allowed = from == TR_PEER_FROM_INCOMING || from == TR_PEER_FROM_LPD || from == TR_PEER_FROM_RESUME;
-    return addr.is_ipv4_current_network() || addr.is_ipv6_unspecified() ||
-        (!loopback_allowed && (addr.is_ipv4_loopback() || addr.is_ipv6_loopback())) || addr.is_ipv4_multicast() ||
-        addr.is_ipv6_multicast();
-}
-
-} // namespace is_valid_for_peers_helpers
-} // namespace
-
 // --- tr_port
 
 tr_port tr_port::from_network(uint16_t const nport) noexcept
@@ -551,10 +531,14 @@ std::string tr_socket_address::display_name(tr_address const& address, tr_port p
 
 bool tr_socket_address::is_valid_for_peers(tr_peer_from from) const noexcept
 {
-    using namespace is_valid_for_peers_helpers;
+    // Loopback is only meaningful from a source that can name our own host.
+    auto const loopback_allowed = from == TR_PEER_FROM_INCOMING || from == TR_PEER_FROM_LPD || from == TR_PEER_FROM_RESUME;
 
+    // The martian address checks below were written by Juliusz Chroboczek as
+    // isMartianAddr(), and are covered under the same license as third-party/dht/dht.c.
     return is_valid() && !std::empty(port_) && !address_.is_ipv6_link_local() && !address_.is_ipv6_ipv4_mapped() &&
-        !is_martian_addr(address_, from);
+        !address_.is_ipv4_current_network() && !address_.is_ipv6_unspecified() && !address_.is_ipv4_multicast() &&
+        !address_.is_ipv6_multicast() && (loopback_allowed || (!address_.is_ipv4_loopback() && !address_.is_ipv6_loopback()));
 }
 
 std::optional<tr_socket_address> tr_socket_address::from_string(std::string_view sockaddr_sv)

--- a/libtransmission/net.cc
+++ b/libtransmission/net.cc
@@ -534,8 +534,6 @@ bool tr_socket_address::is_valid_for_peers(tr_peer_from from) const noexcept
     // Loopback is only meaningful from a source that can name our own host.
     auto const loopback_allowed = from == TR_PEER_FROM_INCOMING || from == TR_PEER_FROM_LPD || from == TR_PEER_FROM_RESUME;
 
-    // The martian address checks below were written by Juliusz Chroboczek as
-    // isMartianAddr(), and are covered under the same license as third-party/dht/dht.c.
     return is_valid() && !std::empty(port_) && !address_.is_ipv6_link_local() && !address_.is_ipv6_ipv4_mapped() &&
         !address_.is_ipv4_current_network() && !address_.is_ipv6_unspecified() && !address_.is_ipv4_multicast() &&
         !address_.is_ipv6_multicast() && (loopback_allowed || (!address_.is_ipv4_loopback() && !address_.is_ipv6_loopback()));

--- a/tests/libtransmission/net-test.cc
+++ b/tests/libtransmission/net-test.cc
@@ -977,3 +977,59 @@ TEST_F(NetTest, IPv4MappedAddress)
         EXPECT_EQ(native_sv, native->display_name());
     }
 }
+
+TEST_F(NetTest, isValidForPeers)
+{
+    static auto constexpr Tests = std::array<std::pair<std::string_view, bool>, 13>{ {
+        { "1.2.3.4:6881"sv, true },
+        { "[2001:db8::1]:6881"sv, true },
+        { "0.0.0.0:6881"sv, false }, // "this network"
+        { "0.1.2.3:6881"sv, false }, // "this network"
+        { "[::]:6881"sv, false }, // unspecified
+        { "224.0.0.1:6881"sv, false }, // multicast
+        { "239.255.255.255:6881"sv, false }, // multicast
+        { "[ff02::1]:6881"sv, false }, // multicast
+        { "[fe80::1]:6881"sv, false }, // link-local
+        { "[::ffff:1.2.3.4]:6881"sv, false }, // ipv4-mapped
+        { "[::ffff:127.0.0.1]:6881"sv, false }, // ipv4-mapped
+        { "127.0.0.1:6881"sv, false }, // loopback, see LoopbackTests
+        { "[::1]:6881"sv, false }, // loopback, see LoopbackTests
+    } };
+
+    for (auto const& [presentation, expected] : Tests)
+    {
+        auto const socket_address = tr_socket_address::from_string(presentation);
+        ASSERT_TRUE(socket_address.has_value()) << presentation;
+        EXPECT_EQ(expected, socket_address->is_valid_for_peers(TR_PEER_FROM_TRACKER)) << presentation;
+    }
+
+    // a peer address without a port is useless
+    {
+        auto const address = tr_address::from_string("1.2.3.4"sv);
+        ASSERT_TRUE(address.has_value());
+        EXPECT_FALSE(tr_socket_address(*address, tr_port{}).is_valid_for_peers(TR_PEER_FROM_TRACKER));
+    }
+
+    // loopback peers are only accepted from sources that can legitimately name them
+    static auto constexpr LoopbackTests = std::array<std::pair<tr_peer_from, bool>, 8>{ {
+        { TR_PEER_FROM_INCOMING, true },
+        { TR_PEER_FROM_LPD, true },
+        { TR_PEER_FROM_RESUME, true },
+        { TR_PEER_FROM_TRACKER, false },
+        { TR_PEER_FROM_DHT, false },
+        { TR_PEER_FROM_PEX, false },
+        { TR_PEER_FROM_LTEP, false },
+        { TR_PEER_FROM_HOLEPUNCH, false },
+    } };
+
+    for (auto const& presentation : { "127.0.0.1:6881"sv, "[::1]:6881"sv })
+    {
+        auto const socket_address = tr_socket_address::from_string(presentation);
+        ASSERT_TRUE(socket_address.has_value()) << presentation;
+
+        for (auto const& [from, expected] : LoopbackTests)
+        {
+            EXPECT_EQ(expected, socket_address->is_valid_for_peers(from)) << presentation << " from " << from;
+        }
+    }
+}


### PR DESCRIPTION
`is_martian_addr()` was separate for historical reasons, as @tearfur noted: it began as an LTEP-only check and was folded into peer validation later. Splitting it kept the loopback rule in the helper and the rest at the call site, so the full rule for a peer address was never in one place.

This inlines the checks. The attribution comment is gone as well: @tearfur overhauled `is_martian_addr()` and little of the original code is left, so the block now falls under the project's GPL like the rest of `net.cc`. No behavior change.

`is_valid_for_peers()` had no test coverage, so I added a test first against the existing code, then refactored under it. It also pins the loopback rule: which sources may name `127.0.0.1` or `::1` and which may not.

I left `is_ipv6_ipv4_mapped()` in place rather than dropping it on the `IPV6_V6ONLY` argument, since that only covers addresses arriving over our own sockets, not ones a tracker or PEX hands us.

Fixes #7848
