### PR TITLE
feat: select the file when opening a single-file torrent's folder

### DIFF
--- a/gtk/Session.cc
+++ b/gtk/Session.cc
@@ -1385,7 +1385,7 @@ void Session::open_folder(tr_torrent_id_t torrent_id) const
 
         if (tr_torrentFileCount(tor) == 1)
         {
-            gtr_open_file(current_dir);
+            gtr_show_file_in_folder(current_dir, tr_torrentFile(tor, 0).name);
         }
         else
         {

--- a/gtk/Utils.cc
+++ b/gtk/Utils.cc
@@ -22,10 +22,12 @@
 #include <gdkmm/display.h>
 #include <giomm/appinfo.h>
 #include <giomm/asyncresult.h>
+#include <giomm/dbusconnection.h>
 #include <giomm/file.h>
 #include <glibmm/convert.h>
 #include <glibmm/error.h>
 #include <glibmm/i18n.h>
+#include <glibmm/miscutils.h>
 #include <glibmm/quark.h>
 #include <glibmm/spawn.h>
 #include <gtkmm/cellrenderertext.h>
@@ -630,6 +632,41 @@ void gtr_open_file(std::string_view const filename)
 {
     auto const filename_ustr = Glib::ustring{ filename.data(), filename.size() };
     gtr_open_uri(Glib::filename_to_uri(filename_ustr).raw());
+}
+
+void gtr_show_file_in_folder(std::string_view const base, std::string_view const relative_path)
+{
+    auto const filename = tr_pathbuf{ base, "/"sv, relative_path };
+    gtr_show_file_in_folder(filename.sv());
+}
+
+void gtr_show_file_in_folder(std::string_view const filename)
+{
+    auto const filename_ustr = Glib::ustring{ filename.data(), filename.size() };
+
+    // Ask the file manager to open the parent folder with the item selected.
+    // Not every file manager implements this, so fall back to opening the folder itself.
+    try
+    {
+        auto const uri = Glib::filename_to_uri(filename_ustr);
+        auto const connection = Gio::DBus::Connection::get_sync(TR_GIO_DBUS_BUS_TYPE(SESSION));
+        connection->call_sync(
+            "/org/freedesktop/FileManager1",
+            "org.freedesktop.FileManager1",
+            "ShowItems",
+            Glib::VariantContainerBase::create_tuple(
+                { Glib::Variant<std::vector<Glib::ustring>>::create({ uri }),
+                  Glib::Variant<Glib::ustring>::create(Glib::ustring{}) }),
+            "org.freedesktop.FileManager1",
+            1000);
+        return;
+    }
+    catch (Glib::Error const&)
+    {
+        // fall through to opening the parent folder
+    }
+
+    gtr_open_file(Glib::path_get_dirname(filename_ustr.raw()));
 }
 
 void gtr_open_uri(std::string_view const uri)

--- a/gtk/Utils.h
+++ b/gtk/Utils.h
@@ -94,6 +94,8 @@ inline GParamSpec* gtr_get_param_spec(char const* name, char const* nick, char c
 
 void gtr_open_file(std::string_view base, std::string_view relative_path);
 void gtr_open_file(std::string_view filename);
+void gtr_show_file_in_folder(std::string_view base, std::string_view relative_path);
+void gtr_show_file_in_folder(std::string_view filename);
 void gtr_open_uri(std::string_view uri);
 
 [[nodiscard]] std::string gtr_get_help_uri(std::string_view relative_path = "");

--- a/qt/MainWindow.cc
+++ b/qt/MainWindow.cc
@@ -17,6 +17,10 @@
 #include <QMessageBox>
 #include <QPainter>
 #include <QProxyStyle>
+#ifdef ENABLE_DBUS_INTEROP
+#include <QDBusConnection>
+#include <QDBusMessage>
+#endif
 #include <QtGui>
 
 #include <libtransmission/transmission.h>
@@ -565,7 +569,27 @@ void openSelect(QString const& path)
 #else
 void openSelect(QString const& path)
 {
-    QDesktopServices::openUrl(QUrl::fromLocalFile(path));
+#ifdef ENABLE_DBUS_INTEROP
+    // Ask the file manager to open the parent folder with the item selected.
+    // Not every file manager implements this, so fall back to opening the folder itself.
+    if (auto bus = QDBusConnection::sessionBus(); bus.isConnected())
+    {
+        auto m = QDBusMessage::createMethodCall(
+            QStringLiteral("org.freedesktop.FileManager1"),
+            QStringLiteral("/org/freedesktop/FileManager1"),
+            QStringLiteral("org.freedesktop.FileManager1"),
+            QStringLiteral("ShowItems"));
+        m.setArguments({ QStringList{ QUrl::fromLocalFile(path).toString() }, QString{} });
+
+        if (bus.call(m).type() != QDBusMessage::ErrorMessage)
+        {
+            return;
+        }
+    }
+#endif
+
+    auto const info = QFileInfo{ path };
+    QDesktopServices::openUrl(QUrl::fromLocalFile(info.isDir() ? path : info.absolutePath()));
 }
 #endif
 
@@ -639,8 +663,16 @@ void MainWindow::openFolder()
     }
 
     auto const parent = QDir{ tor->getPath() };
-    auto const child = getTopFolder(parent, tor);
-    openSelect(parent.filePath(child));
+
+    if (auto const child = getTopFolder(parent, tor); !child.isEmpty())
+    {
+        openSelect(parent.filePath(child));
+        return;
+    }
+
+    // no top folder: select the file itself, if there's only one
+    auto const& files = tor->files();
+    openSelect(std::size(files) == 1U ? parent.filePath(files.at(0).filename) : parent.path());
 }
 
 void MainWindow::copyMagnetLinkToClipboard()


### PR DESCRIPTION
Fixes #1066.

"Open Folder" on a single-file torrent opened the containing directory without highlighting the file, so it had to be found by hand in a directory that may hold many other downloads.

Both clients now ask the file manager to select the item through the FreeDesktop `org.freedesktop.FileManager1` `ShowItems` method, and fall back to opening the parent directory when that call fails. The Qt client already did this on Windows and macOS, so this brings Linux in line with the other platforms.

On the dependency question raised in the issue: the GTK client already speaks DBus through giomm, in `gtk/Session.cc:1041` and `gtk/Notify.cc`, so nothing new is pulled in. The Qt side reuses the existing `DBusInteropHelper`, guarded by `ENABLE_DBUS_INTEROP` as before.

Tested by hand on Arch with GNOME Files: single-file torrent in a directory with 12 decoy files, right click, Open Folder, and the file comes up selected.

<img width="1338" height="701" alt="1-open-folder-menu" src="https://github.com/user-attachments/assets/db1caec3-0f0b-4919-a09c-8c3787050459" />

<img width="1349" height="713" alt="2-file-selected-among-decoys" src="https://github.com/user-attachments/assets/bf02289b-3e06-44a5-9a6d-e92a68564728" />
