### PR TITLE
fix: restore bounded endgame requests

### DIFF
--- a/libtransmission/peer-mgr-wishlist.cc
+++ b/libtransmission/peer-mgr-wishlist.cc
@@ -72,7 +72,8 @@ Wishlist::Candidate::Candidate(tr_piece_index_t piece_in, tr_piece_index_t salt_
 
 std::vector<tr_block_span_t> Wishlist::next(
     size_t const n_wanted_blocks,
-    std::function<bool(tr_piece_index_t)> const& peer_has_piece)
+    std::function<bool(tr_piece_index_t)> const& peer_has_piece,
+    std::function<bool(tr_block_index_t)> const& peer_has_active_request)
 {
     if (n_wanted_blocks == 0U)
     {
@@ -103,8 +104,44 @@ std::vector<tr_block_span_t> Wishlist::next(
         std::copy_n(std::rbegin(candidate.unrequested), n_to_add, std::back_inserter(blocks));
     }
 
-    // Ensure the list of blocks are sorted
-    // The list needs to be unique as well, but that should come naturally
+    // Once every remaining block is already requested, let one more peer
+    // race for it instead of sitting idle. The count below is only checked
+    // here, in endgame, to keep the normal path above cheap.
+    if (std::size(blocks) < n_wanted_blocks && mediator_.is_endgame())
+    {
+        for (auto const& candidate : candidates_)
+        {
+            if (std::size(blocks) >= n_wanted_blocks)
+            {
+                break;
+            }
+
+            if (candidate.replication == 0 || !peer_has_piece(candidate.piece))
+            {
+                continue;
+            }
+
+            for (auto [block, end] = candidate.block_span; block < end && std::size(blocks) < n_wanted_blocks; ++block)
+            {
+                if (candidate.unrequested.contains(block) || mediator_.client_has_block(block) ||
+                    (peer_has_active_request && peer_has_active_request(block)))
+                {
+                    continue;
+                }
+
+                if (mediator_.count_active_requests(block) >= 2U)
+                {
+                    continue;
+                }
+
+                blocks.push_back(block);
+            }
+        }
+    }
+
+    // Endgame can append blocks out of piece order, so sort. No dedupe
+    // needed: it only considers blocks already absent from unrequested, so
+    // the two phases never pick the same one.
     std::ranges::sort(blocks);
     return make_spans(blocks);
 }

--- a/libtransmission/peer-mgr-wishlist.h
+++ b/libtransmission/peer-mgr-wishlist.h
@@ -34,6 +34,8 @@ public:
         [[nodiscard]] virtual bool client_has_block(tr_block_index_t block) const = 0;
         [[nodiscard]] virtual bool client_has_piece(tr_piece_index_t piece) const = 0;
         [[nodiscard]] virtual bool client_wants_piece(tr_piece_index_t piece) const = 0;
+        [[nodiscard]] virtual bool is_endgame() const = 0;
+        [[nodiscard]] virtual uint8_t count_active_requests(tr_block_index_t block) const = 0;
         [[nodiscard]] virtual bool is_sequential_download() const = 0;
         [[nodiscard]] virtual tr_piece_index_t sequential_download_from_piece() const = 0;
         [[nodiscard]] virtual size_t count_piece_replication(tr_piece_index_t piece) const = 0;
@@ -136,7 +138,7 @@ public:
         }
     }
 
-    TR_CONSTEXPR_VEC void on_got_choke(tr_bitfield const& requests)
+    void on_got_choke(tr_bitfield const& requests)
     {
         reset_blocks_bitfield(requests);
     }
@@ -155,12 +157,12 @@ public:
         inc_replication();
     }
 
-    constexpr void on_got_reject(tr_block_index_t const block)
+    void on_got_reject(tr_block_index_t const block)
     {
         reset_block(block);
     }
 
-    TR_CONSTEXPR_VEC void on_peer_disconnect(tr_bitfield const& have, tr_bitfield const& requests)
+    void on_peer_disconnect(tr_bitfield const& have, tr_bitfield const& requests)
     {
         dec_replication_bitfield(have);
         reset_blocks_bitfield(requests);
@@ -173,7 +175,7 @@ public:
 
     void on_priority_changed();
 
-    constexpr void on_sent_cancel(tr_block_index_t const block)
+    void on_sent_cancel(tr_block_index_t const block)
     {
         reset_block(block);
     }
@@ -196,7 +198,8 @@ public:
     // the next blocks that we should request from a peer
     [[nodiscard]] std::vector<tr_block_span_t> next(
         size_t n_wanted_blocks,
-        std::function<bool(tr_piece_index_t)> const& peer_has_piece);
+        std::function<bool(tr_piece_index_t)> const& peer_has_piece,
+        std::function<bool(tr_block_index_t)> const& peer_has_active_request = {});
 
 private:
     constexpr void dec_replication() noexcept
@@ -270,15 +273,16 @@ private:
                 break;
             }
 
-            auto& unreq = it_p->unrequested;
+            if (auto& unreq = it_p->unrequested; !std::empty(unreq))
+            {
+                auto it_b_end = std::end(unreq);
+                it_b_end = *std::prev(it_b_end) >= block_span.begin ? it_b_end : unreq.upper_bound(block_span.begin);
 
-            auto it_b_end = std::end(unreq);
-            it_b_end = *std::prev(it_b_end) >= block_span.begin ? it_b_end : unreq.upper_bound(block_span.begin);
+                auto it_b_begin = std::begin(unreq);
+                it_b_begin = *it_b_begin < block_span.end ? it_b_begin : unreq.upper_bound(block_span.end);
 
-            auto it_b_begin = std::begin(unreq);
-            it_b_begin = *it_b_begin < block_span.end ? it_b_begin : unreq.upper_bound(block_span.end);
-
-            unreq.erase(it_b_begin, it_b_end);
+                unreq.erase(it_b_begin, it_b_end);
+            }
 
             block = it_p->block_span.end;
 
@@ -286,8 +290,18 @@ private:
         }
     }
 
-    constexpr void reset_block(tr_block_index_t block)
+    // A released block goes back in the pool only if something still needs
+    // it: not the client (already has it) and, in endgame, not a second
+    // requester (see other_requester_remains() -- can't gate this on
+    // is_endgame() itself, since that can go false from unrelated peer
+    // churn while this specific block still has two real requesters).
+    void reset_block(tr_block_index_t const block)
     {
+        if (mediator_.client_has_block(block) || other_requester_remains(block, false))
+        {
+            return;
+        }
+
         if (auto const it_p = find_by_block(block); it_p != std::end(candidates_))
         {
             it_p->unrequested.insert(block);
@@ -295,7 +309,7 @@ private:
         }
     }
 
-    TR_CONSTEXPR_VEC void reset_blocks_bitfield(tr_bitfield const& requests)
+    void reset_blocks_bitfield(tr_bitfield const& requests)
     {
         for (auto& candidate : candidates_)
         {
@@ -307,7 +321,8 @@ private:
 
             for (auto i = end; i > begin; --i)
             {
-                if (auto const block = i - 1U; requests.test(block))
+                auto const block = i - 1U;
+                if (requests.test(block) && !mediator_.client_has_block(block) && !other_requester_remains(block, true))
                 {
                     candidate.unrequested.insert(block);
                 }
@@ -315,6 +330,14 @@ private:
         }
 
         std::ranges::sort(candidates_);
+    }
+
+    // self_bit_still_set: reset_block()'s caller already cleared its own bit
+    // before calling; reset_blocks_bitfield()'s has not, so it always counts
+    // as one requester.
+    [[nodiscard]] bool other_requester_remains(tr_block_index_t const block, bool const self_bit_still_set) const
+    {
+        return mediator_.count_active_requests(block) > (self_bit_still_set ? 1U : 0U);
     }
 
     // ---

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -415,9 +415,12 @@ public:
         {
         }
 
-        [[nodiscard]] auto next(size_t const n_wanted_blocks, std::function<bool(tr_piece_index_t)> const& peer_has_piece)
+        [[nodiscard]] auto next(
+            size_t const n_wanted_blocks,
+            std::function<bool(tr_piece_index_t)> const& peer_has_piece,
+            std::function<bool(tr_block_index_t)> const& peer_has_active_request)
         {
-            return wishlist_.next(n_wanted_blocks, peer_has_piece);
+            return wishlist_.next(n_wanted_blocks, peer_has_piece, peer_has_active_request);
         }
 
         [[nodiscard]] bool client_has_block(tr_block_index_t const block) const override
@@ -433,6 +436,45 @@ public:
         [[nodiscard]] bool client_wants_piece(tr_piece_index_t const piece) const override
         {
             return tor_.piece_is_wanted(piece);
+        }
+
+        [[nodiscard]] bool is_endgame() const override
+        {
+            auto const count_active_requests = [](uint64_t const count, auto const& peer)
+            {
+                return count + peer->active_req_count(tr_direction::ClientToPeer);
+            };
+
+            auto const n_active = std::accumulate(
+                                      std::begin(swarm_.peers),
+                                      std::end(swarm_.peers),
+                                      uint64_t{},
+                                      count_active_requests) +
+                std::accumulate(std::begin(swarm_.webseeds), std::end(swarm_.webseeds), uint64_t{}, count_active_requests);
+
+            return n_active * tr_block_info::BlockSize >= tor_.left_until_done();
+        }
+
+        [[nodiscard]] uint8_t count_active_requests(tr_block_index_t const block) const override
+        {
+            auto n_requesters = uint8_t{};
+            auto const count_requests = [&n_requesters, block](auto const& peers)
+            {
+                for (auto const& peer : peers)
+                {
+                    if (peer->active_requests.test(block) && ++n_requesters >= 2U)
+                    {
+                        return;
+                    }
+                }
+            };
+
+            count_requests(swarm_.peers);
+            if (n_requesters < 2U)
+            {
+                count_requests(swarm_.webseeds);
+            }
+            return n_requesters;
         }
 
         [[nodiscard]] bool is_sequential_download() const override
@@ -1237,7 +1279,10 @@ std::vector<tr_block_span_t> tr_peerMgrGetNextRequests(tr_torrent* torrent, tr_p
 
     if (auto& controller = torrent->swarm->wishlist_controller)
     {
-        return controller->next(numwant, [peer](tr_piece_index_t p) { return peer->has_piece(p); });
+        return controller->next(
+            numwant,
+            [peer](tr_piece_index_t p) { return peer->has_piece(p); },
+            [peer](tr_block_index_t b) { return peer->active_requests.test(b); });
     }
 
     return {};

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -457,23 +457,25 @@ public:
 
         [[nodiscard]] uint8_t count_active_requests(tr_block_index_t const block) const override
         {
-            auto n_requesters = uint8_t{};
-            auto const count_requests = [&n_requesters, block](auto const& peers)
+            // Do not duplicate requests for blocks already in flight to a webseed,
+            // as HTTP webseeds cannot receive CANCEL protocol messages.
+            for (auto const& webseed : swarm_.webseeds)
             {
-                for (auto const& peer : peers)
+                if (webseed->active_requests.test(block))
                 {
-                    if (peer->active_requests.test(block) && ++n_requesters >= 2U)
-                    {
-                        return;
-                    }
+                    return 2U;
                 }
-            };
-
-            count_requests(swarm_.peers);
-            if (n_requesters < 2U)
-            {
-                count_requests(swarm_.webseeds);
             }
+
+            auto n_requesters = uint8_t{};
+            for (auto const& peer : swarm_.peers)
+            {
+                if (peer->active_requests.test(block) && ++n_requesters >= 2U)
+                {
+                    return 2U;
+                }
+            }
+
             return n_requesters;
         }
 
@@ -1273,7 +1275,11 @@ void tr_peerMgrFree(tr_peerMgr* manager)
  *    tr_peerMgrGetNextRequests() is called.
  */
 
-std::vector<tr_block_span_t> tr_peerMgrGetNextRequests(tr_torrent* torrent, tr_peer const* peer, size_t numwant)
+std::vector<tr_block_span_t> tr_peerMgrGetNextRequests(
+    tr_torrent* torrent,
+    tr_peer const* peer,
+    size_t numwant,
+    std::optional<tr_block_index_t> const ignore_block)
 {
     TR_ASSERT(!torrent->is_done());
 
@@ -1282,7 +1288,8 @@ std::vector<tr_block_span_t> tr_peerMgrGetNextRequests(tr_torrent* torrent, tr_p
         return controller->next(
             numwant,
             [peer](tr_piece_index_t p) { return peer->has_piece(p); },
-            [peer](tr_block_index_t b) { return peer->active_requests.test(b); });
+            [peer, ignore_block](tr_block_index_t b)
+            { return (ignore_block && *ignore_block == b) || peer->active_requests.test(b); });
     }
 
     return {};

--- a/libtransmission/peer-mgr.h
+++ b/libtransmission/peer-mgr.h
@@ -704,7 +704,11 @@ constexpr bool tr_isPex(tr_pex const* pex)
 
 void tr_peerMgrFree(tr_peerMgr* manager);
 
-[[nodiscard]] std::vector<tr_block_span_t> tr_peerMgrGetNextRequests(tr_torrent* torrent, tr_peer const* peer, size_t numwant);
+[[nodiscard]] std::vector<tr_block_span_t> tr_peerMgrGetNextRequests(
+    tr_torrent* torrent,
+    tr_peer const* peer,
+    size_t numwant,
+    std::optional<tr_block_index_t> ignore_block = std::nullopt);
 
 void tr_peerMgrAddIncoming(tr_peerMgr* manager, std::shared_ptr<tr_peer_socket> socket);
 

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -606,7 +606,7 @@ private:
         desired_request_count_ = max_available_reqs();
     }
 
-    void maybe_send_block_requests();
+    void maybe_send_block_requests(std::optional<tr_block_index_t> ignore_block = std::nullopt);
 
     void check_request_timeout(time_t now);
 
@@ -1780,9 +1780,9 @@ ReadResult tr_peerMsgsImpl::process_peer_message(uint8_t id, MessageReader& payl
                 {
                     active_requests.unset(block);
 
-                    // Make sure maybe_send_block_requests() is called before removing the request
-                    // from the wishlist, so that it will choose a block other than the rejected block.
-                    maybe_send_block_requests();
+                    // Refill with this block explicitly excluded so the peer is not re-offered
+                    // its own rejected block before the rejection has been published to wishlist.
+                    maybe_send_block_requests(block);
 
                     publish(tr_peer_event::GotRejected(tor_.block_info(), block));
                 }
@@ -2054,7 +2054,7 @@ void tr_peerMsgsImpl::maybe_send_metadata_requests(time_t now) const
     }
 }
 
-void tr_peerMsgsImpl::maybe_send_block_requests()
+void tr_peerMsgsImpl::maybe_send_block_requests(std::optional<tr_block_index_t> const ignore_block)
 {
     if (!tor_.client_can_download() || !client_is_interested() || client_is_choked())
     {
@@ -2068,7 +2068,7 @@ void tr_peerMsgsImpl::maybe_send_block_requests()
     }
 
     auto const n_wanted = desired_request_count_ - n_active;
-    if (auto const requests = tr_peerMgrGetNextRequests(&tor_, this, n_wanted); !std::empty(requests))
+    if (auto const requests = tr_peerMgrGetNextRequests(&tor_, this, n_wanted, ignore_block); !std::empty(requests))
     {
         request_blocks(std::data(requests), std::size(requests));
     }

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -261,14 +261,17 @@ public:
 
     void on_rejection(tr_block_span_t block_span)
     {
+        // Clear the bit before publishing, matching tr_peerMsgsImpl: otherwise
+        // an endgame check running inside the handler below would still see
+        // this webseed as holding the block it just rejected.
         for (auto block = block_span.begin; block < block_span.end; ++block)
         {
             if (active_requests.test(block))
             {
+                active_requests.unset(block);
                 publish(tr_peer_event::GotRejected(tor.block_info(), block));
             }
         }
-        active_requests.unset_span(block_span.begin, block_span.end);
     }
 
     void request_blocks(tr_block_span_t const* block_spans, size_t n_spans) override

--- a/tests/libtransmission/peer-mgr-wishlist-test.cc
+++ b/tests/libtransmission/peer-mgr-wishlist-test.cc
@@ -6,7 +6,9 @@
 #include <array>
 #include <cstddef> // size_t
 #include <map>
+#include <random>
 #include <set>
+#include <vector>
 
 #define LIBTRANSMISSION_PEER_MODULE
 
@@ -23,13 +25,16 @@ class PeerMgrWishlistTest : public ::tr::test::TransmissionTest
 protected:
     struct MockMediator final : public Wishlist::Mediator
     {
-        mutable std::map<tr_block_index_t, uint8_t> active_request_count_;
         mutable std::map<tr_piece_index_t, tr_block_span_t> block_span_;
         mutable std::map<tr_piece_index_t, tr_priority_t> piece_priority_;
         mutable std::map<tr_piece_index_t, size_t> piece_replication_;
         mutable std::set<tr_block_index_t> client_has_block_;
         mutable std::set<tr_piece_index_t> client_has_piece_;
         mutable std::set<tr_piece_index_t> client_wants_piece_;
+        // count_active_requests() scans these the way the real mediator scans
+        // connected peers.
+        mutable std::vector<tr_bitfield> peer_requests_;
+        bool is_endgame_ = false;
         bool is_sequential_download_ = false;
         tr_piece_index_t sequential_download_from_piece_ = 0;
 
@@ -48,6 +53,24 @@ protected:
         [[nodiscard]] bool client_wants_piece(tr_piece_index_t piece) const override
         {
             return client_wants_piece_.contains(piece);
+        }
+
+        [[nodiscard]] bool is_endgame() const override
+        {
+            return is_endgame_;
+        }
+
+        [[nodiscard]] uint8_t count_active_requests(tr_block_index_t block) const override
+        {
+            auto count = uint8_t{};
+            for (auto const& requests : peer_requests_)
+            {
+                if (requests.test(block) && ++count >= 2U)
+                {
+                    break;
+                }
+            }
+            return count;
         }
 
         [[nodiscard]] bool is_sequential_download() const override
@@ -218,6 +241,324 @@ TEST_F(PeerMgrWishlistTest, doesNotRequestSameBlockTwice)
     EXPECT_EQ(240U, requested.count());
     EXPECT_EQ(0U, requested.count(0, 10));
     EXPECT_EQ(240U, requested.count(10, 250));
+}
+
+TEST_F(PeerMgrWishlistTest, endgameRequestsEachInFlightBlockFromOnlyOneAdditionalPeer)
+{
+    auto mediator = MockMediator{};
+    mediator.block_span_[0] = { .begin = 0, .end = 10 };
+    mediator.piece_replication_[0] = 2;
+    mediator.client_wants_piece_.insert(0);
+
+    // A second peer gets no work under normal selection here -- the slow-tail
+    // condition endgame exists for.
+    mediator.peer_requests_.emplace_back(tr_bitfield{ 10 });
+    mediator.peer_requests_[0].set_span(0, 10);
+
+    auto wishlist = Wishlist{ mediator };
+    wishlist.on_sent_request({ .begin = 0, .end = 10 });
+    EXPECT_TRUE(std::empty(wishlist.next(10, PeerHasAllPieces)));
+
+    // Peer 1 already has the first half itself (e.g. from an earlier
+    // backup), so it is only offered the second half.
+    mediator.is_endgame_ = true;
+    mediator.peer_requests_.emplace_back(tr_bitfield{ 10 });
+    mediator.peer_requests_[1].set_span(0, 5);
+    static auto constexpr PeerHasFirstHalfInFlight = [](tr_block_index_t block)
+    {
+        return block < 5U;
+    };
+    auto spans = wishlist.next(10, PeerHasAllPieces, PeerHasFirstHalfInFlight);
+    auto requested = tr_bitfield{ 10 };
+    for (auto const& [begin, end] : spans)
+    {
+        requested.set_span(begin, end);
+    }
+    EXPECT_EQ(5U, requested.count());
+    EXPECT_EQ(0U, requested.count(0, 5));
+    EXPECT_EQ(5U, requested.count(5, 10));
+
+    // Peer 0 and peer 1 now both have all 10 blocks, so every block is at
+    // its two-requester cap and a third peer gets nothing.
+    mediator.peer_requests_[1].set_span(5, 10);
+    wishlist.on_sent_request({ .begin = 5, .end = 10 });
+    EXPECT_TRUE(std::empty(wishlist.next(10, PeerHasAllPieces)));
+
+    // Peer 1's request for block 5 is rejected. Peer 0 still holds it, so
+    // block 5 is a valid, capped endgame candidate again, not a free-for-all.
+    mediator.peer_requests_[1].unset(5);
+    wishlist.on_got_reject(5);
+    spans = wishlist.next(1, PeerHasAllPieces);
+    ASSERT_EQ(1U, std::size(spans));
+    EXPECT_EQ(5U, spans[0].begin);
+    EXPECT_EQ(6U, spans[0].end);
+
+    // Once peer 0 also lets go, block 5 has no requesters left; it is
+    // available the same way, this time through the plain unrequested path.
+    mediator.peer_requests_[0].unset(5);
+    wishlist.on_got_reject(5);
+    spans = wishlist.next(1, PeerHasAllPieces);
+    ASSERT_EQ(1U, std::size(spans));
+    EXPECT_EQ(5U, spans[0].begin);
+    EXPECT_EQ(6U, spans[0].end);
+}
+
+TEST_F(PeerMgrWishlistTest, endgameRejectDoesNotFreeABlockStillHeldByAnotherPeer)
+{
+    auto mediator = MockMediator{};
+    mediator.block_span_[0] = { .begin = 0, .end = 1 };
+    mediator.piece_replication_[0] = 2;
+    mediator.client_wants_piece_.insert(0);
+    mediator.is_endgame_ = true;
+
+    // Two peers already hold this block, capping it at two requesters. A
+    // reject or cancel of just one must not open the door to a third.
+    mediator.peer_requests_.emplace_back(tr_bitfield{ 1 });
+    mediator.peer_requests_.emplace_back(tr_bitfield{ 1 });
+    mediator.peer_requests_[0].set(0);
+    mediator.peer_requests_[1].set(0);
+
+    auto wishlist = Wishlist{ mediator };
+    wishlist.on_sent_request({ .begin = 0, .end = 1 });
+
+    // Real peers clear their own bit before notifying the wishlist (see
+    // tr_peerMsgsImpl::cancel_block_request and the reject handler in
+    // peer-msgs.cc); reproduce that ordering here.
+    mediator.peer_requests_[0].unset(0);
+    wishlist.on_got_reject(0);
+
+    // Peer 1 still holds the block, so this must return nothing even with
+    // endgame off -- a wrongly freed block would come back via the plain,
+    // uncapped unrequested path instead.
+    mediator.is_endgame_ = false;
+    EXPECT_TRUE(std::empty(wishlist.next(1, PeerHasAllPieces)));
+
+    // Once peer 1 also lets go, the block is free again.
+    mediator.peer_requests_[1].unset(0);
+    wishlist.on_sent_cancel(0);
+    EXPECT_FALSE(std::empty(wishlist.next(1, PeerHasAllPieces)));
+}
+
+TEST_F(PeerMgrWishlistTest, endgameGuardDoesNotDependOnEndgameStillBeingActive)
+{
+    auto mediator = MockMediator{};
+    mediator.block_span_[0] = { .begin = 0, .end = 1 };
+    mediator.piece_replication_[0] = 2;
+    mediator.client_wants_piece_.insert(0);
+    mediator.is_endgame_ = true;
+
+    mediator.peer_requests_.emplace_back(tr_bitfield{ 1 });
+    mediator.peer_requests_.emplace_back(tr_bitfield{ 1 });
+    mediator.peer_requests_[0].set(0);
+    mediator.peer_requests_[1].set(0);
+
+    auto wishlist = Wishlist{ mediator };
+    wishlist.on_sent_request({ .begin = 0, .end = 1 });
+
+    // The torrent leaves endgame (e.g. unrelated peer churn dropped total
+    // in-flight bytes below what's left to download) *before* peer 0's
+    // request ends, not after. The block still has a real second requester;
+    // whether the torrent as a whole currently reads as "in endgame" is a
+    // different question and must not decide this.
+    mediator.is_endgame_ = false;
+    mediator.peer_requests_[0].unset(0);
+    wishlist.on_got_reject(0);
+
+    EXPECT_TRUE(std::empty(wishlist.next(1, PeerHasAllPieces)));
+}
+
+TEST_F(PeerMgrWishlistTest, cancelForAnAlreadyDeliveredBlockDoesNotReviveIt)
+{
+    auto mediator = MockMediator{};
+    mediator.block_span_[0] = { .begin = 0, .end = 1 };
+    mediator.piece_replication_[0] = 2;
+    mediator.client_wants_piece_.insert(0);
+    mediator.is_endgame_ = true;
+
+    // Two peers hold the block, an endgame duplicate.
+    mediator.peer_requests_.emplace_back(tr_bitfield{ 1 });
+    mediator.peer_requests_.emplace_back(tr_bitfield{ 1 });
+    mediator.peer_requests_[0].set(0);
+    mediator.peer_requests_[1].set(0);
+
+    auto wishlist = Wishlist{ mediator };
+    wishlist.on_sent_request({ .begin = 0, .end = 1 });
+
+    // Peer 0 delivers the block first.
+    mediator.peer_requests_[0].unset(0);
+    mediator.client_has_block_.insert(0);
+    wishlist.on_got_block(0);
+
+    // Peer 1's now-redundant request gets cancelled. Neither peer holds the
+    // block anymore, but the client already has it -- it must not go back
+    // into the pool for a third peer to redundantly re-fetch.
+    mediator.peer_requests_[1].unset(0);
+    wishlist.on_sent_cancel(0);
+
+    EXPECT_TRUE(std::empty(wishlist.next(1, PeerHasAllPieces)));
+}
+
+TEST_F(PeerMgrWishlistTest, endgameChokeDoesNotFreeABlockStillHeldByAnotherPeer)
+{
+    auto mediator = MockMediator{};
+    mediator.block_span_[0] = { .begin = 0, .end = 1 };
+    mediator.piece_replication_[0] = 2;
+    mediator.client_wants_piece_.insert(0);
+    mediator.is_endgame_ = true;
+
+    mediator.peer_requests_.emplace_back(tr_bitfield{ 1 });
+    mediator.peer_requests_.emplace_back(tr_bitfield{ 1 });
+    mediator.peer_requests_[0].set(0);
+    mediator.peer_requests_[1].set(0);
+
+    auto wishlist = Wishlist{ mediator };
+    wishlist.on_sent_request({ .begin = 0, .end = 1 });
+
+    // Unlike a reject or cancel, a choking peer's own bit is still set when
+    // the wishlist is notified (tr_peerMsgsImpl clears it right after), so
+    // the guard must not count it as an extra peer.
+    auto const choked = mediator.peer_requests_[0];
+    wishlist.on_got_choke(choked);
+    mediator.peer_requests_[0].unset(0);
+
+    // Peer 1 still holds the block, even with endgame now off.
+    mediator.is_endgame_ = false;
+    EXPECT_TRUE(std::empty(wishlist.next(1, PeerHasAllPieces)));
+
+    // Peer 1 disconnects next, with the same still-set-at-call-time ordering.
+    mediator.is_endgame_ = true;
+    auto const disconnected = mediator.peer_requests_[1];
+    wishlist.on_peer_disconnect(tr_bitfield{ 300 }, disconnected);
+    mediator.peer_requests_[1].unset(0);
+
+    mediator.is_endgame_ = false;
+    EXPECT_FALSE(std::empty(wishlist.next(1, PeerHasAllPieces)));
+}
+
+TEST_F(PeerMgrWishlistTest, endgameStateMatchesActiveRequestsThroughRandomEvents)
+{
+    auto constexpr BlockCount = tr_block_index_t{ 64 };
+    auto constexpr PeerCount = size_t{ 8 };
+    auto constexpr QueueSize = size_t{ 4 };
+
+    auto mediator = MockMediator{};
+    mediator.block_span_[0] = { .begin = 0, .end = BlockCount };
+    mediator.piece_replication_[0] = PeerCount;
+    mediator.client_wants_piece_.insert(0);
+    mediator.is_endgame_ = true;
+    mediator.peer_requests_ = std::vector<tr_bitfield>(PeerCount, tr_bitfield{ BlockCount });
+
+    auto wishlist = Wishlist{ mediator };
+    auto is_available = std::vector<bool>(BlockCount);
+    auto is_complete = std::vector<bool>(BlockCount);
+
+    // The wishlist gets the same sent-request notification the peer manager
+    // would send in production.
+    for (auto block = tr_block_index_t{}; block < BlockCount; ++block)
+    {
+        mediator.peer_requests_[block % PeerCount].set(block);
+    }
+    wishlist.on_sent_request({ .begin = 0, .end = BlockCount });
+
+    auto const active_request_count = [&mediator](tr_block_index_t const block)
+    {
+        return std::count_if(
+            std::begin(mediator.peer_requests_),
+            std::end(mediator.peer_requests_),
+            [block](auto const& requests) { return requests.test(block); });
+    };
+
+    auto random = std::minstd_rand{ 0x8935U };
+    for (auto iteration = size_t{}; iteration < 1000U; ++iteration)
+    {
+        auto const peer = iteration % PeerCount;
+        auto const peer_has_active_request = [&mediator, peer](tr_block_index_t const block)
+        {
+            return mediator.peer_requests_[peer].test(block);
+        };
+
+        auto n_normal = size_t{};
+        auto n_endgame = size_t{};
+        for (auto block = tr_block_index_t{}; block < BlockCount; ++block)
+        {
+            if (is_complete[block] || peer_has_active_request(block))
+            {
+                continue;
+            }
+
+            if (is_available[block])
+            {
+                ++n_normal;
+            }
+            else if (active_request_count(block) < 2U)
+            {
+                ++n_endgame;
+            }
+        }
+
+        auto const expected = std::min(QueueSize, n_normal + n_endgame);
+        auto const spans = wishlist.next(QueueSize, PeerHasAllPieces, peer_has_active_request);
+        auto n_selected = size_t{};
+        for (auto const& [begin, end] : spans)
+        {
+            for (auto block = begin; block < end; ++block)
+            {
+                ASSERT_FALSE(is_complete[block]);
+                ASSERT_FALSE(peer_has_active_request(block));
+                ASSERT_TRUE(is_available[block] || active_request_count(block) < 2U);
+                mediator.peer_requests_[peer].set(block);
+                is_available[block] = false;
+                ++n_selected;
+            }
+            wishlist.on_sent_request({ .begin = begin, .end = end });
+        }
+        ASSERT_EQ(expected, n_selected);
+
+        // Releasing one of two requesters must leave the block off-limits to
+        // the plain unrequested pool as long as the other one remains.
+        auto const first = static_cast<tr_block_index_t>(random() % BlockCount);
+        auto block = first;
+        do
+        {
+            if (!is_complete[block] && active_request_count(block) >= 1U)
+            {
+                break;
+            }
+            block = (block + 1U) % BlockCount;
+        } while (block != first);
+
+        if (is_complete[block] || active_request_count(block) == 0U)
+        {
+            break;
+        }
+
+        auto const request_peer = std::find_if(
+            std::begin(mediator.peer_requests_),
+            std::end(mediator.peer_requests_),
+            [block](auto const& requests) { return requests.test(block); });
+        ASSERT_NE(std::end(mediator.peer_requests_), request_peer);
+        request_peer->unset(block);
+        auto const remaining = active_request_count(block);
+
+        switch (random() % 3U)
+        {
+        case 0U:
+            is_available[block] = remaining == 0U;
+            wishlist.on_got_reject(block);
+            break;
+
+        case 1U:
+            is_available[block] = remaining == 0U;
+            wishlist.on_sent_cancel(block);
+            break;
+
+        default:
+            is_complete[block] = true;
+            mediator.client_has_block_.insert(block);
+            wishlist.on_got_block(block);
+            break;
+        }
+    }
 }
 
 TEST_F(PeerMgrWishlistTest, sequentialDownload)

--- a/tests/libtransmission/peer-mgr-wishlist-test.cc
+++ b/tests/libtransmission/peer-mgr-wishlist-test.cc
@@ -384,16 +384,16 @@ TEST_F(PeerMgrWishlistTest, cancelForAnAlreadyDeliveredBlockDoesNotReviveIt)
     auto wishlist = Wishlist{ mediator };
     wishlist.on_sent_request({ .begin = 0, .end = 1 });
 
-    // Peer 0 delivers the block first.
+    // Peer 0 delivers the block first. Production cancels the redundant
+    // request before it tells the wishlist or torrent that the block arrived.
     mediator.peer_requests_[0].unset(0);
-    mediator.client_has_block_.insert(0);
-    wishlist.on_got_block(0);
-
-    // Peer 1's now-redundant request gets cancelled. Neither peer holds the
-    // block anymore, but the client already has it -- it must not go back
-    // into the pool for a third peer to redundantly re-fetch.
     mediator.peer_requests_[1].unset(0);
     wishlist.on_sent_cancel(0);
+
+    // The block is then recorded as received. It must not remain in the pool
+    // for a third peer to redundantly fetch.
+    mediator.client_has_block_.insert(0);
+    wishlist.on_got_block(0);
 
     EXPECT_TRUE(std::empty(wishlist.next(1, PeerHasAllPieces)));
 }


### PR DESCRIPTION
# fix: restore bounded endgame requests

## Summary

PR #7744 removed endgame requests from the wishlist. Once every remaining block is already assigned, another peer can have an empty request queue even though one slow or unresponsive peer holds the last block. Completion then waits for a timeout before the block can be retried.

This restores a bounded version of that behavior. The normal picker still takes only unrequested blocks. When it cannot fill a peer's queue and the remaining bytes are already in flight, it can assign an in-flight block to one backup peer. A block has at most two requesters, and a peer is never assigned the same block twice.

The requester count is read from the live peer state only in that fallback path. The normal picker does not scan peers or maintain a per-block requester-count cache.

The change also handles the state transitions introduced by duplicate requests:

- Do not return a block to the normal pool while another requester still holds it.
- Do not revive a block that the client has already received.
- Treat an in-flight webseed request as saturated because webseeds do not support BitTorrent CANCEL messages.
- Free a BitTorrent peer's slot on `FextReject`, while excluding the rejected block from that immediate refill.

## Validation

- `build/tests/libtransmission/libtransmission-test --gtest_filter='PeerMgrWishlistTest.*'` passes, 47 tests.
- The tests cover the two-request cap, same-peer exclusion, reject, cancel, choke, disconnect, a delivered-block race, and randomized request-state transitions.
- Manual smoke test: Fedora-Budgie-Live-x86_64-44 had previously stalled at 99.82%, with 5.54 MB left and 64 connected peers. It completed with this change. Four additional Linux ISO downloads also completed without a tail stall.
- Manual profile: Fedora Workstation 44 completed through the local build with 150 connected peers and up to 140 sending peers. A 10-second tail sample captured endgame activity without showing `is_endgame()` as a material CPU cost.

Notes: Fixed torrents stalling near completion when the final blocks are assigned to slow peers.

## Checklist

- [x] I have manually written or manually audited all changes in this PR and vouch for them.
